### PR TITLE
fix: confine command file writes and require admin for saveprofile

### DIFF
--- a/src/main/java/dev/krona/urbex/commands/CommandExportPart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandExportPart.java
@@ -23,6 +23,7 @@ import dev.krona.urbex.worldgen.lost.cityassets.Palette;
 import dev.krona.urbex.worldgen.lost.regassets.BuildingPartRE;
 import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -32,10 +33,9 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.state.BlockState;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 public class CommandExportPart implements Command<CommandSourceStack> {
@@ -158,12 +158,13 @@ public class CommandExportPart implements Command<CommandSourceStack> {
         String json = gson.toJson(root);
 
         try {
-            BufferedWriter writer = new BufferedWriter(new FileWriter(filename, StandardCharsets.UTF_8));
-            writer.write(json);
-            writer.close();
-            context.getSource().sendSuccess(() -> ComponentFactory.literal("Exported part to '" + filename + "'!"), false);
-        } catch (IOException e) {
-            context.getSource().sendFailure(Component.literal("Error writing file '" + filename + "'!").withStyle(ChatFormatting.RED));
+            Path exportDir = FabricLoader.getInstance().getConfigDir().resolve("urbex").resolve("exports");
+            Path target = ExportPath.resolve(exportDir, filename);
+            Files.createDirectories(exportDir);
+            Files.writeString(target, json);
+            context.getSource().sendSuccess(() -> ComponentFactory.literal("Exported part to '" + target + "'!"), false);
+        } catch (IllegalArgumentException | IOException e) {
+            context.getSource().sendFailure(Component.literal("Error writing file '" + filename + "': " + e.getMessage()).withStyle(ChatFormatting.RED));
         }
 
         return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandSaveProfile.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandSaveProfile.java
@@ -12,13 +12,14 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.config.ProfileSetup;
 import dev.krona.urbex.config.LostCityProfile;
 import dev.krona.urbex.varia.ComponentFactory;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.PrintWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class CommandSaveProfile implements Command<CommandSourceStack> {
 
@@ -26,7 +27,7 @@ public class CommandSaveProfile implements Command<CommandSourceStack> {
 
     public static ArgumentBuilder<CommandSourceStack, ?> register(CommandDispatcher<CommandSourceStack> dispatcher) {
         return Commands.literal("saveprofile")
-                .requires(Commands.hasPermission(Commands.LEVEL_ALL))
+                .requires(Commands.hasPermission(Commands.LEVEL_ADMINS))
                 .then(Commands.argument("profile", StringArgumentType.word())
                     .executes(CMD));
     }
@@ -42,16 +43,17 @@ public class CommandSaveProfile implements Command<CommandSourceStack> {
         }
         JsonObject jsonObject = profile.toJson(false);
         Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+        Path target;
         try {
-            try (PrintWriter writer = new PrintWriter(new File(name + ".json"))) {
-                writer.print(gson.toJson(jsonObject));
-                writer.flush();
-            }
-        } catch (FileNotFoundException e) {
+            Path profileDir = FabricLoader.getInstance().getConfigDir().resolve("urbex").resolve("profiles");
+            target = ExportPath.resolve(profileDir, name);
+            Files.createDirectories(profileDir);
+            Files.writeString(target, gson.toJson(jsonObject));
+        } catch (IllegalArgumentException | IOException e) {
             context.getSource().sendSuccess(() -> ComponentFactory.literal(ChatFormatting.RED + "Error saving profile '" + name + "'!"), true);
             return 0;
         }
-        context.getSource().sendSuccess(() -> ComponentFactory.literal(ChatFormatting.GREEN + "Saved profile '" + name + "'!"), true);
+        context.getSource().sendSuccess(() -> ComponentFactory.literal(ChatFormatting.GREEN + "Saved profile to '" + target + "'!"), true);
         return 0;
     }
 }

--- a/src/main/java/dev/krona/urbex/commands/ExportPath.java
+++ b/src/main/java/dev/krona/urbex/commands/ExportPath.java
@@ -1,0 +1,31 @@
+package dev.krona.urbex.commands;
+
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves user-supplied names for command file output to a confined location.
+ * Commands must never write to a path derived from raw player input: a name like
+ * "whitelist" or "ops" aimed at the server working directory can overwrite server
+ * control files (issue #32).
+ */
+public final class ExportPath {
+
+    private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
+
+    private ExportPath() {
+    }
+
+    /**
+     * Returns {@code base/<name>.json} after validating that {@code name} contains only
+     * letters, digits, underscores and hyphens.
+     *
+     * @throws IllegalArgumentException if the name is empty or contains any other character
+     */
+    public static Path resolve(Path base, String name) {
+        if (!SAFE_NAME.matcher(name).matches()) {
+            throw new IllegalArgumentException("Invalid file name '" + name + "': only letters, digits, '_' and '-' are allowed");
+        }
+        return base.resolve(name + ".json");
+    }
+}

--- a/src/test/java/dev/krona/urbex/commands/ExportPathTest.java
+++ b/src/test/java/dev/krona/urbex/commands/ExportPathTest.java
@@ -1,0 +1,56 @@
+package dev.krona.urbex.commands;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ExportPathTest {
+
+    private static final Path BASE = Path.of("config", "urbex", "profiles");
+
+    @Test
+    public void resolvesPlainNameInsideBaseWithJsonSuffix() {
+        Path result = ExportPath.resolve(BASE, "default");
+        assertEquals(BASE.resolve("default.json"), result);
+    }
+
+    @Test
+    public void allowsLettersDigitsUnderscoreAndHyphen() {
+        Path result = ExportPath.resolve(BASE, "my-Profile_2");
+        assertEquals(BASE.resolve("my-Profile_2.json"), result);
+    }
+
+    @Test
+    public void rejectsDotsSoServerJsonFilesCannotBeTargeted() {
+        // "whitelist.json" would escape the .json suffix scheme: it must not
+        // silently become whitelist.json.json either - reject loudly.
+        assertThrows(IllegalArgumentException.class, () -> ExportPath.resolve(BASE, "whitelist.json"));
+    }
+
+    @Test
+    public void rejectsParentDirectoryTraversal() {
+        assertThrows(IllegalArgumentException.class, () -> ExportPath.resolve(BASE, ".."));
+    }
+
+    @Test
+    public void rejectsEmptyName() {
+        assertThrows(IllegalArgumentException.class, () -> ExportPath.resolve(BASE, ""));
+    }
+
+    @Test
+    public void rejectsPathSeparators() {
+        // brigadier word() cannot produce these today, but the helper must not
+        // rely on the argument type for safety
+        assertThrows(IllegalArgumentException.class, () -> ExportPath.resolve(BASE, "a/b"));
+        assertThrows(IllegalArgumentException.class, () -> ExportPath.resolve(BASE, "a\\b"));
+    }
+
+    @Test
+    public void rejectsPlusAndOtherWordCharsOutsideAllowlist() {
+        // '+' is legal in brigadier word() but stays outside the allowlist
+        assertThrows(IllegalArgumentException.class, () -> ExportPath.resolve(BASE, "a+b"));
+    }
+}


### PR DESCRIPTION
Closes #32.

`saveprofile` was permission-level 0 and wrote player-named files into the server working directory — any player on a dedicated server could overwrite `whitelist.json`, `ops.json`, etc. `exportpart` had the same unconfined write at admin level.

## Changes
- `saveprofile` now requires `LEVEL_ADMINS`.
- Both commands resolve output through a new `ExportPath` helper: names restricted to `[A-Za-z0-9_-]`, `.json` always appended, output confined to `config/urbex/profiles/` and `config/urbex/exports/` (created on demand).
- Success messages now report the full path the file was written to.

## Testing
`ExportPathTest` (7 tests, written first): plain names, allowed charset, rejection of dots (`whitelist.json`), `..`, path separators, `+`, and empty names. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)