### PR TITLE
fix: worldgen correctness batch 2

### DIFF
--- a/src/main/java/dev/krona/urbex/varia/Tools.java
+++ b/src/main/java/dev/krona/urbex/varia/Tools.java
@@ -70,6 +70,16 @@ public class Tools {
         return value.defaultBlockState();
     }
 
+    /**
+     * {@code min + rand.nextInt(maxExclusive - min)}, degrading to {@code min} when the range is
+     * empty or inverted. Profile and datapack bounds are user-editable; equal min/max used to
+     * reach {@code nextInt(0)} and crash chunk generation (issue #47). Draws exactly one value
+     * when the range is valid, so worlds generated with valid bounds do not shift.
+     */
+    public static int randomBetween(RandomSource rand, int min, int maxExclusive) {
+        return maxExclusive <= min ? min : min + rand.nextInt(maxExclusive - min);
+    }
+
     public static <T> T getRandomFromList(RandomSource random, List<T> list, Function<T, Float> weightGetter) {
         if (list.isEmpty()) {
             return null;

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -585,12 +585,23 @@ public class ChunkDriver {
             boolean isAir = state.isAir();
             boolean dirty = false;
             boolean record = recordingWrites;    // read the flag once, not once per block
+            BlockPos.MutableBlockPos worldPos = null;
             while (y1 <= y2) {
                 int sectionIdx = (y1 - minY) / SECTION_HEIGHT;
                 int idx = (px << 8) + ((y1 & 0xf) << 4) + pz;
 
                 BlockState st = cache[sectionIdx].section[idx];
-                if (st != state && st != null && test.test(st)) {
+                if (st == null) {
+                    // Fall back to the world for positions this chunk never touched. Skipping
+                    // them made the predicate form a no-op on virgin terrain: the highway
+                    // clear-above passes target vanilla blocks that are never in the cache,
+                    // so highways were not cleared of terrain at all (issue #35).
+                    if (worldPos == null) {
+                        worldPos = new BlockPos.MutableBlockPos();
+                    }
+                    st = owner.region.getBlockState(worldPos.set(cx + px, y1, cz + pz));
+                }
+                if (st != state && test.test(st)) {
                     dirty = true;
                     cache[sectionIdx].section[idx] = state;
                     if (!isAir) {

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
@@ -9,6 +9,7 @@ import dev.krona.urbex.worldgen.lost.cityassets.LightPool;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 
 import javax.annotation.Nullable;
@@ -31,6 +32,12 @@ public final class ChunkGenContext {
     public final CompiledPalette palette;
     public final char street;
     public final NoiseBuffers buffers;
+    /**
+     * Scratch for {@link LostCityTerrainFeature#moveDown}'s top-of-column stash. Lives here
+     * because the feature instance is shared across worldgen worker threads: as an instance
+     * field there, two threads in moveDown at once swapped each other's terrain (issue #43).
+     */
+    public final BlockState[] moveDownBuffer = new BlockState[6];
     private final LightTodoQueue lightTodo;
 
 

--- a/src/main/java/dev/krona/urbex/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/dev/krona/urbex/worldgen/LostCityTerrainFeature.java
@@ -779,11 +779,10 @@ public class LostCityTerrainFeature {
         return maxYTouched;
     }
 
-    private final BlockState[] buffer = new BlockState[6];
-
     // Return the new max height of the chunk in this column. Or Short.MIN_VALUE if nothing was done
     private int moveDown(ChunkGenContext ctx, int x, int z, int height, int maxBuildLimit) {
         ChunkDriver driver = ctx.driver;
+        BlockState[] buffer = ctx.moveDownBuffer;
         int maxYTouched = Short.MIN_VALUE;       // Max Y that we touched
         int y = maxBuildLimit-1;
         driver.current(x, y, z);
@@ -2137,11 +2136,13 @@ public class LostCityTerrainFeature {
                 int destroyedBlocks = (int) (blocks * damage);
                 // How many go this direction (approx, based on cardinal directions from building as well as number that simply fall down)
                 destroyedBlocks /= info.profile.DEBRIS_TO_NEARBYCHUNK_FACTOR;
-                int h = adjacentInfo.getMaxHeight() + 10;
+                int startHeight = adjacentInfo.getMaxHeight() + 10;
                 int maxBuildHeight = info.provider.getWorld().getMaxY() + 1;
-                if (h > maxBuildHeight - 1) {
-                    int minBuildHeight = info.provider.getWorld().getMinY();
-                    h = minBuildHeight - 1;
+                int minBuildHeight = info.provider.getWorld().getMinY();
+                if (startHeight > maxBuildHeight - 1) {
+                    // Clamp to the top of the world: the old code clamped an out-of-range start
+                    // to minBuildHeight - 1, dropping debris at bedrock and reading below minY
+                    startHeight = maxBuildHeight - 1;
                 }
 
                 CompiledPalette palette = info.getCompiledPalette();
@@ -2152,8 +2153,12 @@ public class LostCityTerrainFeature {
                     int x = debrisRandom.nextInt(16);
                     int z = debrisRandom.nextInt(16);
                     if (debrisRandom.nextFloat() < locationFactor.apply(x, z)) {
+                        // Fresh drop per debris block: h used to persist across iterations, so
+                        // after the first block sank, every later one started at its level and
+                        // debris piled at one height instead of following the surface (issue #42)
+                        int h = startHeight;
                         driver.current(x, h, z);
-                        while (h > 0 && isEmpty(driver.getBlock())) {
+                        while (h > minBuildHeight && isEmpty(driver.getBlock())) {
                             h--;
                             driver.decY();
                         }

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Highways.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Highways.java
@@ -24,16 +24,16 @@ public class Highways {
             // will clear out what is above it
             if (levelX == 0) {
                 generateHighwayPart(ctx, feature, info, levelX, Transform.ROTATE_NONE, info.getZmin(), info.getZmax(), false);
-                generateHighwayPart(ctx, feature, info, levelZ, Transform.ROTATE_90, info.getXmax(), info.getXmax(), false);
+                generateHighwayPart(ctx, feature, info, levelZ, Transform.ROTATE_90, info.getXmin(), info.getXmax(), false);
             } else {
-                generateHighwayPart(ctx, feature, info, levelZ, Transform.ROTATE_90, info.getXmax(), info.getXmax(), false);
+                generateHighwayPart(ctx, feature, info, levelZ, Transform.ROTATE_90, info.getXmin(), info.getXmax(), false);
                 generateHighwayPart(ctx, feature, info, levelX, Transform.ROTATE_NONE, info.getZmin(), info.getZmax(), false);
             }
         } else {
             if (levelX >= 0) {
                 generateHighwayPart(ctx, feature, info, levelX, Transform.ROTATE_NONE, info.getZmin(), info.getZmax(), false);
             } else if (levelZ >= 0) {
-                generateHighwayPart(ctx, feature, info, levelZ, Transform.ROTATE_90, info.getXmax(), info.getXmax(), false);
+                generateHighwayPart(ctx, feature, info, levelZ, Transform.ROTATE_90, info.getXmin(), info.getXmax(), false);
             }
         }
     }

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.worldgen.gen;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.varia.Rng;
+import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.ChunkDriver;
 import dev.krona.urbex.worldgen.ChunkGenContext;
 import dev.krona.urbex.worldgen.LostCityTerrainFeature;
@@ -124,12 +125,12 @@ public class Stuff {
         }
         int mincount = settings.getMincount();
         int maxcount = settings.getMaxcount();
-        int count = slot(ctx, stuffOrdinal, -1, 0).nextInt(maxcount - mincount) + mincount;
+        int count = Tools.randomBetween(slot(ctx, stuffOrdinal, -1, 0), mincount, maxcount);
         for (int j = 0; j < count; j++) {
             for (int i = 0; i < attempts; i++) {
                 RandomSource rand = slot(ctx, stuffOrdinal, j, i);
                 int x = rand.nextInt(16);
-                int y = rand.nextInt(maxheight - minheight) + minheight;
+                int y = Tools.randomBetween(rand, minheight, maxheight);
                 int z = rand.nextInt(16);
                 if (testBlock(driver, settings.getBlockMatcher(), x, y-1, z) && testBlock(driver, settings.getUpperBlockMatcher(), x, y + blocks.length(), z)) {
                     Boolean isSeesky = settings.isSeesky();

--- a/src/main/java/dev/krona/urbex/worldgen/lost/CitySphere.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/CitySphere.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.worldgen.lost;
 
 import dev.krona.urbex.config.LostCityProfile;
 import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.varia.Rng;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
@@ -252,7 +253,7 @@ public class CitySphere {
         if (city != null) {
             return city.getRadius() * profile.CITYSPHERE_FACTOR;
         }
-        return profile.CITY_MINRADIUS + rand.nextInt(profile.CITY_MAXRADIUS - profile.CITY_MINRADIUS) * profile.CITYSPHERE_FACTOR;
+        return profile.CITY_MINRADIUS + Tools.randomBetween(rand, 0, profile.CITY_MAXRADIUS - profile.CITY_MINRADIUS) * profile.CITYSPHERE_FACTOR;
     }
 
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
@@ -122,9 +122,9 @@ public class DamageArea {
     private Explosion getExplosionAt(ChunkCoord coord, IDimensionInfo provider) {
         RandomSource randomExplosion = Rng.at(seed, coord.chunkX(), coord.chunkZ(), Rng.Purpose.EXPLOSION);
         if (randomExplosion.nextFloat() < profile.EXPLOSION_CHANCE) {
-            return new Explosion(profile.EXPLOSION_MINRADIUS + randomExplosion.nextInt(profile.EXPLOSION_MAXRADIUS - profile.EXPLOSION_MINRADIUS),
+            return new Explosion(Tools.randomBetween(randomExplosion, profile.EXPLOSION_MINRADIUS, profile.EXPLOSION_MAXRADIUS),
                     new BlockPos((coord.chunkX() << 4) + randomExplosion.nextInt(16),
-                            BuildingInfo.getBuildingInfo(coord, provider).cityLevel * 6 + profile.EXPLOSION_MINHEIGHT + randomExplosion.nextInt(profile.EXPLOSION_MAXHEIGHT - profile.EXPLOSION_MINHEIGHT),
+                            BuildingInfo.getBuildingInfo(coord, provider).cityLevel * 6 + Tools.randomBetween(randomExplosion, profile.EXPLOSION_MINHEIGHT, profile.EXPLOSION_MAXHEIGHT),
                             (coord.chunkZ() << 4) + randomExplosion.nextInt(16)));
         }
         return null;
@@ -133,9 +133,9 @@ public class DamageArea {
     private Explosion getMiniExplosionAt(ChunkCoord coord, IDimensionInfo provider) {
         RandomSource randomMiniExplosion = Rng.at(seed, coord.chunkX(), coord.chunkZ(), Rng.Purpose.EXPLOSION_MINI);
         if (randomMiniExplosion.nextFloat() < profile.MINI_EXPLOSION_CHANCE) {
-            return new Explosion(profile.MINI_EXPLOSION_MINRADIUS + randomMiniExplosion.nextInt(profile.MINI_EXPLOSION_MAXRADIUS - profile.MINI_EXPLOSION_MINRADIUS),
+            return new Explosion(Tools.randomBetween(randomMiniExplosion, profile.MINI_EXPLOSION_MINRADIUS, profile.MINI_EXPLOSION_MAXRADIUS),
                     new BlockPos((coord.chunkX() << 4) + randomMiniExplosion.nextInt(16),
-                            BuildingInfo.getBuildingInfo(coord, provider).cityLevel * 6 + profile.MINI_EXPLOSION_MINHEIGHT + randomMiniExplosion.nextInt(profile.MINI_EXPLOSION_MAXHEIGHT - profile.MINI_EXPLOSION_MINHEIGHT),
+                            BuildingInfo.getBuildingInfo(coord, provider).cityLevel * 6 + Tools.randomBetween(randomMiniExplosion, profile.MINI_EXPLOSION_MINHEIGHT, profile.MINI_EXPLOSION_MAXHEIGHT),
                             (coord.chunkZ() << 4) + randomMiniExplosion.nextInt(16)));
         }
         return null;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
@@ -95,11 +95,13 @@ public class MultiChunk {
             }
         }
 
-        // Get all the desired multibuildings based on the percentage of the city styles and the counter
-        List<MultiBuilding> multiBuildings = new ArrayList<>();
+        // Get all the desired multibuildings based on the percentage of the city styles and the counter.
+        // One list of pairs, not two parallel lists: the size sort below used to reorder only the
+        // buildings, pairing them with the wrong styles (issue #39).
+        record Chosen(MultiBuilding building, CityStyle style) {}
+        List<Chosen> chosen = new ArrayList<>();
         List<CityStyle> styleList = new ArrayList<>(cityStyleCounter.getMap().keySet());
         styleList.sort(Comparator.comparing(CityStyle::getName));
-        List<CityStyle> styleForBuilding = new ArrayList<>();
         for (int i = 0 ; i < cnt ; i++) {
             CityStyle cityStyle = Tools.getRandomFromList(rand, styleList, style -> (float) cityStyleCounter.get(style));
             String multiBuilding = cityStyle.getRandomMultiBuilding(rand, topleft);
@@ -107,16 +109,16 @@ public class MultiChunk {
             if (mb == null) {
                 throw new RuntimeException("Cannot find multibuilding: " + multiBuilding);
             }
-            multiBuildings.add(mb);
-            styleForBuilding.add(cityStyle);
+            chosen.add(new Chosen(mb, cityStyle));
         }
 
         // Sort the multibuildings by size. Largest first
-        multiBuildings.sort((b1, b2) -> Integer.compare(b2.getDimX() + b2.getDimZ(), b1.getDimX() + b1.getDimZ()));
+        chosen.sort((c1, c2) -> Integer.compare(c2.building().getDimX() + c2.building().getDimZ(),
+                c1.building().getDimX() + c1.building().getDimZ()));
 
         // For every building we want to place, try to find a spot
-        for (int i = 0 ; i < multiBuildings.size() ; i++) {
-            MultiBuilding mb = multiBuildings.get(i);
+        for (Chosen ch : chosen) {
+            MultiBuilding mb = ch.building();
             // Find the maximum possible number of cellars for all buildings in this multibuilding
             int maxCellars = 0;
             for (String b : mb.getBuildingSet()) {
@@ -135,7 +137,7 @@ public class MultiChunk {
             for (int att = 0 ; att < attempts ; att++) {
                 int x = rand.nextInt(areasize - dimX + 1);
                 int z = rand.nextInt(areasize - dimZ + 1);
-                if (canPlaceBuilding(topleft, provider, provider.getProfile(), styleForBuilding.get(i), mb, cityLevel, maxCellars, x, z)) {
+                if (canPlaceBuilding(topleft, provider, provider.getProfile(), ch.style(), mb, cityLevel, maxCellars, x, z)) {
                     placeBuilding(mb, x, z);
                     break;
                 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
@@ -114,7 +114,7 @@ public class Railway {
                     boolean cityEast = BuildingInfo.isCityRaw(key.offset(10, 0), provider, profile) ||
                             BuildingInfo.isCityRaw(key.offset(10, - 10), provider, profile) ||
                             BuildingInfo.isCityRaw(key.offset(10, 10), provider, profile);
-                    boolean cityWest = BuildingInfo.isCityRaw(key.offset(10, 0), provider, profile) ||
+                    boolean cityWest = BuildingInfo.isCityRaw(key.offset(- 10, 0), provider, profile) ||
                             BuildingInfo.isCityRaw(key.offset(- 10, - 10), provider, profile) ||
                             BuildingInfo.isCityRaw(key.offset(- 10, 10), provider, profile);
                     if (!cityEast && !cityWest) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CompiledPalette.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CompiledPalette.java
@@ -167,11 +167,14 @@ public class CompiledPalette {
     }
 
     /**
-     * Return true if this is a simple character that can have only one value in the palette
+     * Return true if this is a simple character that can have only one value in the palette.
+     * The palette map only ever holds {@code BlockState} (simple) or {@code BlockState[]}
+     * (weighted); the old {@code instanceof Character} test matched neither, so the bulk-fill
+     * fast path behind this check was dead (issue #33).
      */
     public boolean isSimple(char c) {
         Object o = palette.get(c);
-        return o instanceof Character;
+        return o instanceof BlockState;
     }
 
     /**
@@ -261,7 +264,9 @@ public class CompiledPalette {
                 return Collections.emptySet();
             } else {
                 BlockState[] randomBlocks = (BlockState[]) o;
-                return Set.of(randomBlocks);
+                // Set.copyOf, not Set.of: a weighted array always repeats states, and the
+                // varargs form throws on duplicates (issue #44)
+                return Set.copyOf(Arrays.asList(randomBlocks));
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/dev/krona/urbex/varia/ToolsRandomBetweenTest.java
+++ b/src/test/java/dev/krona/urbex/varia/ToolsRandomBetweenTest.java
@@ -1,0 +1,39 @@
+package dev.krona.urbex.varia;
+
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ToolsRandomBetweenTest {
+
+    @Test
+    public void equalBoundsReturnMinInsteadOfThrowing() {
+        // Profile fields are user-editable: EXPLOSION_MINRADIUS == EXPLOSION_MAXRADIUS used to
+        // crash chunk generation with IllegalArgumentException (issue #47).
+        assertEquals(12, Tools.randomBetween(new XoroshiroRandomSource(1), 12, 12));
+    }
+
+    @Test
+    public void invertedBoundsReturnMin() {
+        assertEquals(12, Tools.randomBetween(new XoroshiroRandomSource(1), 12, 5));
+    }
+
+    @Test
+    public void validBoundsStayInHalfOpenRange() {
+        for (long seed = 0; seed < 200; seed++) {
+            int v = Tools.randomBetween(new XoroshiroRandomSource(seed), 10, 13);
+            assertTrue(v >= 10 && v < 13, "got " + v);
+        }
+    }
+
+    @Test
+    public void validBoundsMatchTheOldDrawExactly() {
+        // Sites replaced by this helper drew min + nextInt(max - min); worlds must not shift.
+        for (long seed = 0; seed < 50; seed++) {
+            int expected = 7 + new XoroshiroRandomSource(seed).nextInt(9);
+            assertEquals(expected, Tools.randomBetween(new XoroshiroRandomSource(seed), 7, 16));
+        }
+    }
+}


### PR DESCRIPTION
Closes #33, #35, #39, #40, #41, #42, #43, #44, #47.

The remaining small-to-medium worldgen correctness bugs from the audit. Most change generated output (highways clear terrain now, debris follows the surface, west rail termination works), so this is best released alongside — or immediately after — the first world-changing batch (#83) under the same generation-change notice.

## Changes
- **#35** — the predicate form of `putRange` falls back to reading the world for positions the driver never touched. The highway clear-above passes target vanilla terrain that is never in the cache, so highway clearing was a silent no-op on virgin terrain.
- **#33** — `CompiledPalette.isSimple` tests `instanceof BlockState` (the map only ever holds `BlockState`/`BlockState[]`; the old `instanceof Character` matched neither), reviving the bulk `setBlockRange` fast path for every single-state filler/border column.
- **#39** — `MultiChunk` sorts one list of `(building, style)` pairs instead of sorting one of two parallel lists, so placement checks run against the right city style.
- **#40** — `Railway` `cityWest` checks `offset(-10, 0)` instead of the copy-pasted east offset.
- **#41** — Z-direction highways pass `getXmin(), getXmax()` instead of `getXmax()` twice (three call sites), so the open-vs-bridge decision sees both neighbours.
- **#42** — debris starts from a fresh height per block (the sink height used to persist across the loop, piling debris at one level), the out-of-range clamp targets `maxBuildHeight - 1` instead of below bedrock, and the sink loop respects `minBuildHeight`.
- **#43** — `moveDown`'s six-block column stash moved from the feature instance (shared across worldgen worker threads) onto `ChunkGenContext`.
- **#44** — `CompiledPalette.getAll` uses `Set.copyOf`, which tolerates the duplicates every weighted array has; `Set.of` threw and killed chunk generation.
- **#47** — new `Tools.randomBetween` guards every user-editable `min == max` bound (`Stuff` count and height, both `DamageArea` explosions, `CitySphere` radius). Valid ranges draw exactly one value as before, so existing worlds with valid configs do not shift.

Deliberately **not** included: #34 (`correct()` gating) and #46/#48 (heightmap/flush ordering) — those belong with the ChunkDriver rewrite (#52), where the design changes make them safe.

## Testing
`ToolsRandomBetweenTest` (4 tests, written first) pins the degenerate-bounds behavior and byte-identical draws for valid ranges. Full suite green, 0 failures. Worldgen-level verification remains the digest gametest gap tracked in #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)