### PR TITLE
refactor: replace Forge Config API Port with a codec-backed config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,11 +90,7 @@ motd=urbex digest check
 '''
         def cfgDir = new File(dir, 'world/serverconfig')
         cfgDir.mkdirs()
-        new File(cfgDir, 'urbex-server.toml').text = '''\
-[profiles]
-\tselectedProfile = "default"
-\tselectedCustomJson = ""
-'''
+        new File(cfgDir, 'urbex.json').text = '{ "selectedProfile": "default" }\n'
     }
 }
 
@@ -107,7 +103,6 @@ dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     implementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
-    implementation "fuzs.forgeconfigapiport:forgeconfigapiport-fabric:${forge_config_api_port_version}"
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ minecraft_version=26.2
 fabric_loader_version=0.19.3
 fabric_version=0.155.2+26.2
 loom_version=1.17.17
-forge_config_api_port_version=26.2.1
 
 java_version=25
 

--- a/src/main/java/dev/krona/urbex/Urbex.java
+++ b/src/main/java/dev/krona/urbex/Urbex.java
@@ -1,6 +1,5 @@
 package dev.krona.urbex;
 
-import fuzs.forgeconfigapiport.fabric.api.v5.ConfigRegistry;
 import dev.krona.urbex.network.PacketRequestProfile;
 import dev.krona.urbex.network.PacketReturnProfileToClient;
 import dev.krona.urbex.setup.*;
@@ -18,7 +17,6 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.BiomeTags;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
-import net.neoforged.fml.config.ModConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,10 +42,7 @@ public class Urbex implements ModInitializer {
         File dir = new File(configPath + File.separator + "urbex");
         dir.mkdirs();
 
-        // Forge Config API Port keeps the NeoForge ModConfigSpec API intact on Fabric
-        ConfigRegistry.INSTANCE.register(MODID, ModConfig.Type.CLIENT, Config.CLIENT_CONFIG, "urbex/client.toml");
-        ConfigRegistry.INSTANCE.register(MODID, ModConfig.Type.COMMON, Config.COMMON_CONFIG, "urbex/common.toml");
-        ConfigRegistry.INSTANCE.register(MODID, ModConfig.Type.SERVER, Config.SERVER_CONFIG);
+        Config.loadGlobal(configPath);
 
         setup.preInit();
         setup.init();

--- a/src/main/java/dev/krona/urbex/config/LegacyToml.java
+++ b/src/main/java/dev/krona/urbex/config/LegacyToml.java
@@ -1,0 +1,80 @@
+package dev.krona.urbex.config;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import java.util.List;
+
+/**
+ * A minimal reader for the TOML files Forge Config API Port used to write
+ * ({@code config/urbex/common.toml}, {@code <world>/serverconfig/urbex-server.toml}), so
+ * existing installations migrate to the JSON config without losing their settings. Understands
+ * exactly what those files contain: flat {@code key = value} pairs with quoted strings,
+ * booleans, integers, and string arrays (single- or multi-line). Everything else is ignored.
+ */
+public final class LegacyToml {
+
+    private LegacyToml() {
+    }
+
+    public static JsonObject toJson(List<String> lines) {
+        JsonObject json = new JsonObject();
+        JsonArray pendingArray = null;
+        String pendingKey = null;
+        for (String raw : lines) {
+            String line = raw.trim();
+            if (pendingArray != null) {
+                boolean closes = line.endsWith("]");
+                String inner = closes ? line.substring(0, line.length() - 1) : line;
+                addArrayElements(pendingArray, inner);
+                if (closes) {
+                    json.add(pendingKey, pendingArray);
+                    pendingArray = null;
+                    pendingKey = null;
+                }
+                continue;
+            }
+            if (line.isEmpty() || line.startsWith("#") || line.startsWith("[")) {
+                continue;
+            }
+            int eq = line.indexOf('=');
+            if (eq < 0) {
+                continue;
+            }
+            String key = line.substring(0, eq).trim();
+            String value = line.substring(eq + 1).trim();
+            if (value.startsWith("[")) {
+                JsonArray array = new JsonArray();
+                if (value.endsWith("]")) {
+                    addArrayElements(array, value.substring(1, value.length() - 1));
+                    json.add(key, array);
+                } else {
+                    pendingArray = array;
+                    pendingKey = key;
+                    addArrayElements(array, value.substring(1));
+                }
+            } else if (value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2) {
+                json.add(key, new JsonPrimitive(value.substring(1, value.length() - 1)));
+            } else if ("true".equals(value) || "false".equals(value)) {
+                json.add(key, new JsonPrimitive(Boolean.parseBoolean(value)));
+            } else {
+                try {
+                    json.add(key, new JsonPrimitive(Long.parseLong(value)));
+                } catch (NumberFormatException ignored) {
+                    // Not a type the old files contained; skip rather than guess
+                }
+            }
+        }
+        return json;
+    }
+
+    private static void addArrayElements(JsonArray array, String inner) {
+        for (String part : inner.split(",")) {
+            String element = part.trim();
+            if (element.startsWith("\"") && element.endsWith("\"") && element.length() >= 2) {
+                array.add(element.substring(1, element.length() - 1));
+            }
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/config/UrbexConfig.java
+++ b/src/main/java/dev/krona/urbex/config/UrbexConfig.java
@@ -1,0 +1,92 @@
+package dev.krona.urbex.config;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The mod's own configuration, as a plain codec-backed record. Replaces the NeoForge
+ * {@code ModConfigSpec} that came in through Forge Config API Port - the last NeoForge artifact
+ * in a Fabric-only mod (issue #75).
+ * <p>
+ * One flat schema serves two files: the global {@code config/urbex/urbex.json} and an optional
+ * per-world {@code <world>/serverconfig/urbex.json} whose keys override the global ones (the
+ * merge happens at the JSON level, so a world file only needs the keys it changes).
+ */
+public record UrbexConfig(
+        List<String> dimensionsWithProfiles,
+        int heightSampleSize,
+        String specialBedBlock,
+        String selectedProfile,
+        String selectedCustomJson,
+        int todoQueueSize,
+        boolean forceSaplingGrowth,
+        int cacheCleanupSeconds,
+        List<String> avoidStructures,
+        boolean avoidStructuresAdjacent,
+        boolean avoidSurfaceStructures,
+        boolean structuresYieldToCities,
+        boolean avoidVillages,
+        boolean avoidVillagesAdjacent,
+        boolean avoidFlattening) {
+
+    public static final UrbexConfig DEFAULT = new UrbexConfig(
+            List.of("urbex:city=biosphere"),
+            3,
+            "minecraft:diamond_block",
+            "",
+            "",
+            20,
+            true,
+            300,
+            List.of("minecraft:mansion", "minecraft:jungle_pyramid", "minecraft:desert_pyramid",
+                    "minecraft:igloo", "minecraft:swamp_huts", "minecraft:pillager_outpost"),
+            false,
+            false,
+            false,
+            true,
+            false,
+            true);
+
+    public static final Codec<UrbexConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Codec.STRING.listOf().optionalFieldOf("dimensionsWithProfiles", DEFAULT.dimensionsWithProfiles()).forGetter(UrbexConfig::dimensionsWithProfiles),
+            Codec.intRange(1, 100).optionalFieldOf("heightSampleSize", DEFAULT.heightSampleSize()).forGetter(UrbexConfig::heightSampleSize),
+            Codec.STRING.optionalFieldOf("specialBedBlock", DEFAULT.specialBedBlock()).forGetter(UrbexConfig::specialBedBlock),
+            Codec.STRING.optionalFieldOf("selectedProfile", DEFAULT.selectedProfile()).forGetter(UrbexConfig::selectedProfile),
+            Codec.STRING.optionalFieldOf("selectedCustomJson", DEFAULT.selectedCustomJson()).forGetter(UrbexConfig::selectedCustomJson),
+            Codec.intRange(1, 100000).optionalFieldOf("todoQueueSize", DEFAULT.todoQueueSize()).forGetter(UrbexConfig::todoQueueSize),
+            Codec.BOOL.optionalFieldOf("forceSaplingGrowth", DEFAULT.forceSaplingGrowth()).forGetter(UrbexConfig::forceSaplingGrowth),
+            Codec.intRange(1, 86400).optionalFieldOf("cacheCleanupSeconds", DEFAULT.cacheCleanupSeconds()).forGetter(UrbexConfig::cacheCleanupSeconds),
+            Codec.STRING.listOf().optionalFieldOf("avoidStructures", DEFAULT.avoidStructures()).forGetter(UrbexConfig::avoidStructures),
+            Codec.BOOL.optionalFieldOf("avoidStructuresAdjacent", DEFAULT.avoidStructuresAdjacent()).forGetter(UrbexConfig::avoidStructuresAdjacent),
+            Codec.BOOL.optionalFieldOf("avoidSurfaceStructures", DEFAULT.avoidSurfaceStructures()).forGetter(UrbexConfig::avoidSurfaceStructures),
+            Codec.BOOL.optionalFieldOf("structuresYieldToCities", DEFAULT.structuresYieldToCities()).forGetter(UrbexConfig::structuresYieldToCities),
+            Codec.BOOL.optionalFieldOf("avoidVillages", DEFAULT.avoidVillages()).forGetter(UrbexConfig::avoidVillages),
+            Codec.BOOL.optionalFieldOf("avoidVillagesAdjacent", DEFAULT.avoidVillagesAdjacent()).forGetter(UrbexConfig::avoidVillagesAdjacent),
+            Codec.BOOL.optionalFieldOf("avoidFlattening", DEFAULT.avoidFlattening()).forGetter(UrbexConfig::avoidFlattening)
+    ).apply(instance, UrbexConfig::new));
+
+    /** Parses a config from JSON; empty if any present key fails validation. */
+    public static Optional<UrbexConfig> fromJson(JsonObject json) {
+        return CODEC.parse(JsonOps.INSTANCE, json).result();
+    }
+
+    public static JsonObject toJson(UrbexConfig config) {
+        return CODEC.encodeStart(JsonOps.INSTANCE, config).getOrThrow().getAsJsonObject();
+    }
+
+    /** Shallow key-level merge: every key the overlay carries replaces the base's. */
+    public static JsonObject merge(JsonObject base, JsonObject overlay) {
+        JsonObject merged = base.deepCopy();
+        for (Map.Entry<String, JsonElement> entry : overlay.entrySet()) {
+            merged.add(entry.getKey(), entry.getValue().deepCopy());
+        }
+        return merged;
+    }
+}

--- a/src/main/java/dev/krona/urbex/setup/Config.java
+++ b/src/main/java/dev/krona/urbex/setup/Config.java
@@ -1,89 +1,182 @@
 package dev.krona.urbex.setup;
 
-import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import dev.krona.urbex.Urbex;
+import dev.krona.urbex.config.UrbexConfig;
 import dev.krona.urbex.config.UrbexProfile;
 import dev.krona.urbex.config.ProfileSetup;
 import dev.krona.urbex.data.UrbexData;
-import dev.krona.urbex.worldgen.lost.regassets.data.Selectors;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
-import net.neoforged.neoforge.common.ModConfigSpec;
+import net.minecraft.world.level.storage.LevelResource;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
+/**
+ * Configuration access. Values come from the codec-backed {@link UrbexConfig}: the global
+ * {@code config/urbex/urbex.json}, optionally overridden per world by
+ * {@code <world>/serverconfig/urbex.json}. Legacy Forge Config API Port TOML files are read
+ * once and migrated (issue #75).
+ * <p>
+ * The public surface is kept supplier-shaped ({@code Config.X.get()}) so the many call sites
+ * did not have to change when the ModConfigSpec backing was removed.
+ */
 public class Config {
 
-    public static final String CATEGORY_PROFILES = "profiles";
-    public static final String CATEGORY_GENERAL = "general";
     public static final boolean DEBUG = false;
 
-    public static ModConfigSpec.ConfigValue<String> SPECIAL_BED_BLOCK;// = "minecraft:diamond_block";
+    /** The currently active config: global, with the running world's overrides applied. */
+    private static volatile UrbexConfig active = UrbexConfig.DEFAULT;
+    /** The global config alone, restored when a world's overrides are dropped. */
+    private static volatile UrbexConfig global = UrbexConfig.DEFAULT;
 
-    private static final String[] DEFAULT_DIMENSION_PROFILES = new String[] {
-            "urbex:city=biosphere",
-            "lostworlds:abyss=biosphere_caves",
-    };
-    private static final ModConfigSpec.ConfigValue<List<? extends String>> DIMENSION_PROFILES;
+    public static final Supplier<String> SPECIAL_BED_BLOCK = () -> active.specialBedBlock();
+    public static final Supplier<String> SELECTED_PROFILE = () -> active.selectedProfile();
+    public static final Supplier<String> SELECTED_CUSTOM_JSON = () -> active.selectedCustomJson();
+    public static final Supplier<Integer> TODO_QUEUE_SIZE = () -> active.todoQueueSize();
+    public static final Supplier<Boolean> FORCE_SAPLING_GROWTH = () -> active.forceSaplingGrowth();
+    public static final Supplier<Integer> CACHE_CLEANUP_SECONDS = () -> active.cacheCleanupSeconds();
+    public static final Supplier<Integer> HEIGHT_SAMPLE_SIZE = () -> active.heightSampleSize();
+    public static final Supplier<Boolean> AVOID_STRUCTURES_ADJACENT = () -> active.avoidStructuresAdjacent();
+    public static final Supplier<Boolean> AVOID_SURFACE_STRUCTURES = () -> active.avoidSurfaceStructures();
+    public static final Supplier<Boolean> STRUCTURES_YIELD_TO_CITIES = () -> active.structuresYieldToCities();
+    public static final Supplier<Boolean> AVOID_VILLAGES = () -> active.avoidVillages();
+    public static final Supplier<Boolean> AVOID_VILLAGES_ADJACENT = () -> active.avoidVillagesAdjacent();
+    public static final Supplier<Boolean> AVOID_FLATTENING = () -> active.avoidFlattening();
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+    /**
+     * Loads the global config from {@code config/urbex/urbex.json}, migrating the legacy
+     * {@code common.toml} on first run. Called once from mod init.
+     */
+    public static void loadGlobal(Path configDir) {
+        Path dir = configDir.resolve("urbex");
+        Path file = dir.resolve("urbex.json");
+        JsonObject json = null;
+        if (Files.exists(file)) {
+            json = readJson(file);
+        } else {
+            Path legacy = dir.resolve("common.toml");
+            if (Files.exists(legacy)) {
+                json = readLegacyToml(legacy);
+                Urbex.getLogger().info("Migrating legacy config {} to {}", legacy, file);
+            }
+        }
+        if (json != null) {
+            Optional<UrbexConfig> parsed = UrbexConfig.fromJson(json);
+            if (parsed.isPresent()) {
+                global = parsed.get();
+            } else {
+                Urbex.getLogger().error("Invalid config in {} - using defaults. Fix or delete the file.", file);
+            }
+        }
+        active = global;
+        // Write back the full, normalized file so every available option is visible
+        try {
+            Files.createDirectories(dir);
+            Files.writeString(file, GSON.toJson(UrbexConfig.toJson(global)));
+        } catch (IOException e) {
+            Urbex.getLogger().error("Could not write {}", file, e);
+        }
+    }
+
+    /**
+     * Applies {@code <world>/serverconfig/urbex.json} (or the legacy
+     * {@code urbex-server.toml}) over the global config. Called at SERVER_STARTING, before any
+     * worldgen; the merge is per-key, so a world file only carries what it changes.
+     */
+    public static void applyWorldOverrides(MinecraftServer server) {
+        UrbexConfig result = global;
+        Path dir = server.getWorldPath(LevelResource.ROOT).resolve("serverconfig");
+        Path file = dir.resolve("urbex.json");
+        JsonObject overrides = null;
+        if (Files.exists(file)) {
+            overrides = readJson(file);
+        } else {
+            Path legacy = dir.resolve("urbex-server.toml");
+            if (Files.exists(legacy)) {
+                overrides = readLegacyToml(legacy);
+                Urbex.getLogger().info("Migrating legacy world config {} to {}", legacy, file);
+                try {
+                    Files.createDirectories(dir);
+                    Files.writeString(file, GSON.toJson(overrides));
+                } catch (IOException e) {
+                    Urbex.getLogger().error("Could not write {}", file, e);
+                }
+            }
+        }
+        if (overrides != null && !overrides.isEmpty()) {
+            JsonObject merged = UrbexConfig.merge(UrbexConfig.toJson(global), overrides);
+            Optional<UrbexConfig> parsed = UrbexConfig.fromJson(merged);
+            if (parsed.isPresent()) {
+                result = parsed.get();
+                Urbex.getLogger().info("Applied {} world config override(s) from {}", overrides.size(), file);
+            } else {
+                Urbex.getLogger().error("Invalid world config in {} - ignoring it.", file);
+            }
+        }
+        active = result;
+        AVOID_STRUCTURES_SET = null;
+        resetProfileCache();
+    }
+
+    private static JsonObject readJson(Path file) {
+        try (Reader reader = Files.newBufferedReader(file)) {
+            return JsonParser.parseReader(reader).getAsJsonObject();
+        } catch (Exception e) {
+            Urbex.getLogger().error("Could not read {}", file, e);
+            return null;
+        }
+    }
+
+    private static JsonObject readLegacyToml(Path file) {
+        try {
+            return dev.krona.urbex.config.LegacyToml.toJson(Files.readAllLines(file));
+        } catch (IOException e) {
+            Urbex.getLogger().error("Could not read {}", file, e);
+            return null;
+        }
+    }
+
     /**
      * Dimension -> profile name, built once and then published whole.
      * <p>
-     * Reached from worker threads: {@code CityFeature.place} and {@code StructureSuppressor}
-     * both call {@link #getProfileForDimension} during generation, and since the per-dimension
-     * generation lock was removed nothing serialises them. It is {@code volatile} so a reader
-     * either sees {@code null} or sees a map that is already complete, and a
+     * Reached from worker threads: {@code CityFeature} and {@code StructureSuppressor} both call
+     * {@link #getProfileForDimension} during generation, and nothing serialises them. It is
+     * {@code volatile} so a reader either sees {@code null} or a complete map, and a
      * {@code ConcurrentHashMap} because {@link #registerUrbexDimension} can still add to it
-     * after publication.
-     * <p>
-     * The build happens in {@link #buildProfileCache} into a local map, and the field is assigned
-     * last. Two threads racing here therefore build two identical maps from the same config and
-     * the same saved data and the loser's is simply dropped - where the old plain {@code HashMap}
-     * let both threads interleave puts into two different maps while one was still being filled,
-     * and an entry lost that way means a dimension silently generates no cities at all.
-     * <p>
-     * Deliberately not {@code computeIfAbsent}: this cache is reachable from generation, and the
-     * mapping function reads config and level saved data rather than being a cheap pure function.
+     * after publication. Racing builders produce identical maps; the loser's is dropped.
      */
     private static volatile Map<ResourceKey<Level>, String> dimensionProfileCache = null;
 
     // Profile as selected by the client
     public static String profileFromClient = null;
     public static String jsonFromClient = null;
-    public static final ModConfigSpec.ConfigValue<String> SELECTED_PROFILE;
-    public static final ModConfigSpec.ConfigValue<String> SELECTED_CUSTOM_JSON;
-    public static final ModConfigSpec.IntValue TODO_QUEUE_SIZE;
-    public static final ModConfigSpec.BooleanValue FORCE_SAPLING_GROWTH;
-    public static final ModConfigSpec.IntValue CACHE_CLEANUP_SECONDS;
 
-    private static final String[] DEF_AVOID_STRUCTURES = new String[] {
-            "minecraft:mansion",
-            "minecraft:jungle_pyramid",
-            "minecraft:desert_pyramid",
-            "minecraft:igloo",
-            "minecraft:swamp_huts",
-            "minecraft:pillager_outpost"
-    };
-    private static final ModConfigSpec.ConfigValue<List<? extends String>> AVOID_STRUCTURES;
-    // Lazily filled from AVOID_STRUCTURES by cacheAvoidedStructures(). Must start out null:
+    // Lazily filled from avoidStructures by cacheAvoidedStructures(). Must start out null:
     // that method only fills the set when it is still null.
     private static Set<Identifier> AVOID_STRUCTURES_SET = null;
-    public static final ModConfigSpec.BooleanValue AVOID_STRUCTURES_ADJACENT;
-    public static final ModConfigSpec.BooleanValue AVOID_SURFACE_STRUCTURES;
-    public static final ModConfigSpec.BooleanValue STRUCTURES_YIELD_TO_CITIES;
-    public static final ModConfigSpec.BooleanValue AVOID_VILLAGES;
-    public static final ModConfigSpec.BooleanValue AVOID_VILLAGES_ADJACENT;
-    public static final ModConfigSpec.BooleanValue AVOID_FLATTENING;
-    public static final ModConfigSpec.IntValue HEIGHT_SAMPLE_SIZE;
 
     public static void reset() {
         profileFromClient = null;
         jsonFromClient = null;
         dimensionProfileCache = null;
         AVOID_STRUCTURES_SET = null;
+        active = global;
     }
 
     public static void resetProfileCache() {
@@ -115,7 +208,7 @@ public class Config {
 
     private static Map<ResourceKey<Level>, String> buildProfileCache(ServerLevel level) {
         Map<ResourceKey<Level>, String> cache = new ConcurrentHashMap<>();
-        for (String dp : DIMENSION_PROFILES.get()) {
+        for (String dp : active.dimensionsWithProfiles()) {
             String[] split = dp.split("=");
             if (split.length != 2) {
                 Urbex.getLogger().error("Bad format for config value: '{}'!", dp);
@@ -185,9 +278,7 @@ public class Config {
      * later in {@link #getProfileForDimension} during world init.
      *
      * Must run after {@link ProfileSetup#setupProfiles()} has populated {@code STANDARD_PROFILES}
-     * (which includes any user profile JSON files under config/urbex/profiles/, not just the
-     * built-in ones) - i.e. from {@code ServerLifecycleEvents.SERVER_STARTING} or later, once the
-     * server config (selectedProfile) has also been loaded.
+     * and after {@link #applyWorldOverrides} so the world's selectedProfile is in effect.
      */
     public static void validateSelectedProfiles() {
         String selected = SELECTED_PROFILE.get();
@@ -196,7 +287,7 @@ public class Config {
                     "Unknown Urbex profile '" + selected + "'. Valid profiles: "
                     + String.join(", ", new TreeSet<>(ProfileSetup.STANDARD_PROFILES.keySet())));
         }
-        for (String dp : DIMENSION_PROFILES.get()) {
+        for (String dp : active.dimensionsWithProfiles()) {
             String[] split = dp.split("=");
             if (split.length == 2) {
                 String profileName = split[1];
@@ -222,72 +313,11 @@ public class Config {
 
     private static void cacheAvoidedStructures() {
         if (AVOID_STRUCTURES_SET == null) {
-            AVOID_STRUCTURES_SET = new HashSet<>();
-            for (String s : AVOID_STRUCTURES.get()) {
-                AVOID_STRUCTURES_SET.add(Identifier.parse(s));
+            Set<Identifier> set = new HashSet<>();
+            for (String s : active.avoidStructures()) {
+                set.add(Identifier.parse(s));
             }
+            AVOID_STRUCTURES_SET = set;
         }
     }
-
-    private static final ModConfigSpec.Builder COMMON_BUILDER = new ModConfigSpec.Builder();
-    private static final ModConfigSpec.Builder CLIENT_BUILDER = new ModConfigSpec.Builder();
-    private static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
-
-    static {
-        COMMON_BUILDER.comment("General settings").push(CATEGORY_PROFILES);
-        CLIENT_BUILDER.comment("General settings").push(CATEGORY_PROFILES);
-        SERVER_BUILDER.comment("General settings").push(CATEGORY_PROFILES);
-
-        DIMENSION_PROFILES = COMMON_BUILDER
-                .comment("A list of dimensions with associated city generation profiles (format <dimensionid>=<profilename>")
-                .defineList("dimensionsWithProfiles", Lists.newArrayList(Config.DEFAULT_DIMENSION_PROFILES), s -> s instanceof String);
-
-        HEIGHT_SAMPLE_SIZE = COMMON_BUILDER
-                .comment("The size of the chunk grid used for heightmap sampling. Default is 1 which means every chunk is sampled. Higher values will sample less chunks and thus be faster but also less accurate")
-                .defineInRange("heightSampleSize", 3, 1, 100);
-
-        SPECIAL_BED_BLOCK = SERVER_BUILDER
-                .comment("Block to put underneath a bed so that it qualifies as a teleporter bed")
-                .define("specialBedBlock", "minecraft:diamond_block");
-
-        SELECTED_PROFILE = SERVER_BUILDER.define("selectedProfile", "");
-        SELECTED_CUSTOM_JSON = SERVER_BUILDER.define("selectedCustomJson", "");
-        TODO_QUEUE_SIZE = SERVER_BUILDER.comment("The size of the todo queues for the Urbex city generator").defineInRange("todoQueueSize", 20, 1, 100000);
-        FORCE_SAPLING_GROWTH = SERVER_BUILDER.comment("If this is true then saplings will grow into trees during generation. This is more expensive").define("forceSaplingGrowth", true);
-        CACHE_CLEANUP_SECONDS = SERVER_BUILDER.comment("Time in seconds after which cached chunk data is evicted").defineInRange("cacheCleanupSeconds", 300, 1, 86400);
-        AVOID_STRUCTURES = SERVER_BUILDER
-                .comment("List of structures to avoid when generating cities (for example to avoid generating a city in a woodland mansion)")
-                .defineList("avoidStructures", Lists.newArrayList(DEF_AVOID_STRUCTURES), s -> s instanceof String);
-        AVOID_STRUCTURES_ADJACENT = SERVER_BUILDER
-                .comment("If true then also avoid generating the structures mentioned in 'avoidStructures' in chunks adjacent to the chunk with the structure")
-                .define("avoidStructuresAdjacent", false);
-        AVOID_SURFACE_STRUCTURES = SERVER_BUILDER
-                .comment("If true then avoid generating cities in chunks with any structure that generates at the 'surface_structures' step, without having to list them all in 'avoidStructures'. Useful with structure mods. Underground structures (mineshafts, strongholds, ...) are not affected")
-                .define("avoidSurfaceStructures", false);
-        STRUCTURES_YIELD_TO_CITIES = SERVER_BUILDER
-                .comment("If true then structures are not placed in the chunks and at the heights a city occupies, so the city wins instead of being built over. A structure at the edge of a city keeps the part that falls outside it. Structures that pass well below the city (ancient cities, mineshafts, ...) are not affected")
-                .define("structuresYieldToCities", false);
-        AVOID_VILLAGES_ADJACENT = SERVER_BUILDER
-                .comment("If true then also avoid generating cities in chunks adjacent to the chunks with villages")
-                .define("avoidVillagesAdjacent", false);
-        AVOID_VILLAGES = SERVER_BUILDER
-                .comment("If true then avoid generating cities in chunks with villages")
-                .define("avoidVillages", true);
-        AVOID_FLATTENING = SERVER_BUILDER
-                .comment("If true then avoid flattening the terrain around the city in case there was a structure that was avoided")
-                .define("avoidFlattening", true);
-
-        SERVER_BUILDER.pop();
-        COMMON_BUILDER.pop();
-        CLIENT_BUILDER.pop();
-
-        COMMON_CONFIG = COMMON_BUILDER.build();
-        CLIENT_CONFIG = CLIENT_BUILDER.build();
-        SERVER_CONFIG = SERVER_BUILDER.build();
-    }
-
-    public static final ModConfigSpec COMMON_CONFIG;
-    public static final ModConfigSpec CLIENT_CONFIG;
-    public static final ModConfigSpec SERVER_CONFIG;
-
 }

--- a/src/main/java/dev/krona/urbex/setup/ModSetup.java
+++ b/src/main/java/dev/krona/urbex/setup/ModSetup.java
@@ -25,6 +25,10 @@ public class ModSetup {
 
         // The server config (selectedProfile) is only loaded by server start, so validation
         // has to happen here rather than in preInit - failing loudly beats NPEing during world init.
-        ServerLifecycleEvents.SERVER_STARTING.register(server -> Config.validateSelectedProfiles());
+        ServerLifecycleEvents.SERVER_STARTING.register(server -> {
+            // Overrides first: validation must see the world's own selectedProfile
+            Config.applyWorldOverrides(server);
+            Config.validateSelectedProfiles();
+        });
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,6 @@
   "depends": {
     "fabricloader": ">=${fabric_loader_version}",
     "fabric-api": "*",
-    "forgeconfigapiport": "*",
     "minecraft": "${minecraft_version}",
     "java": ">=${java_version}"
   }

--- a/src/test/java/dev/krona/urbex/config/LegacyTomlTest.java
+++ b/src/test/java/dev/krona/urbex/config/LegacyTomlTest.java
@@ -1,0 +1,55 @@
+package dev.krona.urbex.config;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** The migration reader for the old Forge Config API Port TOML files. */
+public class LegacyTomlTest {
+
+    @Test
+    public void readsScalars() {
+        JsonObject json = LegacyToml.toJson(List.of(
+                "#A comment",
+                "[profiles]",
+                "\tselectedProfile = \"biosphere\"",
+                "\ttodoQueueSize = 50",
+                "\tforceSaplingGrowth = false"
+        ));
+        assertEquals("biosphere", json.get("selectedProfile").getAsString());
+        assertEquals(50, json.get("todoQueueSize").getAsInt());
+        assertFalse(json.get("forceSaplingGrowth").getAsBoolean());
+    }
+
+    @Test
+    public void readsSingleLineArrays() {
+        JsonObject json = LegacyToml.toJson(List.of(
+                "\tdimensionsWithProfiles = [\"urbex:city=biosphere\", \"foo:bar=rare\"]"
+        ));
+        assertEquals(2, json.get("dimensionsWithProfiles").getAsJsonArray().size());
+        assertEquals("foo:bar=rare", json.get("dimensionsWithProfiles").getAsJsonArray().get(1).getAsString());
+    }
+
+    @Test
+    public void readsMultiLineArrays() {
+        JsonObject json = LegacyToml.toJson(List.of(
+                "\tavoidStructures = [",
+                "\t\t\"minecraft:mansion\",",
+                "\t\t\"minecraft:igloo\"",
+                "\t]"
+        ));
+        assertEquals(List.of("minecraft:mansion", "minecraft:igloo"),
+                json.get("avoidStructures").getAsJsonArray().asList().stream().map(e -> e.getAsString()).toList());
+    }
+
+    @Test
+    public void ignoresCommentsAndBlankLines() {
+        JsonObject json = LegacyToml.toJson(List.of("", "#x = 1", "  ", "[profiles]"));
+        assertTrue(json.isEmpty());
+    }
+}

--- a/src/test/java/dev/krona/urbex/config/UrbexConfigTest.java
+++ b/src/test/java/dev/krona/urbex/config/UrbexConfigTest.java
@@ -1,0 +1,59 @@
+package dev.krona.urbex.config;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UrbexConfigTest {
+
+    @Test
+    public void emptyJsonYieldsAllDefaults() {
+        UrbexConfig cfg = UrbexConfig.fromJson(new JsonObject()).orElseThrow();
+        assertEquals(UrbexConfig.DEFAULT, cfg);
+        assertEquals(3, cfg.heightSampleSize());
+        assertEquals("", cfg.selectedProfile());
+        assertTrue(cfg.avoidVillages());
+        assertFalse(cfg.structuresYieldToCities());
+        assertEquals(List.of("urbex:city=biosphere"), cfg.dimensionsWithProfiles());
+    }
+
+    @Test
+    public void jsonFieldsOverrideDefaults() {
+        JsonObject json = JsonParser.parseString(
+                "{\"selectedProfile\": \"rare\", \"cacheCleanupSeconds\": 60}").getAsJsonObject();
+        UrbexConfig cfg = UrbexConfig.fromJson(json).orElseThrow();
+        assertEquals("rare", cfg.selectedProfile());
+        assertEquals(60, cfg.cacheCleanupSeconds());
+        assertEquals(20, cfg.todoQueueSize());   // untouched fields keep defaults
+    }
+
+    @Test
+    public void outOfRangeValueIsRejected() {
+        JsonObject json = JsonParser.parseString("{\"heightSampleSize\": 0}").getAsJsonObject();
+        assertTrue(UrbexConfig.fromJson(json).isEmpty());
+    }
+
+    @Test
+    public void mergeLetsOverlayWinPerKey() {
+        JsonObject base = JsonParser.parseString(
+                "{\"selectedProfile\": \"default\", \"todoQueueSize\": 50}").getAsJsonObject();
+        JsonObject overlay = JsonParser.parseString(
+                "{\"selectedProfile\": \"biosphere\"}").getAsJsonObject();
+        JsonObject merged = UrbexConfig.merge(base, overlay);
+        UrbexConfig cfg = UrbexConfig.fromJson(merged).orElseThrow();
+        assertEquals("biosphere", cfg.selectedProfile());   // overlay wins
+        assertEquals(50, cfg.todoQueueSize());              // base survives where overlay is silent
+    }
+
+    @Test
+    public void roundTripsThroughJson() {
+        UrbexConfig cfg = UrbexConfig.fromJson(new JsonObject()).orElseThrow();
+        assertEquals(cfg, UrbexConfig.fromJson(UrbexConfig.toJson(cfg)).orElseThrow());
+    }
+}


### PR DESCRIPTION
Part 1 of #75 — the dependency half. The `UrbexProfile`/`Configuration` bridge (entangled with the GUI rewrite #64) is part 2 and stays on the issue.

## What changed
- **`forgeconfigapiport` is gone** from `build.gradle`, `gradle.properties`, and `fabric.mod.json` — the last NeoForge artifact in a Fabric-only mod. The empty CLIENT config it registered is simply not replaced.
- **`UrbexConfig`**: a 15-field record with a validating codec (`intRange` bounds where the old spec had them). One flat schema serves two files:
  - `config/urbex/urbex.json` — global; written back normalized so every available option is visible to the user;
  - `<world>/serverconfig/urbex.json` — optional per-world overrides, merged per-key at the JSON level, applied at `SERVER_STARTING` before profile validation and any worldgen.
  This dissolves the arbitrary COMMON/SERVER split: every option can now be set globally *and* overridden per world (`heightSampleSize` included, which used to be global-only).
- **Automatic migration**: legacy `common.toml` and `urbex-server.toml` are read once via a minimal purpose-built TOML reader and rewritten as JSON with their settings intact — existing installations and worlds lose nothing.
- **Zero call-site churn**: the `Config` facade keeps its supplier-shaped surface (`Config.X.get()`), so the ~40 usages across worldgen compile unchanged.

## Verification
- 9 new tests, written first: codec defaults, per-key override merge, range rejection, JSON round-trip, and the TOML reader (scalars, single/multi-line arrays, comments).
- The pinned `DRIVERDIGEST` passes unchanged in **both** end-to-end modes: a fresh world with the new JSON server config, and a migration run where the world had only the legacy TOML (the migration log fires, the file is converted, generation is identical).
- The digest server boots with no forgeconfigapiport jar on the classpath — the dependency is genuinely gone, not just unreferenced.
- Trade-off, stated: JSON has no comments, so option documentation now lives in code/docs rather than inline in the file (the old TOML had inline comments). The normalized write-back at least keeps every key discoverable.

## What this unblocks
`UrbexConfig`'s codec gives a `StreamCodec` nearly for free — the missing piece for dedicated-server profile sync (#73) — and per-world config is a step toward the profile-in-world direction from #6/#85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)