### PR TITLE
fix: restore the Urbex profile through the vanilla Re-Create world flow

### DIFF
--- a/src/main/java/dev/krona/urbex/gui/LostCitySetup.java
+++ b/src/main/java/dev/krona/urbex/gui/LostCitySetup.java
@@ -85,6 +85,30 @@ public class LostCitySetup {
         this.customizedProfile = other.customizedProfile;
     }
 
+    /**
+     * Restores a profile selection read from an existing world's saved data, for the vanilla
+     * Re-Create flow (issue #85). Mirrors what {@link GuiLCConfig#selectProfile} publishes so
+     * the restored choice reaches the server even if the Cities screen is never opened.
+     */
+    public void restoreFromSavedData(String profileName, String json) {
+        if (profileName == null || profileName.isEmpty()) {
+            return;
+        }
+        if (json != null && !json.isEmpty()) {
+            customizedProfile = new LostCityProfile("customized", false);
+            customizedProfile.copyFrom(new LostCityProfile("customized", json));
+            ProfileSetup.STANDARD_PROFILES.put("customized", customizedProfile);
+            profile = "customized";
+            GuiLCConfig.selectProfile("customized", customizedProfile);
+        } else if (ProfileSetup.STANDARD_PROFILES.containsKey(profileName)) {
+            profile = profileName;
+            GuiLCConfig.selectProfile(profileName, null);
+        } else {
+            Urbex.getLogger().warn("Re-created world used unknown Urbex profile '{}'; ignoring", profileName);
+        }
+        refreshPreview.run();
+    }
+
     public void customize() {
         if (profile == null) {
             throw new IllegalStateException("Cannot happen!");

--- a/src/main/java/dev/krona/urbex/gui/RecreateProfileRestore.java
+++ b/src/main/java/dev/krona/urbex/gui/RecreateProfileRestore.java
@@ -1,0 +1,73 @@
+package dev.krona.urbex.gui;
+
+import dev.krona.urbex.Urbex;
+import net.minecraft.client.Minecraft;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Carries the Urbex profile of a world across the vanilla Re-Create flow (issue #85).
+ * <p>
+ * Vanilla rebuilds the CreateWorldScreen from the source world's level.dat, but the profile
+ * choice lives in Urbex's own saved data ({@code data/urbex/data.dat}), which vanilla never
+ * consults - so a re-created world silently lost its cities. {@code WorldListEntryMixin} calls
+ * {@link #capture} with the source world's folder when Re-Create is clicked; the next
+ * CreateWorldScreen consumes the pending restore via {@link #consumePending}.
+ */
+public final class RecreateProfileRestore {
+
+    /** The profile selection read from a source world: the profile name and, when it was a
+     * hand-customized profile, its JSON. */
+    public record Pending(String profile, String json) {
+    }
+
+    private static Pending pending = null;
+
+    private RecreateProfileRestore() {
+    }
+
+    /** Reads the Urbex saved data of the world in {@code levelId} and stashes its profile. */
+    public static void capture(String levelId) {
+        pending = null;
+        try {
+            Path worldDir = Minecraft.getInstance().getLevelSource().getLevelPath(levelId);
+            Path dataFile = worldDir.resolve("data").resolve("urbex").resolve("data.dat");
+            if (!Files.exists(dataFile)) {
+                // Pre-namespaced layout, in case the world was created before the id change
+                dataFile = worldDir.resolve("data").resolve("urbex_data.dat");
+            }
+            if (!Files.exists(dataFile)) {
+                return;
+            }
+            CompoundTag root = NbtIo.readCompressed(dataFile, NbtAccounter.unlimitedHeap());
+            pending = parse(root).orElse(null);
+        } catch (Exception e) {
+            Urbex.getLogger().warn("Could not read the Urbex profile of world '{}' for re-creation", levelId, e);
+        }
+    }
+
+    /** Extracts the profile selection from a saved-data NBT root. Empty if none was stored. */
+    public static Optional<Pending> parse(CompoundTag root) {
+        CompoundTag data = root.getCompoundOrEmpty("data");
+        String profile = data.getStringOr("profile", "");
+        if (profile.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new Pending(profile, data.getStringOr("json", "")));
+    }
+
+    /** Applies and clears the stashed profile; called when a fresh CreateWorldScreen opens. */
+    public static void consumePending() {
+        Pending p = pending;
+        pending = null;
+        if (p != null) {
+            LostCitySetup.CLIENT_SETUP.restoreFromSavedData(p.profile(), p.json());
+            Urbex.getLogger().info("Restored Urbex profile '{}' for world re-creation", p.profile());
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/mixin/WorldListEntryMixin.java
+++ b/src/main/java/dev/krona/urbex/mixin/WorldListEntryMixin.java
@@ -1,0 +1,23 @@
+package dev.krona.urbex.mixin;
+
+import dev.krona.urbex.gui.RecreateProfileRestore;
+import net.minecraft.client.gui.screens.worldselection.WorldSelectionList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Captures which world is being re-created so the Urbex profile stored in that world's saved
+ * data can be restored into the new CreateWorldScreen (issue #85). Vanilla only restores what
+ * level.dat holds, and the profile is not in it.
+ */
+@Mixin(WorldSelectionList.WorldListEntry.class)
+public class WorldListEntryMixin {
+
+    @Inject(method = "recreateWorld", at = @At("HEAD"))
+    private void urbex$captureRecreateSource(CallbackInfo ci) {
+        WorldSelectionList.WorldListEntry self = (WorldSelectionList.WorldListEntry) (Object) this;
+        RecreateProfileRestore.capture(self.getLevelSummary().getLevelId());
+    }
+}

--- a/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
+++ b/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.setup;
 
 import dev.krona.urbex.gui.GuiLCConfig;
 import dev.krona.urbex.gui.LostCitySetup;
+import dev.krona.urbex.gui.RecreateProfileRestore;
 import dev.krona.urbex.varia.ComponentFactory;
 import dev.krona.urbex.worldgen.LostCityFeature;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
@@ -13,12 +14,20 @@ import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
 
 public class ClientEventHandlers {
 
+    private static java.lang.ref.WeakReference<CreateWorldScreen> lastCreateWorldScreen = null;
+
     public static void register() {
         // Inject the "Cities" button into the world creation screen.
         // (The decorative config icon that was blitted in ScreenEvent.Render.Post on NeoForge
         // has been dropped; Fabric's screen API in 26.2 has no direct post-render hook.)
         ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
             if (screen instanceof CreateWorldScreen createWorldScreen) {
+                // A genuinely new screen, not a rebuild of the same one after a window resize:
+                // consume a profile stashed by the Re-Create flow (issue #85)
+                if (lastCreateWorldScreen == null || lastCreateWorldScreen.get() != createWorldScreen) {
+                    lastCreateWorldScreen = new java.lang.ref.WeakReference<>(createWorldScreen);
+                    RecreateProfileRestore.consumePending();
+                }
                 Button lostCitiesButton = Button.builder(ComponentFactory.literal("Cities"), b ->
                         Minecraft.getInstance().gui.setScreen(new GuiLCConfig(createWorldScreen))
                 ).bounds(screen.width - 100, 40, 70, 20).build();

--- a/src/main/resources/urbex.mixins.json
+++ b/src/main/resources/urbex.mixins.json
@@ -7,7 +7,9 @@
     "MinecraftServerMixin",
     "StructureStartMixin"
   ],
-  "client": [],
+  "client": [
+    "WorldListEntryMixin"
+  ],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/test/java/dev/krona/urbex/gui/RecreateProfileRestoreTest.java
+++ b/src/test/java/dev/krona/urbex/gui/RecreateProfileRestoreTest.java
@@ -1,0 +1,50 @@
+package dev.krona.urbex.gui;
+
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RecreateProfileRestoreTest {
+
+    private static CompoundTag payload(String profile, String json) {
+        CompoundTag data = new CompoundTag();
+        data.putString("profile", profile);
+        data.putString("json", json);
+        return data;
+    }
+
+    @Test
+    public void parsesModernSavedDataWrapper() {
+        // SavedData files wrap the codec payload in a "data" compound
+        CompoundTag root = new CompoundTag();
+        root.put("data", payload("rare", ""));
+        Optional<RecreateProfileRestore.Pending> pending = RecreateProfileRestore.parse(root);
+        assertEquals("rare", pending.orElseThrow().profile());
+        assertEquals("", pending.orElseThrow().json());
+    }
+
+    @Test
+    public void parsesCustomizedProfileWithJson() {
+        CompoundTag root = new CompoundTag();
+        root.put("data", payload("customized", "{\"citychance\":0.9}"));
+        Optional<RecreateProfileRestore.Pending> pending = RecreateProfileRestore.parse(root);
+        assertEquals("customized", pending.orElseThrow().profile());
+        assertEquals("{\"citychance\":0.9}", pending.orElseThrow().json());
+    }
+
+    @Test
+    public void emptyProfileMeansNothingToRestore() {
+        CompoundTag root = new CompoundTag();
+        root.put("data", payload("", ""));
+        assertTrue(RecreateProfileRestore.parse(root).isEmpty());
+    }
+
+    @Test
+    public void missingDataCompoundMeansNothingToRestore() {
+        assertTrue(RecreateProfileRestore.parse(new CompoundTag()).isEmpty());
+    }
+}


### PR DESCRIPTION
Closes #85.

## How it works
- `WorldListEntryMixin` (client) hooks `recreateWorld()` and captures the source world's folder name.
- `RecreateProfileRestore.capture` reads the world's `data/urbex/data.dat` (falling back to the pre-namespaced `data/urbex_data.dat`), and `parse` extracts the profile name + customized JSON from the SavedData wrapper.
- When the next **genuinely new** `CreateWorldScreen` opens (a WeakReference identity check ignores same-screen rebuilds from window resizes), the pending selection is consumed: `LostCitySetup.CLIENT_SETUP` gets the profile — including reconstructing a hand-customized profile from its JSON — and the same statics `GuiLCConfig.selectProfile` publishes are set, so the restored choice reaches the server **even if the Cities screen is never opened** before clicking Create.

## Failure behaviour
Missing file, unreadable NBT, or an unknown profile name all degrade to today's behaviour (blank setup) with a warn log — never a crash in the Re-Create flow.

## Testing
- `RecreateProfileRestoreTest` (4 tests, written first): modern SavedData wrapper, customized-with-JSON, empty-profile, and missing-data cases.
- Full build + suite green; the digest check is untouched (client-only change).
- Worth one manual pass on your side since this is your repro: create world with a profile → Re-Create → the Cities screen should show the profile (and a customized profile should carry its values).

## Note
This is the near-term fix from the issue's "possible directions". The long-term direction — profile in `WorldGenSettings` so Re-Create and Import Settings work for free — folds into #6/#75 as the issue says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)