### PR TITLE
feat: headless worldgen digest check for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ jobs:
           java-version: '25'
       - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew build --no-daemon
+      - name: Worldgen digest check
+        run: |
+          ./gradlew runDigestCheck --no-daemon | tee digest-check.log
+          grep -q "URBEX-DIGEST-CHECK: OK" digest-check.log
       - uses: actions/upload-artifact@v4
         with:
           name: jar

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,58 @@ loom {
             ideConfigGenerated(true)
             runDir('runs/server')
         }
+        digestCheck {
+            server()
+            setConfigName('Urbex Digest Check')
+            ideConfigGenerated(false)
+            runDir('runs/digestcheck')
+            vmArg '-Durbex.digestCheck=3,rowmajor,100'
+            // Single worker thread: parallel chunk generation is not yet run-to-run
+            // deterministic (issue #24 - shared mutable ChunkHeightmap and friends), so the
+            // regression pin is taken on a serial baseline. Lifting this flag - two parallel
+            // runs agreeing - is the acceptance test for fixing #24.
+            vmArg '-XX:ActiveProcessorCount=1'
+            // Pinned DRIVERDIGEST for seed 1337; regenerate deliberately on world-changing
+            // changes by deleting the file, running runDigestCheck twice (results must match)
+            // and committing the new value.
+            def golden = file('digest.golden')
+            if (golden.exists()) {
+                vmArg "-Durbex.digestCheck.expected=${golden.text.trim()}"
+            }
+        }
     }
+}
+
+// A fresh, fully pinned dedicated-server environment for every digest run: fixed seed, default
+// (noise) world type, the 'default' urbex profile on the overworld, and no watchdog (the check
+// generates its whole chunk square on the server thread).
+tasks.register('prepareDigestCheck') {
+    notCompatibleWithConfigurationCache("writes the run directory")
+    doLast {
+        def dir = file('runs/digestcheck')
+        project.delete(new File(dir, 'world'))
+        dir.mkdirs()
+        new File(dir, 'eula.txt').text = 'eula=true\n'
+        new File(dir, 'server.properties').text = '''\
+level-seed=1337
+online-mode=false
+spawn-protection=0
+view-distance=6
+max-tick-time=-1
+motd=urbex digest check
+'''
+        def cfgDir = new File(dir, 'world/serverconfig')
+        cfgDir.mkdirs()
+        new File(cfgDir, 'urbex-server.toml').text = '''\
+[profiles]
+\tselectedProfile = "default"
+\tselectedCustomJson = ""
+'''
+    }
+}
+
+tasks.matching { it.name == 'runDigestCheck' }.configureEach {
+    dependsOn 'prepareDigestCheck'
 }
 
 dependencies {

--- a/digest.golden
+++ b/digest.golden
@@ -1,0 +1,1 @@
+efd7fca468efe0a2

--- a/src/main/java/dev/krona/urbex/Urbex.java
+++ b/src/main/java/dev/krona/urbex/Urbex.java
@@ -54,6 +54,9 @@ public class Urbex implements ModInitializer {
 
         registerNetworking();
 
+        // Headless worldgen regression check; no-op without -Durbex.digestCheck
+        DigestCheck.registerIfRequested();
+
         // Track the current server (replaces NeoForge's ServerLifecycleHooks)
         ServerLifecycleEvents.SERVER_STARTING.register(server -> ServerAccess.setServer(server));
         ServerLifecycleEvents.SERVER_STOPPED.register(server -> ServerAccess.setServer(null));

--- a/src/main/java/dev/krona/urbex/commands/CommandDigest.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandDigest.java
@@ -9,21 +9,10 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.status.ChunkStatus;
 import dev.krona.urbex.worldgen.ChunkDriver;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Random;
+import dev.krona.urbex.worldgen.DigestRunner;
 
 /**
  * Generates a square of chunks in a chosen order and prints two hashes of the result.
@@ -44,15 +33,12 @@ import java.util.Random;
  * underwater vegetation, and those bleed across chunk borders: the same seed in the same order,
  * in a dimension with no Urbex profile at all, produces two different values on two runs.
  * <p>
- * Both aggregate in a canonical sorted order - chunks by (x, z), and within a chunk the recorded
- * positions ascending - so only the <em>generation</em> order is ever under test.
+ * The machinery lives in {@link DigestRunner} so the headless digest check can run it without a
+ * command source.
  */
 public class CommandDigest implements Command<CommandSourceStack> {
 
     private static final CommandDigest CMD = new CommandDigest();
-
-    private static final long FNV_OFFSET = 0xCBF29CE484222325L;
-    private static final long FNV_PRIME = 0x100000001B3L;
 
     public static ArgumentBuilder<CommandSourceStack, ?> register(CommandDispatcher<CommandSourceStack> dispatcher) {
         return Commands.literal("digest")
@@ -70,131 +56,20 @@ public class CommandDigest implements Command<CommandSourceStack> {
         int offset = IntegerArgumentType.getInteger(context, "offset");
         ServerLevel level = context.getSource().getLevel();
 
-        List<ChunkPos> chunks = new ArrayList<>();
-        for (int x = -radius; x <= radius; x++) {
-            for (int z = -radius; z <= radius; z++) {
-                chunks.add(new ChunkPos(offset + x, offset + z));
-            }
-        }
-
-        switch (order) {
-            case "rowmajor" -> { /* already row-major */ }
-            case "reverse" -> Collections.reverse(chunks);
-            case "shuffled" -> Collections.shuffle(chunks, new Random(0xC0FFEE));
-            default -> {
-                context.getSource().sendFailure(Component.literal(
-                        "order must be one of: rowmajor, reverse, shuffled").withStyle(ChatFormatting.RED));
-                return 0;
-            }
-        }
-
-        long start = System.currentTimeMillis();
-        int recordedChunks;
-        ChunkDriver.startRecordingWrites();
+        DigestRunner.Result result;
         try {
-            for (ChunkPos pos : chunks) {
-                level.getChunk(pos.x(), pos.z(), ChunkStatus.FULL, true);
-            }
-        } finally {
-            ChunkDriver.stopRecordingWrites();
-            recordedChunks = ChunkDriver.recordedChunkCount();
+            result = DigestRunner.run(level, radius, order, offset);
+        } catch (IllegalArgumentException e) {
+            context.getSource().sendFailure(Component.literal(e.getMessage()).withStyle(ChatFormatting.RED));
+            return 0;
         }
 
-        // Hash in a canonical order so only generation order can affect the result.
-        List<ChunkPos> sorted = new ArrayList<>(chunks);
-        sorted.sort(Comparator.comparingInt(ChunkPos::x).thenComparingInt(ChunkPos::z));
-
-        long digest = FNV_OFFSET;
-        long driverDigest = FNV_OFFSET;
-        long driverBlocks = 0;
-        for (ChunkPos pos : sorted) {
-            digest = hashChunk(level, pos, digest);
-            long[] written = ChunkDriver.recordedWrites(pos);
-            driverBlocks += written.length;
-            driverDigest = hashDriverWrites(level, written, driverDigest);
-        }
-        ChunkDriver.clearRecordedWrites();
-
-        long elapsed = System.currentTimeMillis() - start;
-        String driverLine = String.format(
-                "DRIVERDIGEST=%016x blocks=%d drivenChunks=%d chunks=%d order=%s offset=%d ms=%d",
-                driverDigest, driverBlocks, recordedChunks, chunks.size(), order, offset, elapsed);
-        String line = String.format("DIGEST=%016x chunks=%d order=%s offset=%d ms=%d",
-                digest, chunks.size(), order, offset, elapsed);
+        String driverLine = result.driverLine(order, offset);
+        String line = result.fullLine(order, offset);
         context.getSource().sendSuccess(() -> Component.literal(driverLine).withStyle(ChatFormatting.GREEN), true);
         context.getSource().sendSuccess(() -> Component.literal(line).withStyle(ChatFormatting.YELLOW), true);
         System.out.println(driverLine);     // so headless runs can grep stdout
         System.out.println(line);
         return 1;
-    }
-
-    /**
-     * Hash the final state at each position this mod wrote.
-     * <p>
-     * The states are read here, once, after every chunk has finished generating - not folded in as
-     * the writes happened. A position overwritten three times therefore contributes its last state
-     * exactly once, and two runs that reach the same blocks by different internal paths agree.
-     */
-    private long hashDriverWrites(ServerLevel level, long[] written, long digest) {
-        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
-        for (long packed : written) {
-            mutable.set(BlockPos.getX(packed), BlockPos.getY(packed), BlockPos.getZ(packed));
-            digest = hashLong(digest, packed);
-            digest = hashString(digest, level.getBlockState(mutable).toString());
-            BlockEntity be = level.getBlockEntity(mutable);
-            if (be != null) {
-                digest = hashString(digest, be.saveWithFullMetadata(level.registryAccess()).toString());
-            }
-        }
-        return digest;
-    }
-
-    private long hashChunk(ServerLevel level, ChunkPos pos, long digest) {
-        ChunkAccess chunk = level.getChunk(pos.x(), pos.z(), ChunkStatus.FULL, true);
-        int minY = chunk.getMinY();
-        int maxY = chunk.getMaxY();
-        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
-        for (int x = 0; x < 16; x++) {
-            for (int z = 0; z < 16; z++) {
-                for (int y = minY; y <= maxY; y++) {
-                    mutable.set(pos.getMinBlockX() + x, y, pos.getMinBlockZ() + z);
-                    BlockState state = chunk.getBlockState(mutable);
-                    if (state.isAir()) {
-                        continue;
-                    }
-                    digest = hashLong(digest, mutable.asLong());
-                    digest = hashString(digest, state.toString());
-                    // Look the block entity up through the level rather than the raw ChunkAccess:
-                    // ChunkAccess no longer exposes a bare getBlockEntity(BlockPos) on 26.2 (only
-                    // LevelChunk does), and the level lookup is the stable public way to reach it
-                    // for a chunk we just forced to FULL status.
-                    BlockEntity be = level.getBlockEntity(mutable);
-                    if (be != null) {
-                        // saveWithId(ValueOutput) returns void on 26.2 (the old CompoundTag-returning
-                        // overload is gone). saveWithFullMetadata(HolderLookup.Provider) is the
-                        // vanilla replacement that still hands back a CompoundTag directly - it's the
-                        // exact method LevelChunk/ProtoChunk use to persist block entities to disk,
-                        // so its NBT representation is guaranteed stable across JVM restarts.
-                        digest = hashString(digest,
-                                be.saveWithFullMetadata(level.registryAccess()).toString());
-                    }
-                }
-            }
-        }
-        return digest;
-    }
-
-    private static long hashLong(long digest, long value) {
-        for (int i = 0; i < 8; i++) {
-            digest = (digest ^ ((value >>> (i * 8)) & 0xFF)) * FNV_PRIME;
-        }
-        return digest;
-    }
-
-    private static long hashString(long digest, String value) {
-        for (int i = 0; i < value.length(); i++) {
-            digest = (digest ^ value.charAt(i)) * FNV_PRIME;
-        }
-        return digest;
     }
 }

--- a/src/main/java/dev/krona/urbex/setup/DigestCheck.java
+++ b/src/main/java/dev/krona/urbex/setup/DigestCheck.java
@@ -1,0 +1,92 @@
+package dev.krona.urbex.setup;
+
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.worldgen.DigestRunner;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.minecraft.server.level.ServerLevel;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Headless worldgen regression check: when {@code -Durbex.digestCheck=radius,order,offset} is
+ * set, the server generates that chunk square right after startup, prints the driver digest,
+ * compares it against {@code -Durbex.digestCheck.expected} (when given), emits a single
+ * greppable verdict line and shuts the server down.
+ * <p>
+ * This exists because the vanilla GameTest server runs a flat world in which the Urbex feature
+ * never fires - a real dedicated server on a pinned seed is the only harness that exercises the
+ * actual generation path end to end. CI boots it via the {@code runDigestCheck} Gradle task on a
+ * fresh copy of the pinned world and greps for {@link #OK}.
+ */
+public final class DigestCheck {
+
+    public static final String PROP = "urbex.digestCheck";
+    public static final String PROP_EXPECTED = "urbex.digestCheck.expected";
+    public static final String OK = "URBEX-DIGEST-CHECK: OK";
+    public static final String FAIL = "URBEX-DIGEST-CHECK: FAIL";
+
+    /** The check parameters: {@code radius,order,offset}, e.g. {@code 3,rowmajor,100}. */
+    public record Spec(int radius, String order, int offset) {
+        private static final Set<String> ORDERS = Set.of("rowmajor", "reverse", "shuffled");
+
+        public static Spec parse(String value) {
+            String[] parts = value.split(",");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("Expected radius,order,offset but got '" + value + "'");
+            }
+            int radius = Integer.parseInt(parts[0].trim());
+            if (radius < 1) {
+                throw new IllegalArgumentException("Radius must be at least 1, got " + radius);
+            }
+            String order = parts[1].trim();
+            if (!ORDERS.contains(order)) {
+                throw new IllegalArgumentException("Order must be one of " + ORDERS + ", got '" + order + "'");
+            }
+            int offset = Integer.parseInt(parts[2].trim());
+            return new Spec(radius, order, offset);
+        }
+    }
+
+    private DigestCheck() {
+    }
+
+    /** No-op unless the {@value #PROP} system property is present. Called once from mod init. */
+    public static void registerIfRequested() {
+        String value = System.getProperty(PROP);
+        if (value == null) {
+            return;
+        }
+        Spec spec = Spec.parse(value);
+        String expected = System.getProperty(PROP_EXPECTED);
+
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            try {
+                ServerLevel level = server.overworld();
+                DigestRunner.Result result = DigestRunner.run(level, spec.radius(), spec.order(), spec.offset());
+                String driverLine = result.driverLine(spec.order(), spec.offset());
+                Urbex.getLogger().info(driverLine);
+                System.out.println(driverLine);
+
+                String actual = String.format("%016x", result.driverDigest());
+                if (result.driverBlocks() == 0) {
+                    verdict(FAIL + " (no driver writes recorded - is an urbex profile configured for the overworld?)");
+                } else if (expected != null && !expected.trim().toLowerCase(Locale.ROOT).equals(actual)) {
+                    verdict(FAIL + String.format(" (expected DRIVERDIGEST=%s, got %s)", expected.trim(), actual));
+                } else {
+                    verdict(OK + " DRIVERDIGEST=" + actual);
+                }
+            } catch (Throwable t) {
+                Urbex.getLogger().error("Digest check crashed", t);
+                verdict(FAIL + " (" + t + ")");
+            } finally {
+                server.halt(false);
+            }
+        });
+    }
+
+    private static void verdict(String line) {
+        Urbex.getLogger().info(line);
+        System.out.println(line);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
@@ -1,0 +1,186 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Generates a square of chunks in a chosen order and produces two hashes of the result. This is
+ * the machinery behind {@code /urbex digest} and the headless digest check; see
+ * {@link dev.krona.urbex.commands.CommandDigest} for what the two digests do and do not cover.
+ * <p>
+ * Both digests aggregate in a canonical sorted order - chunks by (x, z), and within a chunk the
+ * recorded positions ascending - so only the <em>generation</em> order is ever under test.
+ */
+public final class DigestRunner {
+
+    private static final long FNV_OFFSET = 0xCBF29CE484222325L;
+    private static final long FNV_PRIME = 0x100000001B3L;
+
+    private DigestRunner() {
+    }
+
+    /**
+     * @param driverDigest hash of the final state at each position the mod wrote through
+     *                     {@link ChunkDriver} - the acceptance signal
+     * @param fullDigest   hash of every non-air block in every chunk - a loose tripwire only
+     */
+    public record Result(long driverDigest, long fullDigest, long driverBlocks, int drivenChunks,
+                         int chunkCount, long elapsedMs) {
+
+        public String driverLine(String order, int offset) {
+            return String.format(
+                    "DRIVERDIGEST=%016x blocks=%d drivenChunks=%d chunks=%d order=%s offset=%d ms=%d",
+                    driverDigest, driverBlocks, drivenChunks, chunkCount, order, offset, elapsedMs);
+        }
+
+        public String fullLine(String order, int offset) {
+            return String.format("DIGEST=%016x chunks=%d order=%s offset=%d ms=%d",
+                    fullDigest, chunkCount, order, offset, elapsedMs);
+        }
+    }
+
+    /**
+     * The chunk square {@code (offset±radius, offset±radius)} arranged in the requested
+     * generation order: {@code rowmajor}, {@code reverse} or {@code shuffled}.
+     *
+     * @throws IllegalArgumentException for an unknown order
+     */
+    public static List<ChunkPos> chunkSquare(int radius, String order, int offset) {
+        List<ChunkPos> chunks = new ArrayList<>();
+        for (int x = -radius; x <= radius; x++) {
+            for (int z = -radius; z <= radius; z++) {
+                chunks.add(new ChunkPos(offset + x, offset + z));
+            }
+        }
+        switch (order) {
+            case "rowmajor" -> { /* already row-major */ }
+            case "reverse" -> Collections.reverse(chunks);
+            case "shuffled" -> Collections.shuffle(chunks, new Random(0xC0FFEE));
+            default -> throw new IllegalArgumentException("order must be one of: rowmajor, reverse, shuffled");
+        }
+        return chunks;
+    }
+
+    /** Generates the square to FULL status in the given order and digests the result. */
+    public static Result run(ServerLevel level, int radius, String order, int offset) {
+        List<ChunkPos> chunks = chunkSquare(radius, order, offset);
+
+        long start = System.currentTimeMillis();
+        int recordedChunks;
+        ChunkDriver.startRecordingWrites();
+        try {
+            for (ChunkPos pos : chunks) {
+                level.getChunk(pos.x(), pos.z(), ChunkStatus.FULL, true);
+            }
+        } finally {
+            ChunkDriver.stopRecordingWrites();
+            recordedChunks = ChunkDriver.recordedChunkCount();
+        }
+
+        // Hash in a canonical order so only generation order can affect the result.
+        List<ChunkPos> sorted = new ArrayList<>(chunks);
+        sorted.sort(Comparator.comparingInt(ChunkPos::x).thenComparingInt(ChunkPos::z));
+
+        boolean detail = System.getProperty("urbex.digestCheck.detail") != null;
+        long digest = FNV_OFFSET;
+        long driverDigest = FNV_OFFSET;
+        long driverBlocks = 0;
+        for (ChunkPos pos : sorted) {
+            digest = hashChunk(level, pos, digest);
+            long[] written = ChunkDriver.recordedWrites(pos);
+            driverBlocks += written.length;
+            driverDigest = hashDriverWrites(level, written, driverDigest);
+            if (detail) {
+                // Independent per-chunk digest, for diffing two runs to localize a mismatch
+                long chunkDigest = hashDriverWrites(level, written, FNV_OFFSET);
+                System.out.printf("CHUNKDIGEST %d %d %016x blocks=%d%n",
+                        pos.x(), pos.z(), chunkDigest, written.length);
+            }
+        }
+        ChunkDriver.clearRecordedWrites();
+
+        long elapsed = System.currentTimeMillis() - start;
+        return new Result(driverDigest, digest, driverBlocks, recordedChunks, chunks.size(), elapsed);
+    }
+
+    /**
+     * Hash the final state at each position this mod wrote.
+     * <p>
+     * The states are read here, once, after every chunk has finished generating - not folded in as
+     * the writes happened. A position overwritten three times therefore contributes its last state
+     * exactly once, and two runs that reach the same blocks by different internal paths agree.
+     */
+    private static long hashDriverWrites(ServerLevel level, long[] written, long digest) {
+        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
+        for (long packed : written) {
+            mutable.set(BlockPos.getX(packed), BlockPos.getY(packed), BlockPos.getZ(packed));
+            digest = hashLong(digest, packed);
+            digest = hashString(digest, level.getBlockState(mutable).toString());
+            BlockEntity be = level.getBlockEntity(mutable);
+            if (be != null) {
+                digest = hashString(digest, be.saveWithFullMetadata(level.registryAccess()).toString());
+            }
+        }
+        return digest;
+    }
+
+    private static long hashChunk(ServerLevel level, ChunkPos pos, long digest) {
+        ChunkAccess chunk = level.getChunk(pos.x(), pos.z(), ChunkStatus.FULL, true);
+        int minY = chunk.getMinY();
+        int maxY = chunk.getMaxY();
+        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                for (int y = minY; y <= maxY; y++) {
+                    mutable.set(pos.getMinBlockX() + x, y, pos.getMinBlockZ() + z);
+                    BlockState state = chunk.getBlockState(mutable);
+                    if (state.isAir()) {
+                        continue;
+                    }
+                    digest = hashLong(digest, mutable.asLong());
+                    digest = hashString(digest, state.toString());
+                    // Look the block entity up through the level rather than the raw ChunkAccess:
+                    // ChunkAccess no longer exposes a bare getBlockEntity(BlockPos) on 26.2 (only
+                    // LevelChunk does), and the level lookup is the stable public way to reach it
+                    // for a chunk we just forced to FULL status.
+                    BlockEntity be = level.getBlockEntity(mutable);
+                    if (be != null) {
+                        // saveWithId(ValueOutput) returns void on 26.2 (the old CompoundTag-returning
+                        // overload is gone). saveWithFullMetadata(HolderLookup.Provider) is the
+                        // vanilla replacement that still hands back a CompoundTag directly - it's the
+                        // exact method LevelChunk/ProtoChunk use to persist block entities to disk,
+                        // so its NBT representation is guaranteed stable across JVM restarts.
+                        digest = hashString(digest,
+                                be.saveWithFullMetadata(level.registryAccess()).toString());
+                    }
+                }
+            }
+        }
+        return digest;
+    }
+
+    private static long hashLong(long digest, long value) {
+        for (int i = 0; i < 8; i++) {
+            digest = (digest ^ ((value >>> (i * 8)) & 0xFF)) * FNV_PRIME;
+        }
+        return digest;
+    }
+
+    private static long hashString(long digest, String value) {
+        for (int i = 0; i < value.length(); i++) {
+            digest = (digest ^ value.charAt(i)) * FNV_PRIME;
+        }
+        return digest;
+    }
+}

--- a/src/test/java/dev/krona/urbex/setup/DigestCheckSpecTest.java
+++ b/src/test/java/dev/krona/urbex/setup/DigestCheckSpecTest.java
@@ -1,0 +1,41 @@
+package dev.krona.urbex.setup;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DigestCheckSpecTest {
+
+    @Test
+    public void parsesRadiusOrderOffset() {
+        DigestCheck.Spec spec = DigestCheck.Spec.parse("3,rowmajor,100");
+        assertEquals(3, spec.radius());
+        assertEquals("rowmajor", spec.order());
+        assertEquals(100, spec.offset());
+    }
+
+    @Test
+    public void parsesNegativeOffsetAndOtherOrders() {
+        DigestCheck.Spec spec = DigestCheck.Spec.parse("5,shuffled,-40");
+        assertEquals(5, spec.radius());
+        assertEquals("shuffled", spec.order());
+        assertEquals(-40, spec.offset());
+    }
+
+    @Test
+    public void rejectsUnknownOrder() {
+        assertThrows(IllegalArgumentException.class, () -> DigestCheck.Spec.parse("3,spiral,0"));
+    }
+
+    @Test
+    public void rejectsWrongArity() {
+        assertThrows(IllegalArgumentException.class, () -> DigestCheck.Spec.parse("3,rowmajor"));
+        assertThrows(IllegalArgumentException.class, () -> DigestCheck.Spec.parse(""));
+    }
+
+    @Test
+    public void rejectsNonPositiveRadius() {
+        assertThrows(IllegalArgumentException.class, () -> DigestCheck.Spec.parse("0,rowmajor,0"));
+    }
+}


### PR DESCRIPTION
Implements the fixed-seed worldgen regression check from #78 — and in doing so produced hard evidence for #24.

## What it is
- `DigestRunner` — the `/urbex digest` machinery extracted so it can run without a command source; the command now delegates to it.
- `DigestCheck` — with `-Durbex.digestCheck=radius,order,offset`, the dedicated server generates that chunk square right after startup, prints `DRIVERDIGEST`, compares against `-Durbex.digestCheck.expected`, emits a single greppable `URBEX-DIGEST-CHECK: OK/FAIL` verdict, and shuts down. No-op without the property.
- `runDigestCheck` Gradle task — boots it on a fully pinned, fresh environment every run: seed 1337, default (noise) world type, `selectedProfile = "default"`, watchdog off. The expected value comes from the committed `digest.golden`.
- CI runs it after `build` and greps for the OK verdict.

Why not a framework gametest: the vanilla GameTest server runs a **flat world in which the urbex feature never fires** — a real dedicated server on a pinned seed is the only harness that exercises the actual generation path end to end.

## What it caught immediately
With normal parallel chunk generation, **identical fresh runs produce different digests** — three runs, three values. The per-chunk diff mode (`-Durbex.digestCheck.detail`) shows two failure shapes: chunks writing *different block sets* (e.g. 16,436 vs 17,574 blocks in the same chunk) and chunks writing the same positions with *different states*. With `-XX:ActiveProcessorCount=1` (single worker thread), two fresh runs are byte-identical.

That confirms the races tracked in #24 (shared mutable `ChunkHeightmap` the prime suspect — differing block sets point at height-dependent decisions shifting). The pin therefore runs single-threaded; **lifting that flag — two parallel runs agreeing — is the acceptance test for fixing #24**. Evidence posted on that issue.

## Verification
- OK path: pinned `efd7fca468efe0a2` reproduces across fresh runs (verified twice locally, plus once more after rebasing on main).
- FAIL path: a tampered golden yields `URBEX-DIGEST-CHECK: FAIL (expected …, got …)` — the check can actually fail.
- `DigestCheckSpecTest` (5 tests, written first) covers the property parsing.
- 771,313 driver-written blocks across 81 driven chunks per run — the check is exercising real city generation, and a zero-write run is an explicit failure (guards against a silently unconfigured profile).

Note: the golden was pinned on macOS; the first CI run on Linux validates cross-platform stability. If Linux reproducibly disagrees, the golden should be re-pinned from CI output (and that would itself be worth understanding).

Regenerating the golden after intentional world-changing PRs: delete `digest.golden`, run `./gradlew runDigestCheck` twice (values must match), commit the new value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)