### PR TITLE
fix: world-changing generation batch

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/ChunkFixer.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkFixer.java
@@ -109,7 +109,7 @@ public class ChunkFixer {
      * {@code VEGETATION}.
      */
     private static float vineRoll(long seed, int x, int y, int z, Rng.Purpose purpose) {
-        return Rng.atPos(seed, x, y, z, purpose).nextFloat();
+        return Rng.floatAtPos(seed, x, y, z, purpose);
     }
 
     /**
@@ -119,7 +119,7 @@ public class ChunkFixer {
      * would have started.
      */
     private static float vineContinueRoll(long seed, int x, int y, int z) {
-        return Rng.atPos(seed, x, y, z, Rng.Purpose.VINES_CONTINUE).nextFloat();
+        return Rng.floatAtPos(seed, x, y, z, Rng.Purpose.VINES_CONTINUE);
     }
 
     private static void createVineStrip(long seed, LevelAccessor world, int bottom, BlockState state, BlockPos pos, BlockPos vineHolderPos) {

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
@@ -6,6 +6,7 @@ import dev.krona.urbex.varia.PerlinNoiseGenerator14;
 import dev.krona.urbex.varia.TimedCache;
 import dev.krona.urbex.worldgen.lost.BiomeInfo;
 import dev.krona.urbex.worldgen.lost.BuildingInfo;
+import dev.krona.urbex.worldgen.gen.Scattered;
 import dev.krona.urbex.worldgen.lost.CityRarityMap;
 import dev.krona.urbex.worldgen.lost.CitySphere;
 import dev.krona.urbex.worldgen.lost.LostChunkCharacteristics;
@@ -41,6 +42,8 @@ public final class DimensionCaches {
     public final ConcurrentHashMap<ChunkCoord, Integer> xHighwayLevel = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<ChunkCoord, Integer> zHighwayLevel = new ConcurrentHashMap<>();
     public final TimedCache<ChunkCoord, ChunkHeightmap> heightmap = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
+    /** Keyed on the scatter area's anchor chunk, not a real chunk coordinate. */
+    public final TimedCache<ChunkCoord, Scattered.AreaScan> scatterAreaScan = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
 
     /**
      * The city-rarity map is per profile rather than per chunk: a city-sphere dimension asks for
@@ -96,6 +99,7 @@ public final class DimensionCaches {
         xHighwayLevel.clear();
         zHighwayLevel.clear();
         heightmap.clear();
+        scatterAreaScan.clear();
         cityRarity.clear();
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/dev/krona/urbex/worldgen/LostCityTerrainFeature.java
@@ -467,7 +467,7 @@ public class LostCityTerrainFeature {
         ScatteredSettings scatteredSettings = provider.getWorldStyle().getScatteredSettings();
         if (scatteredSettings != null) {
             if (!Scattered.avoidScattered(this, info)) {
-                Scattered.generateScattered(ctx, this, info, scatteredSettings, heightmap);
+                Scattered.generateScattered(ctx, this, info, scatteredSettings);
             }
         }
     }
@@ -1292,9 +1292,11 @@ public class LostCityTerrainFeature {
                     height++;
                 }
             } else {
+                // Local redraw only: writing this back into the shared cached BuildingInfo
+                // clobbered the PARK decision neighbours read through isElevatedParkSection()
+                // and friends, making their output depend on generation order (issue #36).
                 RandomSource rnd = ctx.rng(Rng.Purpose.STREET);
-                info.streetType = BuildingInfo.StreetType.values()[rnd.nextInt(BuildingInfo.StreetType.values().length - 2)];
-                streetType = info.streetType;
+                streetType = BuildingInfo.StreetType.randomNonPark(rnd);
             }
 
             switch (streetType) {
@@ -2016,7 +2018,10 @@ public class LostCityTerrainFeature {
 
     private BlockState transformBlockState(Transform transform, BlockState b) {
         if (Tools.hasTag(b.getBlock(), LostTags.ROTATABLE_TAG)) {
-            b = b.rotate(transform.getMcRotation());
+            // Vanilla structure order: mirror first, then rotate. The mirror used to be
+            // approximated with a 180/90 rotation, which turned mirrored stairs/doors/logs
+            // the wrong way (issue #45).
+            b = b.mirror(transform.getMcMirror()).rotate(transform.getMcRotation());
         } else if (getRailStates().contains(b)) {
             EnumProperty<RailShape> shapeProperty;
             if (b.getBlock() == Blocks.RAIL) {

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
@@ -37,7 +37,7 @@ public class Scattered {
         return Highway.hasHighway(info.coord, feature.provider, feature.profile);
     }
 
-    public static void generateScattered(ChunkGenContext ctx, LostCityTerrainFeature feature, BuildingInfo info, ScatteredSettings scatteredSettings, ChunkHeightmap heightmap) {
+    public static void generateScattered(ChunkGenContext ctx, LostCityTerrainFeature feature, BuildingInfo info, ScatteredSettings scatteredSettings) {
         int chunkX = info.coord.chunkX();
         int chunkZ = info.coord.chunkZ();
         IDimensionInfo provider = feature.provider;
@@ -53,8 +53,14 @@ public class Scattered {
             return;
         }
 
-        // Find the right type of scattered asset for this area
-        ScatteredReference reference = selectRandomScattered(feature, info, scatteredSettings, scatteredRandom);
+        // Find the right type of scattered asset for this area. The biome pre-filter is keyed
+        // on the area's anchor chunk, never the chunk that happens to be generating: every
+        // chunk of the area must compute the same filtered list and draw the same reference,
+        // or a multi-chunk building disagrees with itself about where it stands (issue #38).
+        ChunkCoord areaAnchor = new ChunkCoord(provider.getType(),
+                ax * scatteredSettings.getAreasize() - 2000000,
+                az * scatteredSettings.getAreasize() - 2000000);
+        ScatteredReference reference = selectRandomScattered(feature, areaAnchor, scatteredSettings, scatteredRandom);
         if (reference == null) {
             // Nothing matches
             return;
@@ -82,55 +88,26 @@ public class Scattered {
             return;
         }
 
-        // First test the conditions for all the relevant chunks (does this need to be cached?)
-        int minheight = Integer.MAX_VALUE;
-        int maxheight = Integer.MIN_VALUE;
-        int avgheight = 0;
-        for (int x = tlChunkX; x < tlChunkX + w; x++) {
-            for (int z = tlChunkZ; z < tlChunkZ + h; z++) {
-                ChunkCoord coord = new ChunkCoord(provider.getType(), x, z);
-                if (!isValidScatterBiome(feature, reference, coord)) {
-                    return;
-                }
-                BuildingInfo tinfo = BuildingInfo.getBuildingInfo(coord, provider);
-                if (avoidScattered(feature, tinfo)) {
-                    return;
-                }
-                if (reference.isNearHighway()) {
-                    if (!Highway.hasHighway(coord.east(), provider, feature.profile) &&
-                            !Highway.hasHighway(coord.west(), provider, feature.profile) &&
-                            !Highway.hasHighway(coord.north(), provider, feature.profile) &&
-                            !Highway.hasHighway(coord.south(), provider, feature.profile)) {
-                        return;
-                    }
-                }
-                // A copy: calculateAccurateHeight writes minHeight/maxHeight, and the cached
-                // instance is shared with every thread generating near this chunk. See #24.
-                ChunkHeightmap hm = new ChunkHeightmap(feature.getHeightmap(coord, provider.getWorld()));
-                int height = hm.getHeight();
-                hm.calculateAccurateHeight(provider.getWorld(), x, z);   // generator-only, no block access
-                if (!reference.isAllowVoid()) {
-                    if (!(feature.profile.isDefault() || feature.profile.isCavern())) {
-                        // We are in a world that can have void chunks. Check if this chunk is a void chunk
-                        if (height <= feature.provider.getWorld().getMinY() + 3) {
-                            return;
-                        }
-                    }
-                }
-                minheight = Math.min(minheight, hm.getMinHeight());
-                maxheight = Math.max(maxheight, hm.getMaxHeight());
-                avgheight += height;
-            }
+        // Test the conditions for all the relevant chunks. Cached on the area: every chunk of
+        // the footprint used to redo the full scan - w*h noise-column samples each, O((w*h)^2)
+        // in total (issue #38). Everything the scan reads is a pure function of the area, so
+        // the first chunk to arrive computes it for all of them.
+        AreaScan scan = provider.caches().scatterAreaScan.getOrCompute(areaAnchor,
+                k -> scanArea(feature, reference, tlChunkX, tlChunkZ, w, h));
+        if (!scan.valid()) {
+            return;
         }
         // Check the height difference
         if (reference.getMaxheightdiff() != null) {
-            int diff = maxheight - minheight;
+            int diff = scan.maxheight() - scan.minheight();
             if (diff > reference.getMaxheightdiff()) {
                 return;
             }
         }
 
-        avgheight /= w * h;
+        int minheight = scan.minheight();
+        int maxheight = scan.maxheight();
+        int avgheight = scan.avgheight();
 
         // We need to generate a part of the building
         if (multiBuilding == null) {
@@ -146,7 +123,7 @@ public class Scattered {
                 buildingName = buildings.get(scatteredRandom.nextInt(buildings.size()));
             }
             Building building = AssetRegistries.BUILDINGS.getOrThrow(provider.getWorld(), buildingName);
-            int lowestLevel = handleScatteredTerrain(feature, scattered, info.coord, heightmap);
+            int lowestLevel = scatteredLevel(feature, scattered, minheight, maxheight, avgheight);
             if (lowestLevel < -4000) {
                 LostCityProfile profile = feature.provider.getProfile();
                 if (profile.isCavern()) {
@@ -157,7 +134,7 @@ public class Scattered {
             }
             generateScatteredBuilding(ctx, feature, info, building, scatteredRandom, lowestLevel, scattered.getTerrainfix());
         } else {
-            int lowestLevel = handleScatteredTerrainMulti(feature, scattered, info.coord, minheight, maxheight, avgheight);
+            int lowestLevel = scatteredLevel(feature, scattered, minheight, maxheight, avgheight);
             int relx = chunkX - tlChunkX;
             int relz = chunkZ - tlChunkZ;
             String buildingName = multiBuilding.getBuilding(relx, relz);
@@ -167,7 +144,7 @@ public class Scattered {
     }
 
     @Nullable
-    private static ScatteredReference selectRandomScattered(LostCityTerrainFeature feature, BuildingInfo info, ScatteredSettings scatteredSettings, RandomSource rand) {
+    private static ScatteredReference selectRandomScattered(LostCityTerrainFeature feature, ChunkCoord areaAnchor, ScatteredSettings scatteredSettings, RandomSource rand) {
         List<ScatteredReference> list = scatteredSettings.getList();
         if (list.isEmpty()) {
             return null;
@@ -176,7 +153,7 @@ public class Scattered {
         int totalweight = 0;
         List<ScatteredReference> filteredList = new ArrayList<>();
         for (ScatteredReference reference : list) {
-            if (isValidScatterBiome(feature, reference, info.coord)) {
+            if (isValidScatterBiome(feature, reference, areaAnchor)) {
                 totalweight += reference.getWeight();
                 filteredList.add(reference);
             }
@@ -189,13 +166,68 @@ public class Scattered {
         ScatteredReference reference = null;
         for (ScatteredReference scatteredReference : filteredList) {
             int weight = scatteredReference.getWeight();
-            if (rndweight <= weight) {
+            // Strict comparison: <= gave the first entry one extra winning value (issue #38)
+            if (rndweight < weight) {
                 reference = scatteredReference;
                 break;
             }
             rndweight -= weight;
         }
         return reference;
+    }
+
+    /** What the area scan learned about a scatter area: whether it may generate, and its heights. */
+    public record AreaScan(boolean valid, int minheight, int maxheight, int avgheight) {
+        private static final AreaScan INVALID = new AreaScan(false, 0, 0, 0);
+    }
+
+    /**
+     * Validates every chunk of a scatter footprint and gathers its height statistics. Pure
+     * function of the area (all inputs derive from the area coordinate), which is what makes
+     * caching it per area sound.
+     */
+    private static AreaScan scanArea(LostCityTerrainFeature feature, ScatteredReference reference, int tlChunkX, int tlChunkZ, int w, int h) {
+        IDimensionInfo provider = feature.provider;
+        int minheight = Integer.MAX_VALUE;
+        int maxheight = Integer.MIN_VALUE;
+        int avgheight = 0;
+        for (int x = tlChunkX; x < tlChunkX + w; x++) {
+            for (int z = tlChunkZ; z < tlChunkZ + h; z++) {
+                ChunkCoord coord = new ChunkCoord(provider.getType(), x, z);
+                if (!isValidScatterBiome(feature, reference, coord)) {
+                    return AreaScan.INVALID;
+                }
+                BuildingInfo tinfo = BuildingInfo.getBuildingInfo(coord, provider);
+                if (avoidScattered(feature, tinfo)) {
+                    return AreaScan.INVALID;
+                }
+                if (reference.isNearHighway()) {
+                    if (!Highway.hasHighway(coord.east(), provider, feature.profile) &&
+                            !Highway.hasHighway(coord.west(), provider, feature.profile) &&
+                            !Highway.hasHighway(coord.north(), provider, feature.profile) &&
+                            !Highway.hasHighway(coord.south(), provider, feature.profile)) {
+                        return AreaScan.INVALID;
+                    }
+                }
+                // A copy: calculateAccurateHeight writes minHeight/maxHeight, and the cached
+                // instance is shared with every thread generating near this chunk. See #24.
+                ChunkHeightmap hm = new ChunkHeightmap(feature.getHeightmap(coord, provider.getWorld()));
+                int height = hm.getHeight();
+                hm.calculateAccurateHeight(provider.getWorld(), x, z);   // generator-only, no block access
+                if (!reference.isAllowVoid()) {
+                    if (!(feature.profile.isDefault() || feature.profile.isCavern())) {
+                        // We are in a world that can have void chunks. Check if this chunk is a void chunk
+                        if (height <= provider.getWorld().getMinY() + 3) {
+                            return AreaScan.INVALID;
+                        }
+                    }
+                }
+                minheight = Math.min(minheight, hm.getMinHeight());
+                maxheight = Math.max(maxheight, hm.getMaxHeight());
+                avgheight += height;
+            }
+        }
+        return new AreaScan(true, minheight, maxheight, avgheight / (w * h));
     }
 
     private static boolean isValidScatterBiome(LostCityTerrainFeature feature, ScatteredReference reference, ChunkCoord coord) {
@@ -297,25 +329,22 @@ public class Scattered {
         }
     }
 
-    private static int handleScatteredTerrain(LostCityTerrainFeature feature, ScatteredBuilding scattered, ChunkCoord coord, ChunkHeightmap heightmap) {
-        int lowestLevel = switch (scattered.getTerrainheight()) {
-            case LOWEST -> heightmap.getHeight();
-            case AVERAGE -> heightmap.getHeight();
-            case HIGHEST -> heightmap.getHeight();
-            case OCEAN -> ((ServerChunkCache) feature.provider.getWorld().getChunkSource()).getGenerator().getSeaLevel();
-        };
-        lowestLevel += scattered.getHeightoffset();
-        return lowestLevel;
+    private static int scatteredLevel(LostCityTerrainFeature feature, ScatteredBuilding scattered, int minimum, int maximum, int average) {
+        int seaLevel = ((ServerChunkCache) feature.provider.getWorld().getChunkSource()).getGenerator().getSeaLevel();
+        return pickLevel(scattered.getTerrainheight(), minimum, maximum, average, seaLevel) + scattered.getHeightoffset();
     }
 
-    private static int handleScatteredTerrainMulti(LostCityTerrainFeature feature, ScatteredBuilding scattered, ChunkCoord coord, int minimum, int maximum, int average) {
-        int lowestLevel = switch (scattered.getTerrainheight()) {
+    /**
+     * The base level a terrain-height policy asks for. The old multi-chunk switch had the
+     * AVERAGE and HIGHEST arms swapped, and the single-chunk variant returned the same value
+     * for all three (issue #38).
+     */
+    static int pickLevel(ScatteredBuilding.TerrainHeight terrainHeight, int minimum, int maximum, int average, int seaLevel) {
+        return switch (terrainHeight) {
             case LOWEST -> minimum;
-            case AVERAGE -> maximum;
-            case HIGHEST -> average;
-            case OCEAN -> ((ServerChunkCache) feature.provider.getWorld().getChunkSource()).getGenerator().getSeaLevel();
+            case AVERAGE -> average;
+            case HIGHEST -> maximum;
+            case OCEAN -> seaLevel;
         };
-        lowestLevel += scattered.getHeightoffset();
-        return lowestLevel;
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/BuildingInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/BuildingInfo.java
@@ -785,7 +785,7 @@ public class BuildingInfo {
             if (rand.nextDouble() < parkChance) {
                 streetType = StreetType.PARK;
             } else {
-                streetType = StreetType.values()[rand.nextInt(0, BuildingInfo.StreetType.values().length - 2)];
+                streetType = StreetType.randomNonPark(rand);
             }
             float fountainChance = cs.getFountainChance() != null ? cs.getFountainChance() : profile.FOUNTAIN_CHANCE;
             if (rand.nextFloat() < fountainChance) {
@@ -1903,7 +1903,18 @@ public class BuildingInfo {
     public enum StreetType {
         NORMAL,
         FULL,
-        PARK
+        PARK;
+
+        private static final StreetType[] NON_PARK = {NORMAL, FULL};
+
+        /**
+         * An even choice between the non-park street types. PARK is decided separately by the
+         * park chance. The old form, {@code values()[nextInt(values().length - 2)]}, could only
+         * ever yield NORMAL (issue #36).
+         */
+        public static StreetType randomNonPark(RandomSource rand) {
+            return NON_PARK[rand.nextInt(NON_PARK.length)];
+        }
     }
 
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/City.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/City.java
@@ -266,7 +266,10 @@ public class City {
                             if (factor < profile.CITY_STYLE_THRESHOLD) {
                                 styles.add(Pair.of(factor, profile.CITY_STYLE_ALTERNATIVE));
                             } else {
-                                styles.add(Pair.of(factor, getCityStyleForCityCenter(coord, provider)));
+                                // The centre's style, not the observing chunk's: asking at
+                                // `coord` gave every chunk of one city its own roll, so a
+                                // single city had no coherent style (issue #37).
+                                styles.add(Pair.of(factor, getCityStyleForCityCenter(c, provider)));
                             }
                         }
                     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Transform.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Transform.java
@@ -1,34 +1,36 @@
 package dev.krona.urbex.worldgen.lost;
 
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.properties.RailShape;
 
 public enum Transform {
-    ROTATE_NONE(net.minecraft.world.level.block.Rotation.NONE),
-    ROTATE_90(net.minecraft.world.level.block.Rotation.CLOCKWISE_90),
-    ROTATE_180(net.minecraft.world.level.block.Rotation.CLOCKWISE_180),
-    ROTATE_270(net.minecraft.world.level.block.Rotation.COUNTERCLOCKWISE_90),
-    MIRROR_X(net.minecraft.world.level.block.Rotation.CLOCKWISE_180),
-    MIRROR_Z(net.minecraft.world.level.block.Rotation.CLOCKWISE_180),
-    MIRROR_90_X(net.minecraft.world.level.block.Rotation.CLOCKWISE_90);
+    ROTATE_NONE(Rotation.NONE, Mirror.NONE),
+    ROTATE_90(Rotation.CLOCKWISE_90, Mirror.NONE),
+    ROTATE_180(Rotation.CLOCKWISE_180, Mirror.NONE),
+    ROTATE_270(Rotation.COUNTERCLOCKWISE_90, Mirror.NONE),
+    // The mirror/rotation pairs below reproduce the coordinate maps of rotateX/rotateZ in
+    // vanilla's application order (mirror first, then rotate). MIRROR_X flips x (east<->west),
+    // MIRROR_Z flips z (north<->south), MIRROR_90_X is the transpose (x,z)->(z,x).
+    MIRROR_X(Rotation.NONE, Mirror.FRONT_BACK),
+    MIRROR_Z(Rotation.NONE, Mirror.LEFT_RIGHT),
+    MIRROR_90_X(Rotation.CLOCKWISE_90, Mirror.LEFT_RIGHT);
 
-    private final net.minecraft.world.level.block.Rotation mcRotation;
+    private final Rotation mcRotation;
+    private final Mirror mcMirror;
 
-    Transform(net.minecraft.world.level.block.Rotation mcRotation) {
+    Transform(Rotation mcRotation, Mirror mcMirror) {
         this.mcRotation = mcRotation;
+        this.mcMirror = mcMirror;
     }
 
-    public net.minecraft.world.level.block.Rotation getMcRotation() {
+    public Rotation getMcRotation() {
         return mcRotation;
     }
 
-    public static Transform randomRotation() {
-        return switch ((int) (Math.random() * 4)) {
-            case 0 -> ROTATE_NONE;
-            case 1 -> ROTATE_90;
-            case 2 -> ROTATE_180;
-            case 3 -> ROTATE_270;
-            default -> ROTATE_NONE;
-        };
+    public Mirror getMcMirror() {
+        return mcMirror;
     }
 
     public Transform getOpposite() {
@@ -67,147 +69,59 @@ public enum Transform {
         };
     }
 
-    public RailShape transform(RailShape shape) {
-        if (this == ROTATE_NONE) {
-            return shape;
-        }
-        switch (shape) {
-            case NORTH_SOUTH:
-                return (this == ROTATE_90 || this == ROTATE_270 || this == MIRROR_90_X) ? RailShape.EAST_WEST : shape;
-            case EAST_WEST:
-                return (this == ROTATE_90 || this == ROTATE_270) ? RailShape.NORTH_SOUTH : shape;
-            case ASCENDING_EAST:
-                switch (this) {
-                    case ROTATE_90:
-                        return RailShape.ASCENDING_SOUTH;
-                    case MIRROR_90_X:
-                        return RailShape.ASCENDING_NORTH;
-                    case ROTATE_180:
-                        return RailShape.ASCENDING_WEST;
-                    case ROTATE_270:
-                        return RailShape.ASCENDING_NORTH;
-                    case MIRROR_X:
-                        return RailShape.ASCENDING_WEST;
-                }
-                break;
-            case ASCENDING_WEST:
-                switch (this) {
-                    case ROTATE_90:
-                        return RailShape.ASCENDING_NORTH;
-                    case MIRROR_90_X:
-                        return RailShape.ASCENDING_SOUTH;
-                    case ROTATE_180:
-                        return RailShape.ASCENDING_EAST;
-                    case ROTATE_270:
-                        return RailShape.ASCENDING_SOUTH;
-                    case MIRROR_X:
-                        return RailShape.ASCENDING_EAST;
-                }
-                break;
-            case ASCENDING_NORTH:
-                switch (this) {
-                    case ROTATE_90:
-                        return RailShape.ASCENDING_EAST;
-                    case MIRROR_90_X:
-                        return RailShape.ASCENDING_WEST;
-                    case ROTATE_180:
-                        return RailShape.ASCENDING_SOUTH;
-                    case ROTATE_270:
-                        return RailShape.ASCENDING_WEST;
-                    case MIRROR_X:
-                        return RailShape.ASCENDING_SOUTH;
-                    case MIRROR_Z:
-                        return RailShape.ASCENDING_SOUTH;
-                }
-                break;
-            case ASCENDING_SOUTH:
-                switch (this) {
-                    case ROTATE_90:
-                        return RailShape.ASCENDING_WEST;
-                    case MIRROR_90_X:
-                        return RailShape.ASCENDING_EAST;
-                    case ROTATE_180:
-                        return RailShape.ASCENDING_NORTH;
-                    case ROTATE_270:
-                        return RailShape.ASCENDING_EAST;
-                    case MIRROR_X:
-                        return RailShape.ASCENDING_NORTH;
-                    case MIRROR_Z:
-                        return RailShape.ASCENDING_NORTH;
-                }
-                break;
-            case SOUTH_EAST:
-                switch (this) {
-                    case ROTATE_90:
-                        return RailShape.SOUTH_WEST;
-                    case MIRROR_90_X:
-                        return RailShape.NORTH_EAST;
-                    case ROTATE_180:
-                        return RailShape.NORTH_WEST;
-                    case ROTATE_270:
-                        return RailShape.NORTH_EAST;
-                    case MIRROR_X:
-                        return RailShape.SOUTH_WEST;
-                    case MIRROR_Z:
-                        return RailShape.NORTH_EAST;
-                }
-                break;
-            case SOUTH_WEST:
-                switch (this) {
-                    case ROTATE_90:
-                        return RailShape.NORTH_WEST;
-                    case MIRROR_90_X:
-                        return RailShape.SOUTH_EAST;
-                    case ROTATE_180:
-                        return RailShape.NORTH_EAST;
-                    case ROTATE_270:
-                        return RailShape.SOUTH_EAST;
-                    case MIRROR_X:
-                        return RailShape.SOUTH_EAST;
-                    case MIRROR_Z:
-                        return RailShape.NORTH_WEST;
-                }
-                break;
-            case NORTH_WEST:
-                switch (this) {
-                    case ROTATE_90:
-                        return RailShape.NORTH_EAST;
-                    case MIRROR_90_X:
-                        return RailShape.SOUTH_WEST;
-                    case ROTATE_180:
-                        return RailShape.SOUTH_EAST;
-                    case ROTATE_270:
-                        return RailShape.SOUTH_WEST;
-                    case MIRROR_X:
-                        return RailShape.NORTH_EAST;
-                    case MIRROR_Z:
-                        return RailShape.SOUTH_WEST;
-                }
-                break;
-            case NORTH_EAST:
-                switch (this) {
-                    case ROTATE_90:
-                        return RailShape.SOUTH_EAST;
-                    case MIRROR_90_X:
-                        return RailShape.NORTH_WEST;
-                    case ROTATE_180:
-                        return RailShape.SOUTH_WEST;
-                    case ROTATE_270:
-                        return RailShape.NORTH_WEST;
-                    case MIRROR_X:
-                        return RailShape.NORTH_WEST;
-                    case MIRROR_Z:
-                        return RailShape.SOUTH_EAST;
-                }
-                break;
-        }
-        throw new IllegalStateException("Cannot happen!");
+    /**
+     * The horizontal direction this transform sends {@code direction} to. Same geometry as
+     * {@link #rotateX}/{@link #rotateZ}, expressed through the vanilla enums so rails and
+     * rotated/mirrored block states agree on what the transform means.
+     */
+    public Direction transform(Direction direction) {
+        return mcRotation.rotate(mcMirror.mirror(direction));
     }
 
-//    public static void main(String[] args) {
-//        int x;
-//        int z;
-//        x = 4; z = 4;
-//        System.out.println("x,z = " + x +","+z + " -> " +ROTATE_90.rotateX(x, z) +","+ROTATE_90.rotateZ(x,z));
-//    }
+    /**
+     * Rail shapes under this transform, derived from {@link #transform(Direction)} rather than
+     * hand-written tables: the old table had holes that threw (MIRROR_Z on an ascending east/west
+     * rail) and arms that disagreed with the coordinate maps.
+     */
+    public RailShape transform(RailShape shape) {
+        return switch (shape) {
+            case NORTH_SOUTH, EAST_WEST -> straight(transform(axis(shape)));
+            case ASCENDING_EAST -> ascending(transform(Direction.EAST));
+            case ASCENDING_WEST -> ascending(transform(Direction.WEST));
+            case ASCENDING_NORTH -> ascending(transform(Direction.NORTH));
+            case ASCENDING_SOUTH -> ascending(transform(Direction.SOUTH));
+            case SOUTH_EAST -> corner(transform(Direction.SOUTH), transform(Direction.EAST));
+            case SOUTH_WEST -> corner(transform(Direction.SOUTH), transform(Direction.WEST));
+            case NORTH_WEST -> corner(transform(Direction.NORTH), transform(Direction.WEST));
+            case NORTH_EAST -> corner(transform(Direction.NORTH), transform(Direction.EAST));
+        };
+    }
+
+    private static Direction axis(RailShape straight) {
+        return straight == RailShape.NORTH_SOUTH ? Direction.NORTH : Direction.EAST;
+    }
+
+    private static RailShape straight(Direction axis) {
+        return axis.getAxis() == Direction.Axis.Z ? RailShape.NORTH_SOUTH : RailShape.EAST_WEST;
+    }
+
+    private static RailShape ascending(Direction towards) {
+        return switch (towards) {
+            case EAST -> RailShape.ASCENDING_EAST;
+            case WEST -> RailShape.ASCENDING_WEST;
+            case NORTH -> RailShape.ASCENDING_NORTH;
+            case SOUTH -> RailShape.ASCENDING_SOUTH;
+            default -> throw new IllegalArgumentException("Not a horizontal direction: " + towards);
+        };
+    }
+
+    private static RailShape corner(Direction a, Direction b) {
+        Direction northSouth = a.getAxis() == Direction.Axis.Z ? a : b;
+        Direction eastWest = a.getAxis() == Direction.Axis.X ? a : b;
+        if (northSouth == Direction.SOUTH) {
+            return eastWest == Direction.EAST ? RailShape.SOUTH_EAST : RailShape.SOUTH_WEST;
+        } else {
+            return eastWest == Direction.EAST ? RailShape.NORTH_EAST : RailShape.NORTH_WEST;
+        }
+    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CompiledPalette.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CompiledPalette.java
@@ -33,14 +33,48 @@ public class CompiledPalette {
         addPalettes(palettes);
     }
 
-    private int addEntries(BlockState[] randomBlocks, int idx, BlockState c, int cnt) {
-        for (int i = 0 ; i < cnt ; i++) {
-            if (idx >= randomBlocks.length) {
-                return idx;
+    /**
+     * Distributes {@code slotCount} slots over the entries proportionally to their weights
+     * (largest-remainder rounding, remainder ties to the lowest index).
+     * <p>
+     * Weights used to be absolute slot counts out of 128: a pack whose weights summed below 128
+     * crashed at generation time and one summing above 128 was silently truncated (issue #58).
+     * Weights that already sum to exactly {@code slotCount} come back verbatim, so packs authored
+     * against the old contract generate identically.
+     */
+    public static int[] distributeSlots(int[] weights, int slotCount) {
+        long total = 0;
+        for (int w : weights) {
+            if (w < 0) {
+                throw new IllegalArgumentException("Negative palette weight " + w);
             }
-            randomBlocks[idx++] = c;
+            total += w;
         }
-        return idx;
+        if (total <= 0) {
+            throw new IllegalArgumentException("Palette weights must sum to a positive value");
+        }
+        int[] slots = new int[weights.length];
+        long[] remainders = new long[weights.length];
+        int assigned = 0;
+        for (int i = 0; i < weights.length; i++) {
+            long scaled = (long) weights[i] * slotCount;
+            slots[i] = (int) (scaled / total);
+            remainders[i] = scaled % total;
+            assigned += slots[i];
+        }
+        // Fractional parts sum to exactly the shortfall, so this hands out fewer slots than
+        // there are entries and no entry can win twice.
+        for (int remaining = slotCount - assigned; remaining > 0; remaining--) {
+            int best = 0;
+            for (int i = 1; i < weights.length; i++) {
+                if (remainders[i] > remainders[best]) {
+                    best = i;
+                }
+            }
+            slots[best]++;
+            remainders[best] = -1;
+        }
+        return slots;
     }
 
     private void addPalettes(Palette[] palettes) {
@@ -53,18 +87,24 @@ public class CompiledPalette {
                         palette.put(entry.getKey(), pe.blocks());
                     } else if (pe.blocks() instanceof Pair[]) {
                         Pair<Integer, BlockState>[] r = (Pair<Integer, BlockState>[]) pe.blocks();
+                        int[] weights = new int[r.length];
+                        for (int i = 0; i < r.length; i++) {
+                            weights[i] = r[i].getLeft();
+                        }
+                        int[] slots;
+                        try {
+                            slots = distributeSlots(weights, 128);
+                        } catch (IllegalArgumentException e) {
+                            throw new RuntimeException("Invalid palette entry for '" + entry.getKey() + "': " + e.getMessage());
+                        }
                         BlockState[] randomBlocks = new BlockState[128];
                         int idx = 0;
-                        for (Pair<Integer, BlockState> pair : r) {
-                            idx = addEntries(randomBlocks, idx, pair.getRight(), pair.getLeft());
-                            if (idx >= randomBlocks.length) {
-                                break;
+                        for (int i = 0; i < r.length; i++) {
+                            for (int j = 0; j < slots[i]; j++) {
+                                randomBlocks[idx++] = r[i].getRight();
                             }
                         }
                         palette.put(entry.getKey(), randomBlocks);
-                        if (idx < randomBlocks.length) {
-                            throw new RuntimeException("Invalid palette entry for '" + entry.getKey() + "'! Not enough blocks in the random list (factor should go up to 128)");
-                        }
                     } else if (!(pe.blocks() instanceof String)) {
                         if (pe.blocks() == null) {
                             throw new RuntimeException("Invalid palette entry for '" + entry.getKey() + "'!");

--- a/src/test/java/dev/krona/urbex/worldgen/gen/ScatteredTerrainLevelTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/gen/ScatteredTerrainLevelTest.java
@@ -1,0 +1,31 @@
+package dev.krona.urbex.worldgen.gen;
+
+import dev.krona.urbex.worldgen.lost.cityassets.ScatteredBuilding.TerrainHeight;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ScatteredTerrainLevelTest {
+
+    // The old switch had AVERAGE -> maximum and HIGHEST -> average (issue #38).
+
+    @Test
+    public void lowestPicksMinimum() {
+        assertEquals(60, Scattered.pickLevel(TerrainHeight.LOWEST, 60, 90, 75, 63));
+    }
+
+    @Test
+    public void averagePicksAverage() {
+        assertEquals(75, Scattered.pickLevel(TerrainHeight.AVERAGE, 60, 90, 75, 63));
+    }
+
+    @Test
+    public void highestPicksMaximum() {
+        assertEquals(90, Scattered.pickLevel(TerrainHeight.HIGHEST, 60, 90, 75, 63));
+    }
+
+    @Test
+    public void oceanPicksSeaLevel() {
+        assertEquals(63, Scattered.pickLevel(TerrainHeight.OCEAN, 60, 90, 75, 63));
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/StreetTypeTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/StreetTypeTest.java
@@ -1,0 +1,25 @@
+package dev.krona.urbex.worldgen.lost;
+
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StreetTypeTest {
+
+    @Test
+    public void nonParkChoiceReachesBothNormalAndFull() {
+        // The old magic `values()[nextInt(values().length - 2)]` could only ever produce
+        // NORMAL, leaving FULL street sections and the parts.full() asset list dead (issue #36).
+        EnumSet<BuildingInfo.StreetType> seen = EnumSet.noneOf(BuildingInfo.StreetType.class);
+        for (long seed = 0; seed < 64; seed++) {
+            seen.add(BuildingInfo.StreetType.randomNonPark(new XoroshiroRandomSource(seed)));
+        }
+        assertTrue(seen.contains(BuildingInfo.StreetType.NORMAL), "NORMAL should be reachable");
+        assertTrue(seen.contains(BuildingInfo.StreetType.FULL), "FULL should be reachable");
+        assertFalse(seen.contains(BuildingInfo.StreetType.PARK), "PARK is chosen by park chance, never here");
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/TransformTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/TransformTest.java
@@ -1,0 +1,121 @@
+package dev.krona.urbex.worldgen.lost;
+
+import net.minecraft.world.level.block.state.properties.RailShape;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class TransformTest {
+
+    // --- total: no (transform, shape) pair may throw -------------------------------------------
+
+    @Test
+    public void transformIsTotalOverAllShapes() {
+        for (Transform t : Transform.values()) {
+            for (RailShape shape : RailShape.values()) {
+                t.transform(shape);   // must not throw; MIRROR_Z x ASCENDING_EAST used to
+            }
+        }
+    }
+
+    // --- structural invariants -----------------------------------------------------------------
+
+    @Test
+    public void rotateNoneIsIdentity() {
+        for (RailShape shape : RailShape.values()) {
+            assertSame(shape, Transform.ROTATE_NONE.transform(shape));
+        }
+    }
+
+    @Test
+    public void rotationsCompose() {
+        for (RailShape shape : RailShape.values()) {
+            assertSame(Transform.ROTATE_180.transform(shape),
+                    Transform.ROTATE_90.transform(Transform.ROTATE_90.transform(shape)), "180 = 90+90 for " + shape);
+            assertSame(Transform.ROTATE_270.transform(shape),
+                    Transform.ROTATE_90.transform(Transform.ROTATE_180.transform(shape)), "270 = 180+90 for " + shape);
+            assertSame(shape,
+                    Transform.ROTATE_90.transform(Transform.ROTATE_270.transform(shape)), "360 = id for " + shape);
+        }
+    }
+
+    @Test
+    public void mirrorsAreInvolutions() {
+        for (Transform t : new Transform[]{Transform.MIRROR_X, Transform.MIRROR_Z, Transform.MIRROR_90_X}) {
+            for (RailShape shape : RailShape.values()) {
+                assertSame(shape, t.transform(t.transform(shape)), t + " twice on " + shape);
+            }
+        }
+    }
+
+    @Test
+    public void mirror90IsRotate90ThenMirrorX() {
+        // MIRROR_90_X's coordinate map is (x,z) -> (z,x), i.e. ROTATE_90 followed by MIRROR_X;
+        // the rail mapping must agree with the coordinate mapping used to place the blocks.
+        for (RailShape shape : RailShape.values()) {
+            assertSame(Transform.MIRROR_X.transform(Transform.ROTATE_90.transform(shape)),
+                    Transform.MIRROR_90_X.transform(shape), "MIRROR_90_X vs composition on " + shape);
+        }
+    }
+
+    // --- geometric spot checks (derived from rotateX/rotateZ direction maps) -------------------
+
+    @Test
+    public void mirrorXFlipsOnlyEastWest() {
+        // MIRROR_X maps x -> 15-x and leaves z alone: east/west swap, north/south stay.
+        assertSame(RailShape.ASCENDING_WEST, Transform.MIRROR_X.transform(RailShape.ASCENDING_EAST));
+        assertSame(RailShape.ASCENDING_NORTH, Transform.MIRROR_X.transform(RailShape.ASCENDING_NORTH));
+        assertSame(RailShape.ASCENDING_SOUTH, Transform.MIRROR_X.transform(RailShape.ASCENDING_SOUTH));
+        assertSame(RailShape.SOUTH_WEST, Transform.MIRROR_X.transform(RailShape.SOUTH_EAST));
+        assertSame(RailShape.NORTH_SOUTH, Transform.MIRROR_X.transform(RailShape.NORTH_SOUTH));
+        assertSame(RailShape.EAST_WEST, Transform.MIRROR_X.transform(RailShape.EAST_WEST));
+    }
+
+    @Test
+    public void mirrorZFlipsOnlyNorthSouth() {
+        assertSame(RailShape.ASCENDING_EAST, Transform.MIRROR_Z.transform(RailShape.ASCENDING_EAST));
+        assertSame(RailShape.ASCENDING_SOUTH, Transform.MIRROR_Z.transform(RailShape.ASCENDING_NORTH));
+        assertSame(RailShape.NORTH_EAST, Transform.MIRROR_Z.transform(RailShape.SOUTH_EAST));
+        assertSame(RailShape.EAST_WEST, Transform.MIRROR_Z.transform(RailShape.EAST_WEST));
+    }
+
+    @Test
+    public void mirror90TransposesAxes() {
+        // (x,z) -> (z,x): N<->W, E<->S; the corner {S,E} maps onto itself.
+        assertSame(RailShape.EAST_WEST, Transform.MIRROR_90_X.transform(RailShape.NORTH_SOUTH));
+        assertSame(RailShape.NORTH_SOUTH, Transform.MIRROR_90_X.transform(RailShape.EAST_WEST));
+        assertSame(RailShape.ASCENDING_SOUTH, Transform.MIRROR_90_X.transform(RailShape.ASCENDING_EAST));
+        assertSame(RailShape.ASCENDING_WEST, Transform.MIRROR_90_X.transform(RailShape.ASCENDING_NORTH));
+        assertSame(RailShape.SOUTH_EAST, Transform.MIRROR_90_X.transform(RailShape.SOUTH_EAST));
+        assertSame(RailShape.NORTH_WEST, Transform.MIRROR_90_X.transform(RailShape.NORTH_WEST));
+        assertSame(RailShape.SOUTH_WEST, Transform.MIRROR_90_X.transform(RailShape.NORTH_EAST));
+    }
+
+    @Test
+    public void rotate90MapsClockwise() {
+        // (x,z) -> (15-z, x): N->E->S->W->N
+        assertSame(RailShape.ASCENDING_SOUTH, Transform.ROTATE_90.transform(RailShape.ASCENDING_EAST));
+        assertSame(RailShape.ASCENDING_EAST, Transform.ROTATE_90.transform(RailShape.ASCENDING_NORTH));
+        assertSame(RailShape.EAST_WEST, Transform.ROTATE_90.transform(RailShape.NORTH_SOUTH));
+        // corner {S,E} -> {W,S}
+        assertSame(RailShape.SOUTH_WEST, Transform.ROTATE_90.transform(RailShape.SOUTH_EAST));
+    }
+
+    // --- coordinate maps stay untouched by the rewrite -----------------------------------------
+
+    @Test
+    public void oppositeUndoesCoordinateTransform() {
+        for (Transform t : Transform.values()) {
+            Transform opp = t.getOpposite();
+            for (int x = 0; x < 16; x++) {
+                for (int z = 0; z < 16; z++) {
+                    int tx = t.rotateX(x, z);
+                    int tz = t.rotateZ(x, z);
+                    assertEquals(x, opp.rotateX(tx, tz), t + " x roundtrip");
+                    assertEquals(z, opp.rotateZ(tx, tz), t + " z roundtrip");
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CompiledPaletteSlotsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CompiledPaletteSlotsTest.java
@@ -1,0 +1,64 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CompiledPaletteSlotsTest {
+
+    @Test
+    public void weightsSummingToSlotCountAreTakenVerbatim() {
+        // Upstream packs author weights as absolute counts out of 128; those must keep
+        // generating identically.
+        assertArrayEquals(new int[]{100, 20, 8},
+                CompiledPalette.distributeSlots(new int[]{100, 20, 8}, 128));
+    }
+
+    @Test
+    public void overweightEntriesAreScaledProportionally() {
+        // The bundled variants use weights like 1000: 1000/1060 and 60/1060 of 128 slots.
+        assertArrayEquals(new int[]{121, 7},
+                CompiledPalette.distributeSlots(new int[]{1000, 60}, 128));
+    }
+
+    @Test
+    public void underweightEntriesAreScaledUp() {
+        assertArrayEquals(new int[]{64, 64},
+                CompiledPalette.distributeSlots(new int[]{1, 1}, 128));
+    }
+
+    @Test
+    public void remainderSlotsGoToLargestFractionsThenLowestIndex() {
+        // 128/3 = 42.67 each: two remainder slots, equal fractions, first two entries win.
+        assertArrayEquals(new int[]{43, 43, 42},
+                CompiledPalette.distributeSlots(new int[]{1, 1, 1}, 128));
+    }
+
+    @Test
+    public void everySlotIsAssigned() {
+        int[] weights = {7, 13, 1, 999, 40};
+        int[] slots = CompiledPalette.distributeSlots(weights, 128);
+        assertEquals(128, Arrays.stream(slots).sum());
+    }
+
+    @Test
+    public void singleEntryTakesAllSlots() {
+        assertArrayEquals(new int[]{128}, CompiledPalette.distributeSlots(new int[]{3}, 128));
+    }
+
+    @Test
+    public void zeroTotalWeightIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CompiledPalette.distributeSlots(new int[]{0, 0}, 128));
+    }
+
+    @Test
+    public void negativeWeightIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CompiledPalette.distributeSlots(new int[]{5, -1}, 128));
+    }
+}


### PR DESCRIPTION
Closes #36, #37, #38, #45, #50, #58.

Every fix in this PR alters generated output for existing seeds, so they land together as one generation change rather than trickling out across releases.

## Changes
- **#37** — city style is resolved at the candidate city centre instead of the observing chunk, so one city keeps one coherent style.
- **#36** — `StreetType.FULL` is reachable again via an explicit `randomNonPark()` choice (the bundled `street_full` part exists, so nothing renders missing), and `generateStreet` no longer writes its redraw back into the shared cached `BuildingInfo`, removing a generation-order dependence neighbours could observe.
- **#38** — Scattered: the swapped `AVERAGE`/`HIGHEST` terrain arms are fixed and both single- and multi-building paths share one `pickLevel`; the biome pre-filter is keyed on the area's anchor chunk so every chunk of an area draws the same reference (multi-chunk buildings can no longer disagree with themselves about where they stand); the `<=` weighted-pick bias is fixed; and the per-area validity/height scan is cached in `DimensionCaches`, replacing the O((w·h)²) rescans.
- **#45** — `Transform` rewritten: rail shapes derive from the same direction-vector math as the coordinate maps (the hand-written table threw on `MIRROR_Z` × ascending east/west rails and disagreed with placement geometry in several arms), and mirrored parts now apply a real vanilla `Mirror` to block states in vanilla order (mirror, then rotate) instead of approximating with a rotation.
- **#50** — vine rolls use `Rng.floatAtPos`, dropping ~2,000 `RandomSource` allocations per city chunk.
- **#58** — palette weights are distributed proportionally over the 128 slots (largest-remainder rounding). Weights summing to exactly 128 — the upstream authoring convention — produce byte-identical slot arrays, so only packs that previously crashed (sum < 128) or were silently truncated (sum > 128, including the bundled `variants/*.json` with weight 1000) generate differently.

## Testing
23 new tests, written first: `TransformTest` (totality, involutions, composition laws, geometric spot checks — these exposed additional wrong arms in the old table beyond what #45 filed), `CompiledPaletteSlotsTest`, `StreetTypeTest`, `ScatteredTerrainLevelTest`. Full suite: 98 tests, 0 failures.

The one-line fixes in `City` and `ChunkFixer` and the Scattered wiring have no worldgen-level automated verification yet — that is the fixed-seed digest gametest gap tracked in #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)