### PR TITLE
feat(gui): Phase 1 — Cities tab, preset list, live preview

### DIFF
--- a/docs/superpowers/plans/2026-08-10-gui-redesign.md
+++ b/docs/superpowers/plans/2026-08-10-gui-redesign.md
@@ -1,0 +1,144 @@
+# World-Creation GUI Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the injected-button GUI with a real Cities tab (preset list + detail + live preview) and a metadata-driven Customize editor exposing all profile settings, per `docs/superpowers/specs/2026-08-10-gui-redesign-design.md`.
+
+**Architecture:** Phase 1 adds the tab, preset list, selection state and a fixed/cached preview engine while still opening the old editor. Phase 2 adds a `SettingDescriptor` framework that generates the editor (sidebar categories, search, log/linear sliders, pinned preview) and deletes the old screen. All state publishing reuses `Config.profileFromClient`/`jsonFromClient`.
+
+**Tech Stack:** Fabric 26.2 mappings, vanilla widgets only (`ObjectSelectionList`, `AbstractSliderButton`, `GridLayout`/`LinearLayout`, `TabNavigationBar`), one new client mixin, JUnit 5.
+
+## Global Constraints
+
+- Java 25, MC 26.2 named mappings; method is `markPosForPostProcessing`-style casing — verify names with `javap` against `./.gradle/loom-cache/minecraftMaven/net/minecraft/minecraft-merged-7bbd2dae7e/26.2/minecraft-merged-7bbd2dae7e-26.2.jar` before mixing in.
+- Every mixin `require = 1` (already the json default).
+- No absolute pixel layouts; must be usable at GUI scale 4 on 1920×1080.
+- No display string used as an identity key; all new strings in `assets/urbex/lang/en_us.json`.
+- The worldgen digest (`./gradlew runDigestCheck`) must pass **unchanged** after every task — this is all client-side work.
+- One PR per phase. Phase 1 closes #66, #67, #68. Phase 2 closes #64, #65.
+- Branch: `feat/gui-redesign` (spec already committed there).
+
+---
+
+## Phase 1 — Cities tab, presets, preview
+
+### Task 1: Preview engine — correct and cached
+
+**Files:**
+- Create: `src/main/java/dev/krona/urbex/gui/preview/CityPreview.java`
+- Modify: `src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java`
+- Modify: `src/main/java/dev/krona/urbex/worldgen/lost/City.java` (the two `provider.getWorld() != null` guards)
+- Test: `src/test/java/dev/krona/urbex/gui/preview/CityPreviewKeyTest.java`
+
+**Interfaces:**
+- Produces: `CityPreview.render(GuiGraphics g, int x, int y, int w, int h)`, `CityPreview.update(UrbexProfile profile, String worldStyle, long seed)` (no-op when the (profileHash, worldStyle, seed) key is unchanged), `CityPreview.close()` (frees the texture), `static long seedFromUi(String seedField, long fallbackRandom)`.
+- Consumes: existing `NullDimensionInfo`, `ChunkCharacteristics` via `BuildingInfo.getChunkCharacteristics`.
+
+- [ ] **Step 1: Failing test for the cache key and seed source.** `CityPreviewKeyTest`: `update` with equal (profile JSON hash, worldstyle, seed) must report `false` (no recompute) from a package-visible `boolean needsRecompute(...)`; `seedFromUi("1337", r)` returns `1337`'s `String.hashCode`-free parse — exactly vanilla's rule: numeric string → `Long.parseLong`, non-numeric → `String.hashCode()`, blank → fallback. Three asserts. Run; expect compile failure.
+- [ ] **Step 2: Implement `CityPreview`.** Owns: key record `(int profileJsonHash, String worldStyle, long seed)`; a `NullDimensionInfo` built once per key change; an `int[] colors = new int[W*H]` (W=62, H=58 as today) filled from `getChunkCharacteristics` (city → 0x995555, building → 0xffffff, else terrain green, water blue for `isOcean`-style biomes as the old `renderPreviewMap` did); a `DynamicTexture` uploaded on recompute; `render` blits the texture and a 3-swatch legend (city/building/water) using lang keys `urbex.preview.legend.*`. Recompute is synchronous but only on key change; callers debounce (Task 6).
+- [ ] **Step 3: Fix `NullDimensionInfo` (#67).** `dimension()` returns `Level.OVERWORLD` (agreeing with `getType()`); `getBiome` returns a plains fallback instead of dereferencing the null `biomeRegistry`; `loadPredefinedStuff` path must not latch `AssetRegistries.loadedPredefined` when the level is null (guard in `AssetRegistries.java:79`); give `NullDimensionInfo` the client's `RegistryAccess` (from `Minecraft.getInstance().getConnection()` being null at world-creation, use `CreateWorldScreen`'s `WorldCreationContext.worldgenLoadContext()` passed into the constructor) so `City.java`'s two `provider.getWorld() != null` guards can be relaxed to "has registry access": worldstyle city-chance multiplier and `CITY_MINHEIGHT/MAXHEIGHT` gating then run in previews.
+- [ ] **Step 4: Verify.** `./gradlew test` green (new + existing); `./gradlew runDigestCheck` → `URBEX-DIGEST-CHECK: OK` with the current golden (relaxed guards must behave identically in-world where `getWorld() != null` already held).
+- [ ] **Step 5: Commit** `feat(gui): cached, honest city preview engine`.
+
+### Task 2: Preset selection state
+
+**Files:**
+- Create: `src/main/java/dev/krona/urbex/gui/PresetSelection.java`
+- Modify: `src/main/java/dev/krona/urbex/gui/RecreateProfileRestore.java` (retarget), `src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java` (reset on disconnect), `src/main/java/dev/krona/urbex/gui/ClientProfileSetup.java` (fix `toggleWorldStyle` for #66; the class otherwise stays until Phase 2)
+- Test: `src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java`
+
+**Interfaces:**
+- Produces: `PresetSelection.CLIENT` singleton with `List<Entry> entries()` (`Entry(String id, Component name, boolean custom, String basedOn, Optional<UrbexProfile> profile)`; first entry always `disabled`), `select(String id)`, `selected()`, `publish()` (writes `Config.profileFromClient`/`jsonFromClient` + dirty counter + `Config.resetProfileCache()`, exactly like the old `selectProfile`), `applyCustomized(UrbexProfile copy, String basedOn)`, `reset()`, `restore(String profileName, String json)` (Re-Create path).
+- Consumes: `ProfileSetup.STANDARD_PROFILES` (`isPublic()` filter), `Config` statics.
+
+- [ ] **Step 1: Failing tests.** Ordering (`disabled` first, publics sorted with `default` first as today, customs last); `select("nope")` is a no-op; `restore` with unknown profile leaves selection untouched; `restore` with JSON produces a custom entry `basedOn="customized"`-free label. Run, expect compile failure.
+- [ ] **Step 2: Implement `PresetSelection`.** Pure state + the `publish()` bridge; `entries()` rebuilt from `STANDARD_PROFILES` on demand; nothing here touches widgets, so it is unit-testable headless. `customize()`-style mutation of `STANDARD_PROFILES` is NOT copied here — custom configs live only in the selection (Phase 2's editor supplies them via `applyCustomized`).
+- [ ] **Step 3: Retarget Re-Create.** `RecreateProfileRestore.consumePending()` → `PresetSelection.CLIENT.restore(...)`; `ClientEventHandlers` disconnect → `PresetSelection.CLIENT.reset()` alongside the existing resets.
+- [ ] **Step 4: Fix `toggleWorldStyle` (#66)** in place: try-with-resources on the `MultiPackResourceManager`, source packs from the `CreateWorldScreen`'s `WorldCreationContext` datapack repository instead of the client resource-pack repository, guard the empty-styles list.
+- [ ] **Step 5: Verify + commit** (`./gradlew test`, digest unchanged) `feat(gui): preset selection state, Re-Create retarget, worldstyle toggle fixes`.
+
+### Task 3: The Cities tab
+
+**Files:**
+- Create: `src/main/java/dev/krona/urbex/mixin/CreateWorldScreenTabMixin.java`, `src/main/java/dev/krona/urbex/gui/CitiesTab.java`, `src/main/java/dev/krona/urbex/gui/PresetListWidget.java`, `src/main/resources/assets/urbex/lang/en_us.json`
+- Modify: `src/main/resources/urbex.mixins.json` (client list), `src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java` (delete the More-tab button injection; keep the Re-Create consume hook)
+- Test: manual checklist (widgets) + existing suites
+
+**Interfaces:**
+- Consumes: `PresetSelection.CLIENT`, `CityPreview`, `CreateWorldScreen.getUiState().getSeed()`.
+- Produces: `CitiesTab implements Tab` (GridLayout-based like vanilla's `CreateWorldScreen.MoreTab`), registered by the mixin.
+
+- [ ] **Step 1: Mixin.** Target `TabNavigationBar$Builder#addTabs(Tab...)` from `CreateWorldScreen`'s init: `@ModifyArgs` (or `@ModifyArg` on the array) appending a `new CitiesTab(createWorldScreen)` when the builder call site is `CreateWorldScreen`. Alternative anchor if the varargs shape fights back: inject at `CreateWorldScreen` init `@At("TAIL")` is NOT acceptable (tab bar already built); instead `@Redirect` the `addTabs` call. Verify the chosen target with `javap` first; `require=1` guards the result. Add to `"client"` in `urbex.mixins.json`.
+- [ ] **Step 2: `PresetListWidget`** extends `ObjectSelectionList<PresetListWidget.Row>`; rows render icon (from `UrbexProfile.getIcon()` — the 18 shipped textures; fallback plain tile), name, and for customs a `✎` prefix + "based on X" suffix (lang: `urbex.preset.custom_suffix`). Selection calls `PresetSelection.CLIENT.select(id)` + `publish()`.
+- [ ] **Step 3: `CitiesTab`.** Two-column `GridLayout`: left the list; right a detail panel — name (bold), description/extra/warning (`MultiLineTextWidget`, colors as today's `getProfileInfo`), the `CityPreview` (updates on selection change and on tab switch using `seedFromUi(uiState.getSeed(), randomFallback)`), "⟳ New preview seed" button (disabled + tooltip `urbex.preview.seed_locked` when the seed field is non-blank), and "Customize this preset…" button → opens the **old** `UrbexConfigScreen` (Phase 2 swaps this) — disabled for the `disabled` entry. All strings via lang keys (`urbex.tab.cities`, `urbex.preset.disabled`, …).
+- [ ] **Step 4: Delete the More-tab button injection** from `ClientEventHandlers` (keep screen-identity Re-Create consumption, now keyed on the CreateWorldScreen as before).
+- [ ] **Step 5: Verify.** `./gradlew build` green; `./gradlew runDigestCheck` unchanged; **manual**: `./gradlew runClient` → Create New World shows the Cities tab at GUI scales 2 and 4; selecting Rare shows description+preview; fixed seed `1337` disables reroll; Re-Create of a world with a saved profile pre-selects it. Screenshot for the PR.
+- [ ] **Step 6: Commit + PR (Phase 1).** `feat(gui): Cities tab with preset list, detail panel and live preview` — PR body claims closes #66, closes #67, closes #68, includes screenshots and the unchanged digest line.
+
+---
+
+## Phase 2 — the Customize editor
+
+### Task 4: SettingDescriptor framework
+
+**Files:**
+- Create: `src/main/java/dev/krona/urbex/gui/settings/SettingDescriptor.java`, `src/main/java/dev/krona/urbex/gui/settings/SettingCategory.java`, `src/main/java/dev/krona/urbex/gui/settings/Settings.java` (the full descriptor registry)
+- Modify: `src/main/resources/assets/urbex/lang/en_us.json` (setting names + tooltips)
+- Test: `src/test/java/dev/krona/urbex/gui/settings/SettingsCompletenessTest.java`
+
+**Interfaces:**
+- Produces: `record SettingDescriptor(String key, SettingCategory category, boolean general, ControlKind kind, double min, double max, double step, boolean logScale, Function<UrbexProfile,Object> getter, BiConsumer<UrbexProfile,Object> setter)`; `enum ControlKind { SLIDER, TOGGLE, CYCLE, TEXT }`; `enum SettingCategory { GENERAL, CITIES, BUILDINGS, DAMAGE, TRANSPORT, SPHERES, TERRAIN, SPAWN, ADVANCED }` (labels via `urbex.category.<lowercase>`); `Settings.ALL : List<SettingDescriptor>`; `Settings.byCategory(SettingCategory)`; `Settings.search(String localizedQuery)`.
+- Consumes: `UrbexProfile` public fields directly (getter/setter lambdas) — deliberately NOT the `Configuration` bridge, so #75 part 2 can delete it without touching this framework.
+
+- [ ] **Step 1: Failing completeness test.** Reflection over `UrbexProfile`'s public non-static fields: every field name appears in exactly one non-`general` descriptor key, and every descriptor key matches a field. Excluded fields (e.g. `EDITMODE`-adjacent internals) live in an explicit `EXCLUDED` set in the test with a justification comment each. Also: every descriptor's lang keys (`urbex.setting.<key>`, `.tooltip`) exist in `en_us.json` (load the json from resources in the test).
+- [ ] **Step 2: Write the registry.** All ~131 descriptors, category assignments per the spec (★ General = the curated 15: `CITY_CHANCE` (logScale), `CITY_MINRADIUS`, `CITY_MAXRADIUS`, `BUILDING_MINFLOORS`, `BUILDING_MAXFLOORS`, `RUIN_CHANCE`-family, `EXPLOSION_CHANCE` (logScale), `MINI_EXPLOSION_CHANCE` (logScale), loot/lighting density, landscape type, world style). `general=true` entries are the same descriptor instances flagged, not duplicates. Lang entries generated alongside (names Title Case from field names, tooltips from the comments currently in `UrbexProfile.init`).
+- [ ] **Step 3: Green + commit** `feat(gui): setting descriptor registry covering the full profile`.
+
+### Task 5: Editor controls
+
+**Files:**
+- Create: `src/main/java/dev/krona/urbex/gui/settings/LogValueMapper.java`, `src/main/java/dev/krona/urbex/gui/settings/SettingControls.java` (factory: descriptor → AbstractWidget)
+- Test: `src/test/java/dev/krona/urbex/gui/settings/LogValueMapperTest.java`
+
+**Interfaces:**
+- Produces: `LogValueMapper(double min, double max)` with `double toSlider(double value)` / `double fromSlider(double t)` (t∈[0,1], `fromSlider(toSlider(v)) ≈ v`), `String format(double value)` (decimals adapt: ≥3 significant digits, so 0.0001 and 0.001 are distinct); `SettingControls.create(SettingDescriptor d, UrbexProfile target, Runnable onChanged) : AbstractWidget` — sliders (`AbstractSliderButton` subclass), toggles (`CycleButton.booleanBuilder`), enums (`CycleButton`), text (`EditBox`), each with `Tooltip.create` from the descriptor tooltip key.
+- Consumes: Task 4's descriptors.
+
+- [ ] **Step 1: Failing `LogValueMapperTest`.** Round-trip within 1e-9 relative at min, max, and 7 midpoints for (1e-4, 1); endpoints map to 0 and 1; `format(0.0001)` ≠ `format(0.001)`; monotonicity across 100 samples.
+- [ ] **Step 2: Implement** `toSlider(v) = (ln v − ln min) / (ln max − ln min)`, clamp; format via `BigDecimal.round(new MathContext(3))` stripped of trailing zeros.
+- [ ] **Step 3: Implement `SettingControls`** (thin, widget-side; no test beyond compile — behavior is exercised in-game and by the completeness test's kind/range sanity assertions: every SLIDER has min<max, every logScale has min>0 — add those asserts to the Task 4 test now).
+- [ ] **Step 4: Green + commit** `feat(gui): editor controls with logarithmic sliders`.
+
+### Task 6: The Customize editor screen
+
+**Files:**
+- Create: `src/main/java/dev/krona/urbex/gui/CustomizeScreen.java`, `src/main/java/dev/krona/urbex/gui/SaveAsDialog.java`
+- Modify: `src/main/java/dev/krona/urbex/gui/CitiesTab.java` (Customize opens `CustomizeScreen`), `src/main/resources/assets/urbex/lang/en_us.json`
+- Test: `src/test/java/dev/krona/urbex/gui/SaveAsValidationTest.java`
+
+**Interfaces:**
+- Consumes: `Settings.ALL`, `SettingControls`, `CityPreview`, `PresetSelection.CLIENT.applyCustomized(copy, basedOn)`.
+- Produces: `CustomizeScreen(Screen parent, UrbexProfile base, String baseName)` — works on `new UrbexProfile(baseName+"-copy", false).copyFrom(base)`; `SaveAsDialog.validateName(String, Set<String> taken) : Optional<Component>` (error or empty).
+
+- [ ] **Step 1: Failing `SaveAsValidationTest`.** Rejects: empty, names in `taken` (built-ins + existing customs), non `[a-z0-9_]+` after lowercasing; accepts `my_wasteland`. Error components are lang-keyed (`urbex.saveas.err.*`).
+- [ ] **Step 2: Screen layout.** Left `ObjectSelectionList` of categories (★ General pinned first, Advanced last); middle scrollable widget column rebuilt on category/search change (search `EditBox` on top; filter via `Settings.search`); right the pinned `CityPreview` + reroll button; bottom bar `[Save as…] [Reset to preset] [Done] [Cancel]`; title `Customize: <base>` gaining `*` once any `onChanged` fires. Preview `update` calls debounced 150 ms (a `long nextUpdateAt` checked in `tick()`).
+- [ ] **Step 3: Flows.** Done → `applyCustomized(copy, baseName)` + `publish()` + back to parent. Cancel → back, no publish (the copy is discarded — nothing global was touched, which is what fixes #65's cancel/dup/ESC class; also `onClose()` = Cancel). Reset → re-copy from base, rebuild controls. Save as → dialog; on accept: write `config/urbex/profiles/<name>.json` = `profile.toJson(false)` + `"basedOn": baseName`, register in `STANDARD_PROFILES` as non-public, `PresetSelection` refresh + select it, back to tab. IO errors surface in the dialog (lang `urbex.saveas.err.io`).
+- [ ] **Step 4: Verify.** Tests green; digest unchanged; **manual** at GUI scale 4: search "chance" filters across categories; city-chance slider shows 0.0001↔0.02 usable range; Save as creates the file and the list entry survives a game restart.
+- [ ] **Step 5: Commit** `feat(gui): metadata-driven customize editor`.
+
+### Task 7: Deletions and Phase 2 PR
+
+**Files:**
+- Delete: `src/main/java/dev/krona/urbex/gui/UrbexConfigScreen.java`, `src/main/java/dev/krona/urbex/gui/elements/*` except the slider-math helper class backing `PercentageSliderElementTest` (move it to `gui/settings/` if package-private access demands), `src/main/java/dev/krona/urbex/gui/ClientProfileSetup.java` (state now fully in `PresetSelection`)
+- Modify: whatever still imports them (`RecreateProfileRestore` javadoc references, `ClientEventHandlers`), `docs/superpowers/specs/2026-08-10-gui-redesign-design.md` status line → implemented
+- Test: full suite + digest
+
+- [ ] **Step 1: Delete and fix references.** `grep -rn "UrbexConfigScreen\|ClientProfileSetup\|gui.elements" src/main/java` must return nothing afterwards (except the kept slider-math file).
+- [ ] **Step 2: Verify everything.** `./gradlew build` (all tests), `./gradlew runDigestCheck` unchanged, `runClient` smoke: full flow tab → preset → customize → save-as → create world → cities generate with the customized values (check one obvious setting like city chance visually).
+- [ ] **Step 3: Commit + PR (Phase 2).** `feat(gui): replace the old config screen` — closes #64, closes #65; screenshots of tab, editor, search, and log slider.
+
+## Self-review notes
+
+- Spec coverage: entry/tab (T3), preset model incl. Save-as/basedOn (T2/T6), editor structure+search+log sliders (T4-6), preview seed/correctness/caching/legend (T1/T3), help+lang (T3/T4/T6), deletions (T7), phasing (PR steps in T3/T7). Error handling: greyed invalid configs — covered by `PresetSelection.entries()` skipping unparseable profile JSONs with a greyed row (add in T2 Step 2); preview failure fallback — `CityPreview.render` catches and shows `urbex.preview.unavailable` (T1 Step 2).
+- Types named identically across tasks (`PresetSelection.CLIENT`, `Settings.ALL`, `CityPreview.update/render`).
+- No TBDs; widget-assembly steps carry exact vanilla classes instead of full listings by design (executor model is capable; the novel logic — mappers, validation, cache keys, mixin targets — is spelled out).

--- a/docs/superpowers/specs/2026-08-10-gui-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-10-gui-redesign-design.md
@@ -1,0 +1,158 @@
+# World-Creation GUI Redesign
+
+Date: 2026-08-10
+Status: approved (brainstorm with maintainer; mockups in `.superpowers/brainstorm/94488-1786320857/content/`)
+Supersedes: issue #64 (epic); absorbs #65, #66, #67, #68
+
+## Goal
+
+Replace the injected-button + `UrbexConfigScreen` world-creation GUI with a first-class
+**Cities tab** in Create New World, a **preset list** with a detail panel, and a
+**metadata-driven Customize editor** exposing all profile settings. Selected state must be
+visible without clicking anything; presets must be extendable into named, persistent custom
+configs; the preview must show what the player will actually get.
+
+## Non-goals
+
+- The in-game part editor (#69/#70) — untouched.
+- The `UrbexProfile`/`Configuration` codec rewrite (#75 part 2). The editor framework reads
+  the existing `Configuration` metadata; when part 2 lands, the framework's setting
+  declarations swap their backing without UI changes.
+- Dedicated-server profile sync (#73).
+- Translations other than `en_us` (the lang file makes them possible; providing them is not
+  in scope).
+
+## 1. Entry: the Cities tab
+
+- A real tab ("Cities") in `CreateWorldScreen`'s tab bar, added by one client mixin that
+  appends to the tab list the screen builds. `tabManager` and `MoreTab` access-wideners
+  already exist; a new widener/mixin target for tab construction is expected.
+- The tab contains the preset list (section 2) and detail panel — it *is* the state display:
+  selected preset name, icon, description, warning, mini-preview, and an "✎ based on X"
+  marker for custom configs are always visible on the tab.
+- The injected "Cities" button on the More tab is deleted.
+- "Disabled" is an explicit first entry in the preset list (profile = none), not an implicit
+  default.
+
+## 2. Preset model and extension
+
+**List contents, in order:** Disabled · built-in public profiles (`ProfileSetup`
+`isPublic()`, with their shipped `icon_*.png` finally rendered) · user configs from
+`config/urbex/profiles/*.json`.
+
+**Flows:**
+
+- *Select preset* → detail panel updates (description / extraDescription / warning from the
+  profile, mini-preview, world-style line).
+- *Customize this preset…* → opens the editor on a **copy** of the profile. The base preset
+  object in `STANDARD_PROFILES` is never mutated (fixes the `customize()` pollution from
+  #65).
+- Editor **Done** → the edited copy becomes this world's config (the transient "customized"
+  path that exists today, labeled "✎ Custom (based on X)" in the list).
+- Editor **Save as…** → prompts for a name, writes
+  `config/urbex/profiles/<name>.json` (the folder `ProfileSetup` already loads), including a
+  `basedOn` field for provenance. Saved configs appear in the list on this and future
+  worlds. Name collisions with built-in profiles are rejected in the dialog.
+- Editor **Reset to preset** → discards edits back to the base copy.
+- Editor **Cancel** → returns to the tab with no state published (fixes #65's
+  cancel-publishes-anyway).
+
+**Publishing:** selection and edits feed the existing `Config.profileFromClient` /
+`jsonFromClient` statics exactly as `UrbexConfigScreen.selectProfile` does today; server-side
+behavior is unchanged. `RecreateProfileRestore` (#85) retargets from `ClientProfileSetup` to
+the new state holder and pre-selects the restored entry in the list.
+
+## 3. The Customize editor
+
+Layout (mockup "customize-structure A"): left sidebar of categories · middle scrollable
+control list with a search box · right pinned live preview. Vanilla `GridLayout` /
+`LinearLayout`; no absolute pixel positions; must be usable at GUI scale 4 on 1920×1080.
+
+**Setting declarations.** A `SettingDescriptor` declares each setting once: profile field
+key, category, control type, range/step, display scale (linear or logarithmic), and
+localization key. The editor generates controls from the declarations list. Backing
+read/write goes through the existing `Configuration` bridge for now (see Non-goals).
+All 131 profile settings get descriptors — none of today's 88 missing settings stay hidden.
+
+**Categories:** `★ General` (curated ~15: city chance, city min/max radius, building
+min/max floors, ruin %, explosion chances, loot & lighting density, world style, landscape
+type) · Cities · Buildings · Damage & ruins · Highways & rails · Spheres · Terrain & water ·
+Spawn · Advanced (everything exotic: per-biome multipliers, noise scales, editmode, …).
+A setting appears in exactly one category; `★ General` entries are *duplicated* references
+to their home-category descriptor, marked so search does not list them twice.
+
+**Controls:**
+
+- Bounded numerics → sliders with value readout; fine-step via the existing
+  `PercentageSliderElement` math (tested, kept).
+- City chance, explosion/mini-explosion chance → **logarithmic sliders** (value mapped as
+  `10^x`), formatted with enough decimals to distinguish 0.0001 from 0.001.
+- Booleans → ON/OFF toggle buttons; enums → cycle buttons (the only place cycling remains).
+- Free-text/identifier settings (block ids, biome ids) → edit boxes, in Advanced.
+- Search: substring match on localized names, filters the middle panel across all
+  categories; Esc clears.
+
+**Editing model:** the editor works on the copy from section 2; a `*` in the title marks
+unsaved changes; sliders update the preview live (preview recompute is debounced ~150 ms).
+
+## 4. Preview
+
+- Uses the **actual world seed** from the World tab when the seed field is non-empty —
+  preview equals outcome. Blank seed → random preview seed; "⟳ New preview seed" rerolls it.
+  With a fixed world seed the reroll button is disabled with a tooltip explaining why.
+- Correctness (#67): the preview's dimension info supplies registry access so worldstyle
+  city-chance multipliers and `CITY_MINHEIGHT/MAXHEIGHT` gating apply; `dimension()` and
+  `getType()` agree so caches hit; `getBiome` cannot NPE; `loadedPredefined` is not latched
+  when no level exists.
+- Performance (#68): one preview model per (config hash, seed), rendered into a cached
+  texture; recompute only on config/seed change (debounced), never per frame.
+- A three-swatch legend (city block / building / water) under the map.
+
+## 5. Help and localization
+
+- Every control: tooltip from the setting's description text.
+- Every category: one-line description under its header.
+- All new-GUI strings in `assets/urbex/lang/en_us.json`; keys follow
+  `urbex.setting.<field>`, `urbex.setting.<field>.tooltip`, `urbex.category.<id>`,
+  `urbex.preset.<name>.*`, `urbex.screen.*`. No display string is ever used as an identity
+  key (kills the `"On".equals(...)` class of bugs).
+
+## 6. Deletions
+
+`UrbexConfigScreen`, the `gui/elements` widget set (except the slider-math helper and its
+test), `NullDimensionInfo`'s per-frame construction path, and the More-tab button injection.
+`ClientProfileSetup` shrinks to (or is replaced by) the new selection-state holder.
+
+## Error handling
+
+- Missing/broken user config JSON in `config/urbex/profiles/` → entry shown greyed with a
+  tooltip ("invalid config: <parse error>"), not a crash; selecting it is impossible.
+- Preview generation failure (e.g. broken datapack asset reached through characteristics) →
+  the map area shows "preview unavailable" instead of propagating; the error is logged once.
+- Save-as with an empty/duplicate/reserved name → inline red message, dialog stays open.
+- If the tab mixin fails to apply (`require = 1`), the game crashes at startup loudly —
+  preferred over silently shipping without the tab.
+
+## Testing
+
+- Unit: log-slider mapping (value↔position round-trip, endpoints, formatting);
+  `SettingDescriptor` completeness check (every `UrbexProfile` public field has exactly one
+  descriptor — a reflection test that fails when someone adds a profile field without a
+  descriptor); save-as name validation; preset-list ordering.
+- The existing `PercentageSliderElementTest` and `RecreateProfileRestoreTest` keep passing
+  (retargeted where the state holder moved).
+- Manual checklist per phase (screenshots in PR): tab visible at GUI scales 1–4, preview
+  matches a generated world for a fixed seed, Re-Create pre-selects the restored config.
+- The worldgen digest is expected **unchanged** by every GUI PR (client-only work).
+
+## Phasing
+
+- **Phase 1 — tab & presets:** Cities tab mixin, preset list + detail panel, state display,
+  publishing plumbing, Re-Create retarget, preview fixes (#67/#68) reused by the panel.
+  "Customize" still opens the *old* editor. Ships alone; closes #66, #67, #68.
+- **Phase 2 — editor:** the descriptor framework, sidebar/search/pinned-preview editor,
+  log sliders, lang file, deletions of the old screen/elements. Closes #64, #65 and the
+  remaining scope.
+
+Each phase is one PR, independently shippable, verified in-game with screenshots plus the
+unchanged digest.

--- a/src/main/java/dev/krona/urbex/gui/CitiesTab.java
+++ b/src/main/java/dev/krona/urbex/gui/CitiesTab.java
@@ -66,6 +66,15 @@ public class CitiesTab extends GridLayoutTab {
     @Nullable
     private static CityPreview activePreview;
 
+    /**
+     * Set when this tab hands the player off to the old editor, consumed by
+     * {@code CreateWorldScreenTabMixin} at the tail of the next {@code CreateWorldScreen.init()}.
+     * Coming back from that editor goes through {@code setScreen(parent)}, which re-runs
+     * {@code init()} - and its tail calls {@code selectTab(0, false)}, dropping the player on the
+     * Game tab. Without this they would have to find their way back to Cities every time.
+     */
+    private static boolean reopenOnCitiesTab;
+
     private final CreateWorldScreen screen;
     private final CityPreview preview;
     private final RandomSource random = RandomSource.create();
@@ -83,6 +92,16 @@ public class CitiesTab extends GridLayoutTab {
      * a typed seed wins over it, which is why the button locks while one is present.
      */
     private long previewSeedFallback;
+
+    /**
+     * The tab area the last {@link #doLayout} ran against, so a detail-panel refresh can redo the
+     * layout: the description's height is a function of its text ({@code MultiLineTextWidget
+     * .getHeight()} is {@code lineCount * 9}, verified by decompilation), and nothing else re-runs
+     * the layout on selection change - {@code TabManager} only calls {@code doLayout} on
+     * {@code setTabArea}/{@code setCurrentTab}.
+     */
+    @Nullable
+    private ScreenRectangle lastTabArea;
 
     public CitiesTab(CreateWorldScreen screen) {
         super(TITLE);
@@ -124,6 +143,7 @@ public class CitiesTab extends GridLayoutTab {
 
     @Override
     public void doLayout(ScreenRectangle rectangle) {
+        lastTabArea = rectangle;
         resizeChildren(rectangle);
         this.layout.arrangeElements();
         FrameLayout.alignInRectangle(this.layout, rectangle, 0.5F, 0.0F);
@@ -183,6 +203,7 @@ public class CitiesTab extends GridLayoutTab {
      * {@code UrbexConfigScreen.done()} mirrors the result back, so a round trip stays consistent.
      */
     private void openCustomizeEditor() {
+        requestReopenOnCitiesTab();
         PresetSelection.Entry entry = PresetSelection.CLIENT.selected();
         if (!entry.custom() && entry.profile().isPresent()) {
             // Custom entries are deliberately left alone: ClientProfileSetup still holds the edited
@@ -199,6 +220,12 @@ public class CitiesTab extends GridLayoutTab {
         infoText.setMessage(describe(entry));
         customizeButton.active = !PresetSelection.DISABLED_ID.equals(entry.id());
         refreshSeedControls();
+        if (lastTabArea != null) {
+            // The new description is a different number of lines than the old one, so the preview
+            // below it has to move (and resize) with it - otherwise a long blurb draws over the
+            // preview and a short one leaves a hole.
+            doLayout(lastTabArea);
+        }
     }
 
     private void refreshSeedControls() {
@@ -242,11 +269,39 @@ public class CitiesTab extends GridLayoutTab {
     }
 
     private static CityPreview newPreview(@Nullable RegistryAccess registryAccess) {
-        if (activePreview != null) {
-            activePreview.close();
-        }
+        closeActivePreview();
         activePreview = new CityPreview(registryAccess);
         return activePreview;
+    }
+
+    /**
+     * Releases the live preview's GPU texture. Must be called when the {@code CreateWorldScreen}
+     * goes away (see {@code ClientEventHandlers}): otherwise the texture - and, through
+     * {@code CityPreview}'s registry access, the whole frozen {@code RegistryAccess} of a world
+     * that was never created - would stay pinned until the player opened the screen again.
+     */
+    public static void closeActivePreview() {
+        if (activePreview != null) {
+            activePreview.close();
+            activePreview = null;
+        }
+    }
+
+    /** Asks for the next {@code CreateWorldScreen.init()} to land on this tab. */
+    static void requestReopenOnCitiesTab() {
+        reopenOnCitiesTab = true;
+    }
+
+    /** One-shot: true iff the screen is being re-initialised on the way back from the old editor. */
+    public static boolean consumeReopenOnCitiesTab() {
+        boolean requested = reopenOnCitiesTab;
+        reopenOnCitiesTab = false;
+        return requested;
+    }
+
+    /** Drops a pending {@link #reopenOnCitiesTab} that no longer belongs to this screen. */
+    public static void forgetReopenOnCitiesTab() {
+        reopenOnCitiesTab = false;
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/gui/CitiesTab.java
+++ b/src/main/java/dev/krona/urbex/gui/CitiesTab.java
@@ -1,0 +1,289 @@
+package dev.krona.urbex.gui;
+
+import dev.krona.urbex.config.UrbexProfile;
+import dev.krona.urbex.gui.preview.CityPreview;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.MultiLineTextWidget;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.components.tabs.GridLayoutTab;
+import net.minecraft.client.gui.layouts.FrameLayout;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+
+import javax.annotation.Nullable;
+
+/**
+ * The "Cities" tab of the vanilla world-creation screen (injected by
+ * {@code dev.krona.urbex.mixin.CreateWorldScreenTabMixin}): a preset list on the left, and on the
+ * right a detail panel with the preset's name, its description, a live {@link CityPreview} of the
+ * city layout that preset would generate, and the two actions (reroll the preview seed, open the
+ * customize editor).
+ * <p>
+ * Nothing here lays widgets out at fixed screen coordinates: every size is derived in
+ * {@link #doLayout(ScreenRectangle)} from the tab area the screen hands us, so the tab stays usable
+ * down to GUI scale 4 (~480x254 logical pixels), where the preview simply drops out rather than
+ * pushing the buttons off-screen.
+ */
+public class CitiesTab extends GridLayoutTab {
+
+    private static final Component TITLE = Component.translatable("urbex.tab.cities");
+
+    private static final int MARGIN = 8;
+    private static final int COLUMN_SPACING = 8;
+    private static final int ROW_SPACING = 4;
+    private static final int BUTTON_HEIGHT = 20;
+
+    /** Beyond this the two columns just get emptier, so cap and centre instead. */
+    private static final int MAX_CONTENT_WIDTH = 460;
+    private static final int MIN_LIST_WIDTH = 90;
+    private static final int MAX_LIST_WIDTH = 200;
+    private static final int MIN_DETAIL_WIDTH = 80;
+    private static final int MAX_INFO_ROWS = 5;
+    /** Below this the preview is more noise than information - hide it and give the space back. */
+    private static final int MIN_PREVIEW_HEIGHT = 40;
+
+    /**
+     * The preview owns a GPU texture, and nothing tells a {@link net.minecraft.client.gui.components.tabs.Tab}
+     * when it is discarded (the screen rebuilds every tab on each {@code init()}, i.e. on every
+     * window resize). Holding the live one statically and closing it when the next tab supersedes
+     * it bounds that to a single texture at a time instead of one per resize.
+     */
+    @Nullable
+    private static CityPreview activePreview;
+
+    private final CreateWorldScreen screen;
+    private final CityPreview preview;
+    private final RandomSource random = RandomSource.create();
+
+    private final PresetListWidget list;
+    private final StringWidget nameLabel;
+    private final MultiLineTextWidget infoText;
+    private final PreviewWidget previewWidget;
+    private final Button rerollButton;
+    private final Button customizeButton;
+
+    /**
+     * The seed the preview falls back to while the seed field is empty - vanilla's own
+     * "no seed typed" case (see {@link CityPreview#seedFromUi}). The reroll button rolls a new one;
+     * a typed seed wins over it, which is why the button locks while one is present.
+     */
+    private long previewSeedFallback;
+
+    public CitiesTab(CreateWorldScreen screen) {
+        super(TITLE);
+        this.screen = screen;
+        this.preview = newPreview(previewRegistries(screen));
+        this.previewSeedFallback = random.nextLong();
+
+        Font font = Minecraft.getInstance().font;
+
+        // Widget sizes here are placeholders only: resizeChildren() derives every one of them from
+        // the tab area before the first frame is drawn.
+        this.list = new PresetListWidget(Minecraft.getInstance(), MIN_LIST_WIDTH, MIN_LIST_WIDTH, 0,
+                entry -> refreshDetail());
+        this.nameLabel = new StringWidget(MIN_DETAIL_WIDTH, font.lineHeight, CommonComponents.EMPTY, font);
+        this.infoText = new MultiLineTextWidget(CommonComponents.EMPTY, font);
+        this.previewWidget = new PreviewWidget();
+        this.rerollButton = Button.builder(Component.translatable("urbex.preview.reroll"),
+                b -> previewSeedFallback = random.nextLong()).build();
+        this.customizeButton = Button.builder(Component.translatable("urbex.screen.customize"),
+                b -> openCustomizeEditor()).build();
+
+        this.layout.columnSpacing(COLUMN_SPACING);
+        this.layout.addChild(list, 0, 0);
+        LinearLayout detailColumn = this.layout.addChild(LinearLayout.vertical().spacing(ROW_SPACING), 0, 1);
+        detailColumn.addChild(nameLabel);
+        detailColumn.addChild(infoText);
+        detailColumn.addChild(previewWidget);
+        LinearLayout buttonRow = detailColumn.addChild(LinearLayout.horizontal().spacing(ROW_SPACING));
+        buttonRow.addChild(rerollButton);
+        buttonRow.addChild(customizeButton);
+
+        // Vanilla's own tabs (GameTab, WorldTab) subscribe to the shared ui state the same way; the
+        // listener lives exactly as long as the screen does. We need it because the reroll button
+        // has to lock the moment the player types into the seed field on another tab.
+        screen.getUiState().addListener(state -> refreshSeedControls());
+
+        refreshDetail();
+    }
+
+    @Override
+    public void doLayout(ScreenRectangle rectangle) {
+        resizeChildren(rectangle);
+        this.layout.arrangeElements();
+        FrameLayout.alignInRectangle(this.layout, rectangle, 0.5F, 0.0F);
+        // The grid moved the list widget by setting x/y; its rows are positioned separately and
+        // only follow via updateSizeAndPosition.
+        list.updateSizeAndPosition(list.getWidth(), list.getHeight(), list.getX(), list.getY());
+    }
+
+    /**
+     * Derives every child's size from the tab area. Kept in one place (rather than spread over the
+     * constructor) so the collapse order at small sizes is explicit: the preview goes first, then
+     * the description shrinks row by row; the list and the buttons always survive.
+     */
+    private void resizeChildren(ScreenRectangle rectangle) {
+        Font font = Minecraft.getInstance().font;
+
+        int contentWidth = Math.min(Math.max(rectangle.width() - MARGIN * 2, MIN_LIST_WIDTH + MIN_DETAIL_WIDTH + COLUMN_SPACING),
+                MAX_CONTENT_WIDTH);
+        int contentHeight = Math.max(0, rectangle.height() - MARGIN * 2);
+
+        int listWidth = Mth.clamp(contentWidth * 2 / 5, MIN_LIST_WIDTH, MAX_LIST_WIDTH);
+        int detailWidth = Math.max(MIN_DETAIL_WIDTH, contentWidth - listWidth - COLUMN_SPACING);
+
+        list.setSize(listWidth, contentHeight);
+
+        nameLabel.setWidth(detailWidth);
+        nameLabel.setHeight(font.lineHeight);
+
+        rerollButton.setWidth((detailWidth - ROW_SPACING) / 2);
+        rerollButton.setHeight(BUTTON_HEIGHT);
+        customizeButton.setWidth(detailWidth - ROW_SPACING - rerollButton.getWidth());
+        customizeButton.setHeight(BUTTON_HEIGHT);
+
+        // Everything the description and the preview have to share, after the name row, the button
+        // row and the three gaps between the four stacked blocks.
+        int flexible = Math.max(0, contentHeight - font.lineHeight - BUTTON_HEIGHT - ROW_SPACING * 3);
+
+        int infoRows = Mth.clamp(flexible / 2 / font.lineHeight, 1, MAX_INFO_ROWS);
+        infoText.setMaxWidth(detailWidth);
+        infoText.setMaxRows(infoRows);
+
+        int previewHeight = flexible - infoText.getHeight();
+        if (previewHeight < MIN_PREVIEW_HEIGHT) {
+            previewWidget.visible = false;
+            previewWidget.setSize(0, 0);
+        } else {
+            previewWidget.visible = true;
+            previewWidget.setSize(detailWidth, previewHeight);
+        }
+    }
+
+    /**
+     * Opens the pre-redesign editor on the preset the tab is showing. Phase 2 replaces that screen
+     * (Task 6) with one that edits {@link PresetSelection} directly; until then the two keep
+     * separate state, so the selection has to be handed across explicitly - otherwise
+     * "Customize this preset..." would open on whatever the old editor was last left on.
+     * {@code UrbexConfigScreen.done()} mirrors the result back, so a round trip stays consistent.
+     */
+    private void openCustomizeEditor() {
+        PresetSelection.Entry entry = PresetSelection.CLIENT.selected();
+        if (!entry.custom() && entry.profile().isPresent()) {
+            // Custom entries are deliberately left alone: ClientProfileSetup still holds the edited
+            // profile that produced them, and setProfile() cannot hand back one it never made.
+            ClientProfileSetup.CLIENT_SETUP.setProfile(entry.id());
+        }
+        Minecraft.getInstance().gui.setScreen(new UrbexConfigScreen(screen));
+    }
+
+    /** Repopulates the detail panel from whatever {@link PresetSelection#CLIENT} currently holds. */
+    private void refreshDetail() {
+        PresetSelection.Entry entry = PresetSelection.CLIENT.selected();
+        nameLabel.setMessage(entry.name().copy().withStyle(ChatFormatting.BOLD));
+        infoText.setMessage(describe(entry));
+        customizeButton.active = !PresetSelection.DISABLED_ID.equals(entry.id());
+        refreshSeedControls();
+    }
+
+    private void refreshSeedControls() {
+        boolean seedTyped = !screen.getUiState().getSeed().isBlank();
+        rerollButton.active = !seedTyped;
+        rerollButton.setTooltip(seedTyped ? Tooltip.create(Component.translatable("urbex.preview.seed_locked")) : null);
+    }
+
+    /**
+     * The same three-part blurb the old editor's {@code getProfileInfo} tooltip showed - plain
+     * description, aqua "extra" line, red warning - minus the parts a profile leaves empty.
+     */
+    static Component describe(PresetSelection.Entry entry) {
+        UrbexProfile profile = entry.profile().orElse(null);
+        if (profile == null) {
+            return Component.translatable("urbex.preset.disabled.info");
+        }
+        MutableComponent result = Component.literal(profile.getDescription());
+        if (!profile.getExtraDescription().isEmpty()) {
+            result.append(CommonComponents.NEW_LINE)
+                    .append(Component.literal(profile.getExtraDescription()).withStyle(ChatFormatting.AQUA));
+        }
+        if (!profile.getWarning().isEmpty()) {
+            result.append(CommonComponents.NEW_LINE)
+                    .append(Component.literal(profile.getWarning()).withStyle(ChatFormatting.RED));
+        }
+        return result;
+    }
+
+    /**
+     * The registries the preview should sample biomes from: the ones loaded for the world being
+     * created, so datapack biomes and world-type choices are reflected. Degrades to {@code null}
+     * (the pre-preview "registry-gated rules skipped" behaviour) rather than letting
+     * {@code NullDimensionInfo}'s {@code lookupOrThrow(BIOME)} take the screen down if a
+     * half-loaded context ever lacks the biome registry.
+     */
+    @Nullable
+    private static RegistryAccess previewRegistries(CreateWorldScreen screen) {
+        RegistryAccess access = screen.getUiState().getSettings().worldgenLoadContext();
+        return access.lookup(Registries.BIOME).isPresent() ? access : null;
+    }
+
+    private static CityPreview newPreview(@Nullable RegistryAccess registryAccess) {
+        if (activePreview != null) {
+            activePreview.close();
+        }
+        activePreview = new CityPreview(registryAccess);
+        return activePreview;
+    }
+
+    /**
+     * Thin {@link AbstractWidget} shell so the {@link CityPreview} can live in the tab's layout and
+     * be added/removed with the rest of the tab's widgets. Non-interactive: it takes no focus and
+     * swallows no clicks.
+     */
+    private class PreviewWidget extends AbstractWidget {
+
+        PreviewWidget() {
+            super(0, 0, 0, 0, CommonComponents.EMPTY);
+            this.active = false;
+        }
+
+        @Override
+        protected void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTick) {
+            UrbexProfile profile = PresetSelection.CLIENT.selected().profile().orElse(null);
+            String worldStyle = profile == null ? "" : profile.getWorldStyle();
+            long seed = CityPreview.seedFromUi(screen.getUiState().getSeed(), previewSeedFallback);
+            // A no-op unless (profile, worldstyle, seed) actually changed, so driving it from the
+            // render pass is what makes the preview follow selection changes, seed edits and tab
+            // switches without any of them needing to know about the preview.
+            preview.update(profile, worldStyle, seed);
+
+            // CityPreview draws the map into (width, height - legend) and the legend underneath it,
+            // so a square-ish map means passing a width close to the total height; the legend then
+            // gets the full column width to run along.
+            preview.render(graphics, getX(), getY(), Math.min(getWidth(), getHeight()), getHeight());
+        }
+
+        @Override
+        protected void updateWidgetNarration(NarrationElementOutput output) {
+        }
+
+        @Override
+        public boolean isMouseOver(double mouseX, double mouseY) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/gui/ClientProfileSetup.java
+++ b/src/main/java/dev/krona/urbex/gui/ClientProfileSetup.java
@@ -90,7 +90,14 @@ public class ClientProfileSetup {
         customizedProfile = new UrbexProfile("customized", false);
         UrbexProfile original = ProfileSetup.STANDARD_PROFILES.get(profile);
         ProfileSetup.STANDARD_PROFILES.put("customized", customizedProfile);
-        profiles.add("customized");
+        // profiles is only the toggle-button's cycle cache, and it is built lazily by
+        // toggleProfile(). Since the Cities tab can now hand this class a profile without the
+        // player ever having pressed that button, it may legitimately still be null here - it used
+        // to be impossible, so this was an unguarded NPE. The contains() check likewise stops a
+        // second customize() from pushing a duplicate entry into the cycle.
+        if (profiles != null && !profiles.contains("customized")) {
+            profiles.add("customized");
+        }
         customizedProfile.copyFrom(original);
         profile = "customized";
         refreshPreview.run();

--- a/src/main/java/dev/krona/urbex/gui/ClientProfileSetup.java
+++ b/src/main/java/dev/krona/urbex/gui/ClientProfileSetup.java
@@ -4,7 +4,6 @@ import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.UrbexProfile;
 import dev.krona.urbex.config.ProfileSetup;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.PackType;
@@ -84,30 +83,6 @@ public class ClientProfileSetup {
         this.customizedProfile = other.customizedProfile;
     }
 
-    /**
-     * Restores a profile selection read from an existing world's saved data, for the vanilla
-     * Re-Create flow (issue #85). Mirrors what {@link UrbexConfigScreen#selectProfile} publishes so
-     * the restored choice reaches the server even if the Cities screen is never opened.
-     */
-    public void restoreFromSavedData(String profileName, String json) {
-        if (profileName == null || profileName.isEmpty()) {
-            return;
-        }
-        if (json != null && !json.isEmpty()) {
-            customizedProfile = new UrbexProfile("customized", false);
-            customizedProfile.copyFrom(new UrbexProfile("customized", json));
-            ProfileSetup.STANDARD_PROFILES.put("customized", customizedProfile);
-            profile = "customized";
-            UrbexConfigScreen.selectProfile("customized", customizedProfile);
-        } else if (ProfileSetup.STANDARD_PROFILES.containsKey(profileName)) {
-            profile = profileName;
-            UrbexConfigScreen.selectProfile(profileName, null);
-        } else {
-            Urbex.getLogger().warn("Re-created world used unknown Urbex profile '{}'; ignoring", profileName);
-        }
-        refreshPreview.run();
-    }
-
     public void customize() {
         if (profile == null) {
             throw new IllegalStateException("Cannot happen!");
@@ -158,11 +133,26 @@ public class ClientProfileSetup {
         return path;
     }
 
-    public void toggleWorldStyle() {
-        PackRepository repository = Minecraft.getInstance().getResourcePackRepository();
-        CloseableResourceManager resourceManager = new MultiPackResourceManager(PackType.SERVER_DATA, repository.openAllSelected());
-        Map<Identifier, Resource> map = resourceManager.listResources("urbex/worldstyles", s -> s.toString().endsWith(".json"));
-        List<String> styles = map.keySet().stream().map(ClientProfileSetup::worldStyleToName).collect(Collectors.toList());
+    /**
+     * Cycles the current profile's world style to the next one found under
+     * {@code urbex/worldstyles} in {@code repository}'s selected packs (issue #66).
+     * <p>
+     * {@code repository} is a parameter rather than always {@code Minecraft.getInstance()
+     * .getResourcePackRepository()} so the caller can prefer a more relevant pack list (e.g. the
+     * data packs enabled for the world being created) when one is reachable; see
+     * {@link UrbexConfigScreen}'s call site for the fallback.
+     */
+    public void toggleWorldStyle(PackRepository repository) {
+        List<String> styles;
+        try (CloseableResourceManager resourceManager = new MultiPackResourceManager(PackType.SERVER_DATA, repository.openAllSelected())) {
+            Map<Identifier, Resource> map = resourceManager.listResources("urbex/worldstyles", s -> s.toString().endsWith(".json"));
+            styles = map.keySet().stream().map(ClientProfileSetup::worldStyleToName).collect(Collectors.toList());
+        }
+        if (styles.isEmpty()) {
+            // No worldstyle jsons visible in the selected packs at all - nothing to cycle to.
+            refreshPreview.run();
+            return;
+        }
         String current = get().map(UrbexProfile::getWorldStyle).orElse("<none>");
         int idx = styles.indexOf(current);
         if (idx == -1) {

--- a/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.gui;
 
+import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.UrbexProfile;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
@@ -11,6 +12,8 @@ import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.ChunkPos;
@@ -19,6 +22,7 @@ import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Biomes;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Random;
@@ -94,11 +98,25 @@ public class NullDimensionInfo implements IDimensionInfo {
     private final Random random;
     private final long seed;
 
+    private final RegistryAccess registryAccess;
+    @Nullable
     private final Registry<Biome> biomeRegistry;
     private final CityGenerator feature;
     private final DimensionCaches caches;
 
+    /**
+     * @deprecated No registry access means {@link #getBiome} can't resolve a real biome and the
+     * {@code IDimensionInfo#registryAccess()}-gated rules in {@code City} (worldstyle city-chance
+     * multiplier, CITY_MINHEIGHT/MAXHEIGHT gating) stay off, same as before this constructor
+     * existed. Kept only so existing no-registry callers keep compiling; prefer
+     * {@link #NullDimensionInfo(UrbexProfile, long, RegistryAccess)}.
+     */
+    @Deprecated
     public NullDimensionInfo(UrbexProfile profile, long seed) {
+        this(profile, seed, null);
+    }
+
+    public NullDimensionInfo(UrbexProfile profile, long seed, @Nullable RegistryAccess registryAccess) {
         this.profile = profile;
         this.caches = new DimensionCaches(seed);
         style = new WorldStyle(new WorldStyleRE(
@@ -114,10 +132,8 @@ public class NullDimensionInfo implements IDimensionInfo {
         this.seed = seed;
         random = new Random(seed);
         feature = new CityGenerator(this, profile);
-        // @todo 1.19.3
-//        biomeRegistry = ServerLifecycleHooks.getCurrentServer().registryAccess().registryOrThrow(Registries.BIOME);
-//        biomeRegistry = RegistryAccess.builtinCopy().registry(Registry.BIOME_REGISTRY).get();
-        biomeRegistry = null;
+        this.registryAccess = registryAccess;
+        biomeRegistry = registryAccess != null ? registryAccess.lookupOrThrow(Registries.BIOME) : null;
     }
 
     @Override
@@ -128,6 +144,12 @@ public class NullDimensionInfo implements IDimensionInfo {
     @Override
     public WorldGenLevel getWorld() {
         return null;
+    }
+
+    @Nullable
+    @Override
+    public RegistryAccess registryAccess() {
+        return registryAccess;
     }
 
     @Override
@@ -219,8 +241,19 @@ public class NullDimensionInfo implements IDimensionInfo {
 //        return biomes;
 //    }
 
+    @Nullable
     @Override
     public Holder<Biome> getBiome(BlockPos pos) {
+        if (biomeRegistry == null) {
+            // #67: no registry access (the deprecated no-registry constructor) means there's no
+            // registry to resolve even a plains fallback from - dereferencing it unconditionally is
+            // what used to NPE here. Every caller currently reachable without registry access
+            // (BuildingInfo.getChunkCharacteristicsGui and friends) never dereferences this result:
+            // the registryAccess()-gated rules in City that do read biomes only run when we're not
+            // in this branch.
+            Urbex.LOGGER.warn("NullDimensionInfo.getBiome() called without registry access; returning null.");
+            return null;
+        }
         ChunkPos cp = ChunkPos.containing(pos);
         char b = getBiomeChar(cp.x(), cp.z());
         ResourceKey<Biome> biome = switch (b) {
@@ -233,6 +266,7 @@ public class NullDimensionInfo implements IDimensionInfo {
             // @todo 1.18
             case '*' -> Biomes.BEACH;
             case 'd' -> Biomes.DESERT;
+            // Plains fallback for anything unmapped, same as the old default branch.
             default -> Biomes.PLAINS;
         };
         return biomeRegistry.getOrThrow(biome);
@@ -240,6 +274,8 @@ public class NullDimensionInfo implements IDimensionInfo {
 
     @Override
     public ResourceKey<Level> dimension() {
-        return null;
+        // Agrees with getType(): both name the overworld. dimension() used to return null here,
+        // which disagreed with getType() and tripped up anything that assumed the two matched (#67).
+        return Level.OVERWORLD;
     }
 }

--- a/src/main/java/dev/krona/urbex/gui/PresetListWidget.java
+++ b/src/main/java/dev/krona/urbex/gui/PresetListWidget.java
@@ -1,0 +1,183 @@
+package dev.krona.urbex.gui;
+
+import dev.krona.urbex.config.UrbexProfile;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.Identifier;
+
+import javax.annotation.Nullable;
+import java.util.function.Consumer;
+
+/**
+ * The preset picker on the left of the Cities tab: one row per {@link PresetSelection.Entry},
+ * {@code disabled} first, customs last. Picking a row is the single place the player's choice is
+ * committed - it {@code select}s <em>and</em> {@code publish}es on {@link PresetSelection#CLIENT},
+ * because {@code select} alone never reaches world generation.
+ */
+public class PresetListWidget extends ObjectSelectionList<PresetListWidget.Row> {
+
+    /** Row height: a 20x20 icon plus 2px of breathing room above and below. */
+    public static final int ROW_HEIGHT = 24;
+
+    private static final int ICON_SIZE = 20;
+    private static final int ICON_TEXT_GAP = 4;
+
+    /**
+     * Source rect for the profile icons. The shipped {@code textures/gui/icon_*.png} are all
+     * 128x128 (verified with a PNG header dump over the whole directory), but the value only has
+     * to be self-consistent: {@code blit}'s UVs are {@code (u + uWidth) / texWidth}, so passing the
+     * same number as both the sampled size and the texture size always maps the full texture,
+     * whatever a datapack-supplied icon's real pixel size turns out to be.
+     */
+    private static final int ICON_TEXTURE_SIZE = 128;
+
+    private static final int FALLBACK_TILE_COLOR = 0xff2f2f2f;
+    private static final int FALLBACK_TILE_BORDER_COLOR = 0xff5f5f5f;
+    private static final int ROW_TEXT_COLOR = 0xffffffff;
+
+    private final Consumer<PresetSelection.Entry> onSelectionChanged;
+
+    /**
+     * Guards {@link #setSelected} while {@link #refreshEntries()} restores the already-committed
+     * selection: that is not the player choosing something, so it must not re-publish or reset the
+     * detail panel's scroll/preview state.
+     */
+    private boolean restoringSelection;
+
+    public PresetListWidget(Minecraft minecraft, int width, int height, int y,
+                            Consumer<PresetSelection.Entry> onSelectionChanged) {
+        super(minecraft, width, height, y, ROW_HEIGHT);
+        this.onSelectionChanged = onSelectionChanged;
+        this.centerListVertically = false;
+        refreshEntries();
+    }
+
+    /** Rebuilds the rows from {@link PresetSelection#CLIENT} and re-selects its current entry. */
+    public final void refreshEntries() {
+        restoringSelection = true;
+        try {
+            clearEntries();
+            String selectedId = PresetSelection.CLIENT.selected().id();
+            Row toSelect = null;
+            for (PresetSelection.Entry entry : PresetSelection.CLIENT.entries()) {
+                Row row = new Row(entry);
+                addEntry(row);
+                if (entry.id().equals(selectedId)) {
+                    toSelect = row;
+                }
+            }
+            if (toSelect != null) {
+                setSelected(toSelect);
+            }
+        } finally {
+            restoringSelection = false;
+        }
+    }
+
+    /**
+     * The one funnel for "a row became the selected one": vanilla routes both mouse clicks and
+     * arrow-key navigation through {@code setFocused}, which calls this (confirmed by decompiling
+     * {@code AbstractSelectionList.setFocused} / {@code ObjectSelectionList.nextFocusPath}).
+     * {@code null} - vanilla clearing the selection when focus leaves the list - is passed through
+     * but commits nothing.
+     */
+    @Override
+    public void setSelected(@Nullable Row row) {
+        Row previous = getSelected();
+        super.setSelected(row);
+        if (row == null || restoringSelection || row == previous) {
+            return;
+        }
+        PresetSelection.CLIENT.select(row.entry.id());
+        PresetSelection.CLIENT.publish();
+        onSelectionChanged.accept(row.entry);
+    }
+
+    @Override
+    public int getRowWidth() {
+        // Full column width minus the scrollbar gutter, instead of the vanilla fixed 220.
+        return Math.max(0, getWidth() - scrollbarWidth() - 4);
+    }
+
+    public class Row extends ObjectSelectionList.Entry<Row> {
+
+        private final PresetSelection.Entry entry;
+        private final Component label;
+        @Nullable
+        private final Identifier icon;
+
+        Row(PresetSelection.Entry entry) {
+            this.entry = entry;
+            this.label = buildLabel(entry);
+            this.icon = resolveIcon(entry);
+        }
+
+        public PresetSelection.Entry entry() {
+            return entry;
+        }
+
+        @Override
+        public Component getNarration() {
+            return label;
+        }
+
+        @Override
+        public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float partialTick) {
+            Font font = Minecraft.getInstance().font;
+            int left = getContentX();
+            int top = getContentY();
+            int iconY = top + Math.max(0, (getContentHeight() - ICON_SIZE) / 2);
+            renderIcon(graphics, left, iconY);
+
+            int textX = left + ICON_SIZE + ICON_TEXT_GAP;
+            int textY = top + Math.max(0, (getContentHeight() - font.lineHeight) / 2);
+            // Scissor rather than truncate: long preset names (a custom's "based on" suffix in
+            // particular) must not bleed out of the list column into the detail panel.
+            graphics.enableScissor(textX, top, getContentRight(), getContentBottom());
+            graphics.text(font, label, textX, textY, ROW_TEXT_COLOR);
+            graphics.disableScissor();
+        }
+
+        private void renderIcon(GuiGraphicsExtractor graphics, int x, int y) {
+            if (icon != null) {
+                graphics.blit(RenderPipelines.GUI_TEXTURED, icon, x, y, 0.0F, 0.0F,
+                        ICON_SIZE, ICON_SIZE, ICON_TEXTURE_SIZE, ICON_TEXTURE_SIZE, ICON_TEXTURE_SIZE, ICON_TEXTURE_SIZE);
+                return;
+            }
+            graphics.fill(x, y, x + ICON_SIZE, y + ICON_SIZE, FALLBACK_TILE_BORDER_COLOR);
+            graphics.fill(x + 1, y + 1, x + ICON_SIZE - 1, y + ICON_SIZE - 1, FALLBACK_TILE_COLOR);
+        }
+    }
+
+    static Component buildLabel(PresetSelection.Entry entry) {
+        if (!entry.custom()) {
+            return entry.name();
+        }
+        MutableComponent label = Component.translatable("urbex.preset.custom_prefix").append(entry.name());
+        if (entry.basedOn() != null && !entry.basedOn().isEmpty() && !PresetSelection.CUSTOM_ID.equals(entry.basedOn())) {
+            // basedOn == CUSTOM_ID is the "lineage unknown" marker (a customization restored from
+            // saved world data); dumping that marker at the player would say nothing.
+            label = label.append(Component.translatable("urbex.preset.custom_suffix", entry.basedOn()));
+        }
+        return label;
+    }
+
+    /**
+     * The profile's icon, or {@code null} when it has none or the texture is not actually shipped -
+     * blitting a missing {@link Identifier} would draw the magenta/black "missing texture"
+     * checkerboard, which reads as a bug rather than as "this preset has no art".
+     */
+    @Nullable
+    private static Identifier resolveIcon(PresetSelection.Entry entry) {
+        Identifier icon = entry.profile().map(UrbexProfile::getIcon).orElse(null);
+        if (icon == null) {
+            return null;
+        }
+        return Minecraft.getInstance().getResourceManager().getResource(icon).isPresent() ? icon : null;
+    }
+}

--- a/src/main/java/dev/krona/urbex/gui/PresetSelection.java
+++ b/src/main/java/dev/krona/urbex/gui/PresetSelection.java
@@ -112,8 +112,12 @@ public final class PresetSelection {
 
     /**
      * Restores a profile selection read from an existing world's saved data, for the vanilla
-     * Re-Create flow (issue #85). An unknown profile name is logged and leaves the current
-     * selection untouched, matching the old {@code ClientProfileSetup.restoreFromSavedData}.
+     * Re-Create flow (issue #85), and immediately {@link #publish()}es it. Publishing here (rather
+     * than waiting for the Cities tab to be opened) is what makes the restored choice actually
+     * reach the server if the player never opens that tab before creating the world - matching the
+     * old {@code ClientProfileSetup.restoreFromSavedData}, which called
+     * {@code UrbexConfigScreen.selectProfile} inline for exactly this reason. An unknown profile
+     * name is logged and leaves the current selection (and anything already published) untouched.
      */
     public void restore(String profileName, String json) {
         if (profileName == null || profileName.isEmpty()) {
@@ -123,11 +127,13 @@ public final class PresetSelection {
             UrbexProfile copy = new UrbexProfile(CUSTOM_ID, false);
             copy.copyFrom(new UrbexProfile(CUSTOM_ID, json));
             applyCustomized(copy, CUSTOM_ID);
+            publish();
             return;
         }
         UrbexProfile profile = ProfileSetup.STANDARD_PROFILES.get(profileName);
         if (profile != null) {
             selected = new Entry(profileName, Component.literal(profileName), false, "", Optional.of(profile));
+            publish();
         } else {
             Urbex.getLogger().warn("Re-created world used unknown Urbex profile '{}'; ignoring", profileName);
         }
@@ -135,14 +141,15 @@ public final class PresetSelection {
 
     /**
      * Publishes the current selection so it reaches world generation - the exact same contract as
-     * the old {@code UrbexConfigScreen.selectProfile}: set {@code Config.profileFromClient} (empty
-     * string for "disabled", meaning no profile override), bump the dirty counter, reset the
-     * profile cache, and for a customized profile also mirror it into
-     * {@code ProfileSetup.STANDARD_PROFILES} and {@code Config.jsonFromClient}.
+     * the old {@code UrbexConfigScreen.selectProfile}: set {@code Config.profileFromClient} ({@code
+     * null} for "disabled", meaning no profile override - verbatim what the old
+     * {@code ClientProfileSetup.getProfile()} produced), bump the dirty counter, reset the profile
+     * cache, and for a customized profile also mirror it into {@code ProfileSetup.STANDARD_PROFILES}
+     * and {@code Config.jsonFromClient}.
      */
     public void publish() {
         Entry entry = selected;
-        Config.profileFromClient = DISABLED_ID.equals(entry.id()) ? "" : entry.id();
+        Config.profileFromClient = DISABLED_ID.equals(entry.id()) ? null : entry.id();
 
         CityFeature.globalDimensionInfoDirtyCounter++;
         Config.resetProfileCache();

--- a/src/main/java/dev/krona/urbex/gui/PresetSelection.java
+++ b/src/main/java/dev/krona/urbex/gui/PresetSelection.java
@@ -1,0 +1,158 @@
+package dev.krona.urbex.gui;
+
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.config.ProfileSetup;
+import dev.krona.urbex.config.UrbexProfile;
+import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.worldgen.CityFeature;
+import net.minecraft.network.chat.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Client-side state for "which Urbex preset generates this world", replacing
+ * {@link ClientProfileSetup} for the redesigned Cities tab (Task 3 onwards). Pure state - nothing
+ * here touches widgets, so it's unit-testable headless. {@link ClientProfileSetup} stays alive
+ * for the old editor screen until Phase 2 of the redesign removes it.
+ * <p>
+ * Custom (hand-edited) profiles are never written into {@link ProfileSetup#STANDARD_PROFILES}
+ * by this class outside of {@link #publish()} - they live only in the selection itself, supplied
+ * by the future editor via {@link #applyCustomized}.
+ */
+public final class PresetSelection {
+
+    /** The shared client-side selection, mirroring {@link ClientProfileSetup#CLIENT_SETUP}. */
+    public static final PresetSelection CLIENT = new PresetSelection();
+
+    public static final String DISABLED_ID = "disabled";
+    public static final String CUSTOM_ID = "customized";
+
+    /**
+     * One selectable preset. {@code basedOn} is only meaningful when {@code custom} is true: it's
+     * the id of the public preset the customization started from, or {@link #CUSTOM_ID} itself
+     * when that origin isn't known (e.g. a customization restored from saved world data, which
+     * only carries the resulting JSON, not its lineage).
+     */
+    public record Entry(String id, Component name, boolean custom, String basedOn, Optional<UrbexProfile> profile) {
+    }
+
+    private static final Entry DISABLED_ENTRY =
+            new Entry(DISABLED_ID, Component.translatable("urbex.preset.disabled"), false, "", Optional.empty());
+
+    private Entry selected = DISABLED_ENTRY;
+    private UrbexProfile customProfile = null;
+    private String customBasedOn = "";
+
+    public PresetSelection() {
+    }
+
+    /**
+     * The full, current list of choices: {@code disabled} first, then public built-in presets
+     * ({@code default} first, then alphabetical - same ordering as the old
+     * {@code ClientProfileSetup.toggleProfile}), then the custom entry (if any) last.
+     */
+    public List<Entry> entries() {
+        List<Entry> result = new ArrayList<>();
+        result.add(DISABLED_ENTRY);
+
+        List<String> publicIds = new ArrayList<>();
+        for (Map.Entry<String, UrbexProfile> e : ProfileSetup.STANDARD_PROFILES.entrySet()) {
+            if (e.getValue().isPublic()) {
+                publicIds.add(e.getKey());
+            }
+        }
+        publicIds.sort((a, b) -> {
+            if ("default".equals(a)) {
+                return -1;
+            }
+            if ("default".equals(b)) {
+                return 1;
+            }
+            return a.compareTo(b);
+        });
+        for (String id : publicIds) {
+            result.add(new Entry(id, Component.literal(id), false, "", Optional.of(ProfileSetup.STANDARD_PROFILES.get(id))));
+        }
+
+        if (customProfile != null) {
+            result.add(new Entry(CUSTOM_ID, Component.translatable("urbex.preset.custom"), true, customBasedOn, Optional.of(customProfile)));
+        }
+        return result;
+    }
+
+    /** Selects the entry with the given id. Unknown ids (e.g. a stale id from a rebuilt list) are a no-op. */
+    public void select(String id) {
+        for (Entry entry : entries()) {
+            if (entry.id().equals(id)) {
+                selected = entry;
+                return;
+            }
+        }
+    }
+
+    public Entry selected() {
+        return selected;
+    }
+
+    /** Supplies a hand-edited profile from the (future) customize editor and selects it. */
+    public void applyCustomized(UrbexProfile copy, String basedOn) {
+        this.customProfile = copy;
+        this.customBasedOn = basedOn == null ? "" : basedOn;
+        select(CUSTOM_ID);
+    }
+
+    public void reset() {
+        selected = DISABLED_ENTRY;
+        customProfile = null;
+        customBasedOn = "";
+    }
+
+    /**
+     * Restores a profile selection read from an existing world's saved data, for the vanilla
+     * Re-Create flow (issue #85). An unknown profile name is logged and leaves the current
+     * selection untouched, matching the old {@code ClientProfileSetup.restoreFromSavedData}.
+     */
+    public void restore(String profileName, String json) {
+        if (profileName == null || profileName.isEmpty()) {
+            return;
+        }
+        if (json != null && !json.isEmpty()) {
+            UrbexProfile copy = new UrbexProfile(CUSTOM_ID, false);
+            copy.copyFrom(new UrbexProfile(CUSTOM_ID, json));
+            applyCustomized(copy, CUSTOM_ID);
+            return;
+        }
+        UrbexProfile profile = ProfileSetup.STANDARD_PROFILES.get(profileName);
+        if (profile != null) {
+            selected = new Entry(profileName, Component.literal(profileName), false, "", Optional.of(profile));
+        } else {
+            Urbex.getLogger().warn("Re-created world used unknown Urbex profile '{}'; ignoring", profileName);
+        }
+    }
+
+    /**
+     * Publishes the current selection so it reaches world generation - the exact same contract as
+     * the old {@code UrbexConfigScreen.selectProfile}: set {@code Config.profileFromClient} (empty
+     * string for "disabled", meaning no profile override), bump the dirty counter, reset the
+     * profile cache, and for a customized profile also mirror it into
+     * {@code ProfileSetup.STANDARD_PROFILES} and {@code Config.jsonFromClient}.
+     */
+    public void publish() {
+        Entry entry = selected;
+        Config.profileFromClient = DISABLED_ID.equals(entry.id()) ? "" : entry.id();
+
+        CityFeature.globalDimensionInfoDirtyCounter++;
+        Config.resetProfileCache();
+
+        if (entry.custom() && entry.profile().isPresent()) {
+            UrbexProfile profile = entry.profile().get();
+            ProfileSetup.STANDARD_PROFILES
+                    .computeIfAbsent(CUSTOM_ID, k -> new UrbexProfile(CUSTOM_ID, false))
+                    .copyFrom(profile);
+            Config.jsonFromClient = profile.toJson(false).toString();
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/gui/RecreateProfileRestore.java
+++ b/src/main/java/dev/krona/urbex/gui/RecreateProfileRestore.java
@@ -66,7 +66,7 @@ public final class RecreateProfileRestore {
         Pending p = pending;
         pending = null;
         if (p != null) {
-            ClientProfileSetup.CLIENT_SETUP.restoreFromSavedData(p.profile(), p.json());
+            PresetSelection.CLIENT.restore(p.profile(), p.json());
             Urbex.getLogger().info("Restored Urbex profile '{}' for world re-creation", p.profile());
         }
     }

--- a/src/main/java/dev/krona/urbex/gui/UrbexConfigScreen.java
+++ b/src/main/java/dev/krona/urbex/gui/UrbexConfigScreen.java
@@ -510,9 +510,34 @@ public class UrbexConfigScreen extends Screen {
             selectProfile(localSetup.getProfile(), null);
         }
 
+        syncToPresetSelection(customizedProfile);
+
         Minecraft.getInstance().gui.setScreen(parent);
         CityFeature.globalDimensionInfoDirtyCounter++;
         Config.resetProfileCache();
+    }
+
+    /**
+     * Mirrors what this (old) editor just committed into {@link PresetSelection}, so the Cities tab
+     * shows the same thing when the screen it returns to re-initialises. Phase 2 of the GUI
+     * redesign replaces this editor with one that edits {@code PresetSelection} directly and this
+     * bridge goes away with it; until then the two must not be allowed to disagree about which
+     * preset generates the world.
+     * <p>
+     * Only the selection is mirrored, never {@code publish()}ed: {@link #selectProfile} above has
+     * already written the identical {@code Config} state (see {@code PresetSelection.publish}).
+     */
+    private void syncToPresetSelection(@Nullable UrbexProfile customizedProfile) {
+        String profileName = localSetup.getProfile();
+        if ("customized".equals(profileName) && customizedProfile != null) {
+            // The old setup discards which preset a customization started from, so the lineage is
+            // recorded as "unknown" rather than invented.
+            PresetSelection.CLIENT.applyCustomized(customizedProfile, PresetSelection.CUSTOM_ID);
+        } else if (profileName == null) {
+            PresetSelection.CLIENT.select(PresetSelection.DISABLED_ID);
+        } else {
+            PresetSelection.CLIENT.select(profileName);
+        }
     }
 
     @Override

--- a/src/main/java/dev/krona/urbex/gui/UrbexConfigScreen.java
+++ b/src/main/java/dev/krona/urbex/gui/UrbexConfigScreen.java
@@ -15,6 +15,8 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.server.packs.repository.PackRepository;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -55,6 +57,19 @@ public class UrbexConfigScreen extends Screen {
         localSetup.copyFrom(ClientProfileSetup.CLIENT_SETUP);
     }
 
+    /**
+     * The pack list {@link ClientProfileSetup#toggleWorldStyle} scans for {@code urbex/worldstyles}
+     * jsons (issue #66). Ideally this would be the datapack repository the in-progress
+     * {@link CreateWorldScreen} is using (which can carry worldstyles from packs enabled just for
+     * the new world), but that repository is a private field with no public accessor in this MC
+     * version - there's no way to reach it here without reflection or a new Mixin, which this fix
+     * doesn't add. So this always falls back to the client's resource pack repository, which does
+     * still surface Urbex's own bundled worldstyles (Fabric merges mod jar resources into it).
+     */
+    private PackRepository worldStylePackRepository() {
+        return Minecraft.getInstance().getResourcePackRepository();
+    }
+
     public static void selectProfile(String profileName, @Nullable UrbexProfile profile) {
         Config.profileFromClient = profileName;
 
@@ -92,7 +107,7 @@ public class UrbexConfigScreen extends Screen {
         }).tooltip(Component.literal("Select a standard profile for Urbex worldgen")));
 
         worldstyleButton = addRenderableWidget(new ButtonExt(145, 10, 120, 20, Component.literal(localSetup.getWorldStyleLabel()), p -> {
-            localSetup.toggleWorldStyle();
+            localSetup.toggleWorldStyle(worldStylePackRepository());
             updateValues();
         }).tooltip(Component.literal("Select the worldstyle to use for this profile")));
 

--- a/src/main/java/dev/krona/urbex/gui/UrbexConfigScreen.java
+++ b/src/main/java/dev/krona/urbex/gui/UrbexConfigScreen.java
@@ -3,6 +3,7 @@ package dev.krona.urbex.gui;
 import dev.krona.urbex.config.UrbexProfile;
 import dev.krona.urbex.config.ProfileSetup;
 import dev.krona.urbex.gui.elements.*;
+import dev.krona.urbex.mixin.CreateWorldScreenAccessor;
 import dev.krona.urbex.setup.Config;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.CityFeature;
@@ -59,14 +60,21 @@ public class UrbexConfigScreen extends Screen {
 
     /**
      * The pack list {@link ClientProfileSetup#toggleWorldStyle} scans for {@code urbex/worldstyles}
-     * jsons (issue #66). Ideally this would be the datapack repository the in-progress
-     * {@link CreateWorldScreen} is using (which can carry worldstyles from packs enabled just for
-     * the new world), but that repository is a private field with no public accessor in this MC
-     * version - there's no way to reach it here without reflection or a new Mixin, which this fix
-     * doesn't add. So this always falls back to the client's resource pack repository, which does
-     * still surface Urbex's own bundled worldstyles (Fabric merges mod jar resources into it).
+     * jsons (issue #66). Prefers the datapack repository the in-progress {@link CreateWorldScreen}
+     * is using when {@code parent} is one - exposed via {@link CreateWorldScreenAccessor} since it's
+     * a private field on {@code CreateWorldScreen} - because that can carry worldstyles from packs
+     * enabled just for the new world. That repository is only populated once the player opens the
+     * "Data Packs" screen during creation, so this falls back to the client's resource pack
+     * repository (which still surfaces Urbex's own bundled worldstyles) whenever it's null or
+     * {@code parent} isn't a {@code CreateWorldScreen} at all.
      */
     private PackRepository worldStylePackRepository() {
+        if (parent instanceof CreateWorldScreen createWorldScreen) {
+            PackRepository fromScreen = ((CreateWorldScreenAccessor) createWorldScreen).urbex$getTempDataPackRepository();
+            if (fromScreen != null) {
+                return fromScreen;
+            }
+        }
         return Minecraft.getInstance().getResourcePackRepository();
     }
 

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -1,0 +1,191 @@
+package dev.krona.urbex.gui.preview;
+
+import com.mojang.blaze3d.platform.NativeImage;
+import dev.krona.urbex.config.UrbexProfile;
+import dev.krona.urbex.gui.NullDimensionInfo;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.lost.BuildingInfo;
+import dev.krona.urbex.worldgen.lost.ChunkCharacteristics;
+import dev.krona.urbex.worldgen.lost.City;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.levelgen.WorldOptions;
+
+import javax.annotation.Nullable;
+
+/**
+ * The world-creation city/building preview: a small (62x58) chunk-grid map sampled from a
+ * {@link NullDimensionInfo}, cached against the (profile, worldstyle, seed) that produced it so
+ * repeated {@link #update} calls while the player is merely dragging a slider don't recompute
+ * anything.
+ * <p>
+ * "Honest" relative to the old {@code UrbexConfigScreen.renderPreviewMap}: that preview always ran
+ * with {@code IDimensionInfo.getWorld() == null}, which silently skipped the worldstyle
+ * city-chance multiplier and the CITY_MINHEIGHT/MAXHEIGHT gate in {@code City.getCityFactor} (both
+ * guarded on {@code getWorld() != null}). This preview is built with real registry access, so those
+ * guards - now keyed on {@code registryAccess() != null} - evaluate the same rules a real dimension
+ * would (see {@code City.java} and {@code NullDimensionInfo} for the registry-access plumbing).
+ */
+public class CityPreview implements AutoCloseable {
+
+    public static final int WIDTH = NullDimensionInfo.PREVIEW_WIDTH;
+    public static final int HEIGHT = NullDimensionInfo.PREVIEW_HEIGHT;
+
+    private static final int LEGEND_HEIGHT = 10;
+    private static final int SWATCH_SIZE = 8;
+    private static final int SWATCH_GAP = 6;
+
+    private static final int CITY_COLOR = 0xff995555;
+    private static final int BUILDING_COLOR = 0xffffffff;
+    private static final int WATER_COLOR = 0xff000066;
+
+    private record Key(int profileJsonHash, String worldStyle, long seed) {}
+
+    @Nullable
+    private final RegistryAccess registryAccess;
+
+    private final int[] colors = new int[WIDTH * HEIGHT];
+
+    @Nullable
+    private Key key;
+    @Nullable
+    private DynamicTexture texture;
+
+    public CityPreview(@Nullable RegistryAccess registryAccess) {
+        this.registryAccess = registryAccess;
+    }
+
+    /**
+     * Recomputes the preview iff (profile JSON, worldStyle, seed) differs from the last call.
+     * {@code profile == null} clears whatever is showing (nothing selected yet).
+     */
+    public void update(@Nullable UrbexProfile profile, String worldStyle, long seed) {
+        if (profile == null) {
+            key = null;
+            closeTexture();
+            return;
+        }
+        int profileJsonHash = profile.toJson(false).toString().hashCode();
+        if (!needsRecompute(profileJsonHash, worldStyle, seed)) {
+            return;
+        }
+        recompute(profile, seed);
+    }
+
+    /**
+     * True (and remembers the new key) the first time this exact key is seen; false - no recompute
+     * needed - on every repeat. Package-visible so the cache behaviour is testable without a
+     * running game (no GL, no registries required).
+     */
+    boolean needsRecompute(int profileJsonHash, String worldStyle, long seed) {
+        Key newKey = new Key(profileJsonHash, worldStyle, seed);
+        if (newKey.equals(key)) {
+            return false;
+        }
+        key = newKey;
+        return true;
+    }
+
+    /**
+     * Vanilla's own rule for turning the seed text field into a long
+     * ({@code WorldOptions.parseSeed}): trim; blank means "no seed typed" (the fallback, normally a
+     * freshly-rolled random seed); a number parses as that number; anything else hashes.
+     */
+    public static long seedFromUi(String seedField, long fallbackRandom) {
+        return WorldOptions.parseSeed(seedField).orElse(fallbackRandom);
+    }
+
+    public void render(GuiGraphicsExtractor g, int x, int y, int w, int h) {
+        if (texture == null) {
+            renderUnavailable(g, x, y, w, h);
+            return;
+        }
+        int mapHeight = Math.max(0, h - LEGEND_HEIGHT);
+        g.blit(texture.getTextureView(), texture.getSampler(), x, y, w, mapHeight, 0f, 0f, 1f, 1f);
+        renderLegend(g, x, y + mapHeight, w);
+    }
+
+    @Override
+    public void close() {
+        closeTexture();
+    }
+
+    private void recompute(UrbexProfile profile, long seed) {
+        // The datapack-derived predefined-city/street maps are static (shared with real worldgen)
+        // and keyed only by chunk coord, not by profile - drop them so a new profile/seed combo
+        // doesn't see another profile's predefined content. Mirrors the old
+        // UrbexConfigScreen.refreshPreview().
+        City.cleanPredefinedCache();
+        NullDimensionInfo diminfo = new NullDimensionInfo(profile, seed, registryAccess);
+        for (int z = 0; z < HEIGHT; z++) {
+            for (int x = 0; x < WIDTH; x++) {
+                colors[z * WIDTH + x] = sampleColor(diminfo, x, z);
+            }
+        }
+        uploadTexture();
+    }
+
+    private static int sampleColor(NullDimensionInfo diminfo, int x, int z) {
+        char b = diminfo.getBiomeChar(x, z);
+        int terrainColor = switch (b) {
+            // '-' and '=' are the ocean/river water chars - same blue the old renderPreviewMap used.
+            case '-', '=' -> WATER_COLOR;
+            case '#' -> 0xff447744;
+            case '+' -> 0xff335533;
+            case '*', 'd' -> 0xffcccc55;
+            default -> 0xff005500;
+        };
+        ChunkCoord coord = new ChunkCoord(diminfo.dimension(), x, z);
+        ChunkCharacteristics characteristics = BuildingInfo.getChunkCharacteristicsGui(coord, diminfo);
+        if (characteristics.isCity) {
+            return BuildingInfo.hasBuildingGui(x, z, diminfo, characteristics) ? BUILDING_COLOR : CITY_COLOR;
+        }
+        return terrainColor;
+    }
+
+    private void uploadTexture() {
+        NativeImage image = new NativeImage(NativeImage.Format.RGBA, WIDTH, HEIGHT, false);
+        for (int z = 0; z < HEIGHT; z++) {
+            for (int x = 0; x < WIDTH; x++) {
+                image.setPixel(x, z, colors[z * WIDTH + x]);
+            }
+        }
+        DynamicTexture next = new DynamicTexture(() -> "urbex_city_preview", image);
+        closeTexture();
+        texture = next;
+    }
+
+    private void closeTexture() {
+        if (texture != null) {
+            texture.close();
+            texture = null;
+        }
+    }
+
+    private static void renderUnavailable(GuiGraphicsExtractor g, int x, int y, int w, int h) {
+        Font font = Minecraft.getInstance().font;
+        Component message = Component.translatable("urbex.preview.unavailable");
+        int textX = x + Math.max(0, (w - font.width(message)) / 2);
+        int textY = y + Math.max(0, (h - font.lineHeight) / 2);
+        g.text(font, message, textX, textY, 0xffaaaaaa);
+    }
+
+    private static void renderLegend(GuiGraphicsExtractor g, int x, int y, int w) {
+        Font font = Minecraft.getInstance().font;
+        int cx = x;
+        cx = renderSwatch(g, font, cx, y, CITY_COLOR, Component.translatable("urbex.preview.legend.city"));
+        cx = renderSwatch(g, font, cx, y, BUILDING_COLOR, Component.translatable("urbex.preview.legend.building"));
+        renderSwatch(g, font, cx, y, WATER_COLOR, Component.translatable("urbex.preview.legend.water"));
+    }
+
+    private static int renderSwatch(GuiGraphicsExtractor g, Font font, int x, int y, int color, Component label) {
+        g.fill(x, y, x + SWATCH_SIZE, y + SWATCH_SIZE, color);
+        int textX = x + SWATCH_SIZE + 2;
+        g.text(font, label, textX, y + 1, 0xffffffff);
+        return textX + font.width(label) + SWATCH_GAP;
+    }
+}

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -105,8 +105,14 @@ public class CityPreview implements AutoCloseable {
             return;
         }
         int mapHeight = Math.max(0, h - LEGEND_HEIGHT);
-        g.blit(texture.getTextureView(), texture.getSampler(), x, y, w, mapHeight, 0f, 0f, 1f, 1f);
-        renderLegend(g, x, y + mapHeight, w);
+        // blit(view, sampler, x0, y0, x1, y1, u0, u1, v0, v1): the int quartet is the *absolute end*
+        // corner (x1, y1), not a width/height - confirmed by decompiling BlitRenderState.getBounds,
+        // which builds its ScreenRectangle as (x0, y0, x1 - x0, y1 - y0). The float quartet groups
+        // as (u0, u1, v0, v1), not (u0, v0, u1, v1) - confirmed against GuiGraphicsExtractor's own
+        // internal 128x128 blit call, which passes (0, 0, 128, 128, 0.0F, 1.0F, 0.0F, 1.0F, -1) to
+        // this same innerBlit. Full-texture UVs are therefore (0, 1, 0, 1), not (0, 0, 1, 1).
+        g.blit(texture.getTextureView(), texture.getSampler(), x, y, x + w, y + mapHeight, 0f, 1f, 0f, 1f);
+        renderLegend(g, x, y + mapHeight);
     }
 
     @Override
@@ -174,7 +180,7 @@ public class CityPreview implements AutoCloseable {
         g.text(font, message, textX, textY, 0xffaaaaaa);
     }
 
-    private static void renderLegend(GuiGraphicsExtractor g, int x, int y, int w) {
+    private static void renderLegend(GuiGraphicsExtractor g, int x, int y) {
         Font font = Minecraft.getInstance().font;
         int cx = x;
         cx = renderSwatch(g, font, cx, y, CITY_COLOR, Component.translatable("urbex.preview.legend.city"));

--- a/src/main/java/dev/krona/urbex/mixin/CreateWorldScreenAccessor.java
+++ b/src/main/java/dev/krona/urbex/mixin/CreateWorldScreenAccessor.java
@@ -1,0 +1,25 @@
+package dev.krona.urbex.mixin;
+
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.server.packs.repository.PackRepository;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import javax.annotation.Nullable;
+
+/**
+ * Exposes {@code CreateWorldScreen}'s private {@code tempDataPackRepository} (issue #66): the
+ * repository of data packs enabled for the world currently being created, which is what
+ * {@code urbex/worldstyles} should really be scanned from - not the client's general resource
+ * pack repository, which knows nothing about packs a player enables just for this new world.
+ * <p>
+ * Nullable: the field is only populated once the player opens the "Data Packs" screen during
+ * creation; callers must fall back to the client resource pack repository when this is null.
+ */
+@Mixin(CreateWorldScreen.class)
+public interface CreateWorldScreenAccessor {
+
+    @Accessor("tempDataPackRepository")
+    @Nullable
+    PackRepository urbex$getTempDataPackRepository();
+}

--- a/src/main/java/dev/krona/urbex/mixin/CreateWorldScreenTabMixin.java
+++ b/src/main/java/dev/krona/urbex/mixin/CreateWorldScreenTabMixin.java
@@ -1,13 +1,19 @@
 package dev.krona.urbex.mixin;
 
 import dev.krona.urbex.gui.CitiesTab;
+import net.minecraft.client.gui.components.tabs.MenuTabBar;
 import net.minecraft.client.gui.components.tabs.Tab;
 import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Adds Urbex's {@link CitiesTab} to the vanilla world-creation screen's tab bar.
@@ -22,7 +28,11 @@ import java.util.Arrays;
  * failure rather than a tab that quietly stops existing.
  */
 @Mixin(CreateWorldScreen.class)
-public class CreateWorldScreenTabMixin {
+public abstract class CreateWorldScreenTabMixin {
+
+    @Shadow
+    @Nullable
+    private MenuTabBar tabNavigationBar;
 
     @ModifyArg(
             method = "init",
@@ -35,5 +45,29 @@ public class CreateWorldScreenTabMixin {
         Tab[] withCities = Arrays.copyOf(tabs, tabs.length + 1);
         withCities[tabs.length] = new CitiesTab((CreateWorldScreen) (Object) this);
         return withCities;
+    }
+
+    /**
+     * Puts the player back on the Cities tab after a trip to the Urbex editor.
+     * <p>
+     * Returning from that editor is a {@code setScreen(parent)}, which re-runs {@code init()} - and
+     * {@code init()}'s own tail calls {@code selectTab(0, false)}, i.e. the Game tab (verified by
+     * decompiling {@code init()}). Injecting after that call re-selects Cities, using exactly the
+     * API vanilla just used: {@code selectTab(int, boolean)} routes to
+     * {@code TabManager.setCurrentTab} as long as the bar is not focused, which it is not until
+     * {@code Screen.init(..)} calls {@code setInitialFocus()} after this.
+     */
+    @Inject(method = "init", at = @At("TAIL"))
+    private void urbex$reselectCitiesTab(CallbackInfo ci) {
+        if (!CitiesTab.consumeReopenOnCitiesTab() || tabNavigationBar == null) {
+            return;
+        }
+        List<Tab> tabs = tabNavigationBar.getTabs();
+        for (int i = 0; i < tabs.size(); i++) {
+            if (tabs.get(i) instanceof CitiesTab) {
+                tabNavigationBar.selectTab(i, false);
+                return;
+            }
+        }
     }
 }

--- a/src/main/java/dev/krona/urbex/mixin/CreateWorldScreenTabMixin.java
+++ b/src/main/java/dev/krona/urbex/mixin/CreateWorldScreenTabMixin.java
@@ -1,0 +1,39 @@
+package dev.krona.urbex.mixin;
+
+import dev.krona.urbex.gui.CitiesTab;
+import net.minecraft.client.gui.components.tabs.Tab;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import java.util.Arrays;
+
+/**
+ * Adds Urbex's {@link CitiesTab} to the vanilla world-creation screen's tab bar.
+ * <p>
+ * {@code CreateWorldScreen.init()} builds the bar in a single expression -
+ * {@code MenuTabBar.builder(tabManager, width).addTabs(new GameTab(), new WorldTab(), new MoreTab()).build()} -
+ * and stores the result straight into the {@code tabNavigationBar} field (verified by decompiling
+ * {@code init()}). There is no later point at which a tab can still be added, so this widens the
+ * varargs array on its way into {@code addTabs} rather than injecting at {@code TAIL}. {@code
+ * addTabs} takes exactly one (array) parameter, so {@code @ModifyArg} needs no index. The default
+ * {@code require = 1} from {@code urbex.mixins.json} makes a silently missed target a hard client
+ * failure rather than a tab that quietly stops existing.
+ */
+@Mixin(CreateWorldScreen.class)
+public class CreateWorldScreenTabMixin {
+
+    @ModifyArg(
+            method = "init",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/components/tabs/MenuTabBar$Builder;addTabs([Lnet/minecraft/client/gui/components/tabs/Tab;)Lnet/minecraft/client/gui/components/tabs/MenuTabBar$Builder;"
+            )
+    )
+    private Tab[] urbex$appendCitiesTab(Tab[] tabs) {
+        Tab[] withCities = Arrays.copyOf(tabs, tabs.length + 1);
+        withCities[tabs.length] = new CitiesTab((CreateWorldScreen) (Object) this);
+        return withCities;
+    }
+}

--- a/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
+++ b/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.setup;
 
 import dev.krona.urbex.gui.UrbexConfigScreen;
 import dev.krona.urbex.gui.ClientProfileSetup;
+import dev.krona.urbex.gui.PresetSelection;
 import dev.krona.urbex.gui.RecreateProfileRestore;
 import dev.krona.urbex.worldgen.CityFeature;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
@@ -42,6 +43,7 @@ public class ClientEventHandlers {
         // Clean up client-side state when leaving a world/server
         ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
             ClientProfileSetup.CLIENT_SETUP.reset();
+            PresetSelection.CLIENT.reset();
             Config.reset();
             CityFeature.globalDimensionInfoDirtyCounter++;
         });

--- a/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
+++ b/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
@@ -1,42 +1,31 @@
 package dev.krona.urbex.setup;
 
-import dev.krona.urbex.gui.UrbexConfigScreen;
 import dev.krona.urbex.gui.ClientProfileSetup;
 import dev.krona.urbex.gui.PresetSelection;
 import dev.krona.urbex.gui.RecreateProfileRestore;
 import dev.krona.urbex.worldgen.CityFeature;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
-import net.fabricmc.fabric.api.client.screen.v1.Screens;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
-import net.minecraft.network.chat.Component;
 
 public class ClientEventHandlers {
 
     private static java.lang.ref.WeakReference<CreateWorldScreen> lastCreateWorldScreen = null;
 
     public static void register() {
-        // Inject the "Cities" button into the world creation screen.
-        // (The decorative config icon that was blitted in ScreenEvent.Render.Post on NeoForge
-        // has been dropped; Fabric's screen API in 26.2 has no direct post-render hook.)
-        ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
+        // The Urbex entry point in world creation is the "Cities" tab (added by
+        // CreateWorldScreenTabMixin), not a button any more. What still has to happen here is the
+        // Re-Create handoff (issue #85): the stashed profile must be consumed once per genuinely
+        // new CreateWorldScreen - not on every rebuild of the same screen after a window resize.
+        // BEFORE_INIT, not AFTER_INIT: the tab (and with it the preset list's initial selection) is
+        // built inside CreateWorldScreen.init(), so the restore has to have landed in
+        // PresetSelection by then for a re-created world to show its profile pre-selected.
+        ScreenEvents.BEFORE_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
             if (screen instanceof CreateWorldScreen createWorldScreen) {
-                // A genuinely new screen, not a rebuild of the same one after a window resize:
-                // consume a profile stashed by the Re-Create flow (issue #85)
                 if (lastCreateWorldScreen == null || lastCreateWorldScreen.get() != createWorldScreen) {
                     lastCreateWorldScreen = new java.lang.ref.WeakReference<>(createWorldScreen);
                     RecreateProfileRestore.consumePending();
                 }
-                Button citiesButton = Button.builder(Component.literal("Cities"), b ->
-                        Minecraft.getInstance().gui.setScreen(new UrbexConfigScreen(createWorldScreen))
-                ).bounds(screen.width - 100, 40, 70, 20).build();
-                citiesButton.visible = false;
-                Screens.getWidgets(screen).add(citiesButton);
-                // Only show the button while the "More" tab is active
-                ScreenEvents.afterTick(screen).register(s ->
-                        citiesButton.visible = createWorldScreen.tabManager.getCurrentTab() instanceof CreateWorldScreen.MoreTab);
             }
         });
 

--- a/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
+++ b/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.setup;
 
+import dev.krona.urbex.gui.CitiesTab;
 import dev.krona.urbex.gui.ClientProfileSetup;
 import dev.krona.urbex.gui.PresetSelection;
 import dev.krona.urbex.gui.RecreateProfileRestore;
@@ -25,7 +26,16 @@ public class ClientEventHandlers {
                 if (lastCreateWorldScreen == null || lastCreateWorldScreen.get() != createWorldScreen) {
                     lastCreateWorldScreen = new java.lang.ref.WeakReference<>(createWorldScreen);
                     RecreateProfileRestore.consumePending();
+                    // A brand new screen, so any "come back on the Cities tab" request left over
+                    // from an editor trip the player abandoned (Escape out of the editor goes to
+                    // the title screen, not back here) is stale. A return from the editor re-inits
+                    // the *same* screen instance and so does not take this branch.
+                    CitiesTab.forgetReopenOnCitiesTab();
                 }
+                // The per-screen event holders are rebuilt on every init, immediately before
+                // BEFORE_INIT fires (fabric-screen-api ScreenMixin), so this re-registers cleanly
+                // rather than stacking up listeners across window resizes.
+                ScreenEvents.remove(createWorldScreen).register(s -> CitiesTab.closeActivePreview());
             }
         });
 

--- a/src/main/java/dev/krona/urbex/worldgen/IDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/IDimensionInfo.java
@@ -5,6 +5,7 @@ import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.WorldGenLevel;
@@ -27,6 +28,19 @@ public interface IDimensionInfo {
      * and the level would go looking for the rest.
      */
     WorldGenLevel getWorld();
+
+    /**
+     * Registry access for this dimension, or {@code null} if none is available. Real dimensions
+     * always have one (it comes straight off {@link #getWorld()}); {@code NullDimensionInfo} is the
+     * one implementor that can have registry access - and so be able to evaluate registry-backed
+     * worldgen rules - while still having no {@link WorldGenLevel} to hand out, which is what makes
+     * this a separate question from "is {@link #getWorld()} null".
+     */
+    @Nullable
+    default RegistryAccess registryAccess() {
+        WorldGenLevel world = getWorld();
+        return world != null ? world.registryAccess() : null;
+    }
 
     /** The per-dimension caches. Dropped with the dimension. */
     DimensionCaches caches();

--- a/src/main/java/dev/krona/urbex/worldgen/lost/City.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/City.java
@@ -345,8 +345,11 @@ public class City {
             }
         }
 
-        if (factor > 0.0001 && provider.getWorld() != null) {
-            // Check if the terrain is not too low or high for building
+        if (factor > 0.0001 && provider.registryAccess() != null) {
+            // Check if the terrain is not too low or high for building. Gated on registry access
+            // rather than a real WorldGenLevel so the world-creation preview (registry access
+            // present, world null) applies this too - real worldgen always has both, so this is
+            // unchanged there.
             ChunkHeightmap heightmap = provider.getHeightmap(coord);
             if (heightmap == null) {
                 return 0;
@@ -359,8 +362,8 @@ public class City {
             }
         }
 
-        if (factor > 0.0001 && provider.getWorld() != null) {
-            WorldStyle worldStyle = AssetRegistries.WORLDSTYLES.get(provider.getWorld(), profile.getWorldStyle());
+        if (factor > 0.0001 && provider.registryAccess() != null) {
+            WorldStyle worldStyle = AssetRegistries.WORLDSTYLES.get(provider.registryAccess(), profile.getWorldStyle());
             float multiplier = worldStyle.getCityChanceMultiplier(provider, coord);
             factor *= multiplier;
         }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/City.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/City.java
@@ -63,7 +63,11 @@ public class City {
 
     public static PredefinedCity getPredefinedCity(CommonLevelAccessor level, ChunkCoord coord) {
         AssetRegistries.loadPredefinedStuff(level);
-        if (!predefinedCityMapReady) {
+        // Guarded on level != null for the same reason as AssetRegistries.loadedPredefined (#67):
+        // a null level (the preview's NullDimensionInfo.getWorld()) means nothing was actually
+        // loaded above, so latching "ready" here would permanently stop a later real level from
+        // ever populating this map.
+        if (!predefinedCityMapReady && level != null) {
             for (PredefinedCity city : AssetRegistries.PREDEFINED_CITIES.getIterable()) {
                 PREDEFINED_CITY_MAP.put(new ChunkCoord(city.getDimension(), city.getChunkX(), city.getChunkZ()), city);
             }
@@ -97,13 +101,17 @@ public class City {
     }
 
     private static void calculateOccupied(IDimensionInfo provider) {
-        if (!occupiedBuildingReady) {
-            calculateMap(provider.getWorld());
+        WorldGenLevel world = provider.getWorld();
+        // Same level != null guard as getPredefinedCity above, and for the same reason: with a
+        // null world (the preview) these bodies run on whatever's currently in the datapack-derived
+        // maps - usually nothing yet - and must not latch "ready" over that.
+        if (!occupiedBuildingReady && world != null) {
+            calculateMap(world);
             for (Map.Entry<ChunkCoord, PredefinedBuilding> entry : PREDEFINED_BUILDING_MAP.entrySet()) {
                 PredefinedBuilding pb = entry.getValue();
                 ChunkCoord root = entry.getKey();
                 if (pb.multi()) {
-                    MultiBuilding building = AssetRegistries.MULTI_BUILDINGS.getOrThrow(provider.getWorld(), pb.building());
+                    MultiBuilding building = AssetRegistries.MULTI_BUILDINGS.getOrThrow(world, pb.building());
                     // Add all occupied chunkcoords for the building to the occupied set
                     for (int x = 0 ; x < building.getDimX() ; x++) {
                         for (int z = 0 ; z < building.getDimZ() ; z++) {
@@ -116,8 +124,8 @@ public class City {
             }
             occupiedBuildingReady = true;
         }
-        AssetRegistries.loadPredefinedStuff(provider.getWorld());
-        if (!occupiedStreetReady) {
+        AssetRegistries.loadPredefinedStuff(world);
+        if (!occupiedStreetReady && world != null) {
             for (PredefinedCity city : AssetRegistries.PREDEFINED_CITIES.getIterable()) {
                 for (PredefinedStreet street : city.getPredefinedStreets()) {
                     OCCUPIED_CHUNKS_STREET.put(new ChunkCoord(city.getDimension(),
@@ -130,7 +138,7 @@ public class City {
 
     private static void calculateMap(CommonLevelAccessor level) {
         AssetRegistries.loadPredefinedStuff(level);
-        if (!predefinedBuildingMapReady) {
+        if (!predefinedBuildingMapReady && level != null) {
             for (PredefinedCity city : AssetRegistries.PREDEFINED_CITIES.getIterable()) {
                 for (PredefinedBuilding building : city.getPredefinedBuildings()) {
                     PREDEFINED_BUILDING_MAP.put(new ChunkCoord(city.getDimension(),
@@ -143,7 +151,7 @@ public class City {
 
     public static PredefinedStreet getPredefinedStreet(CommonLevelAccessor level, ChunkCoord coord) {
         AssetRegistries.loadPredefinedStuff(level);
-        if (!predefinedStreetMapReady) {
+        if (!predefinedStreetMapReady && level != null) {
             for (PredefinedCity city : AssetRegistries.PREDEFINED_CITIES.getIterable()) {
                 for (PredefinedStreet street : city.getPredefinedStreets()) {
                     PREDEFINED_STREET_MAP.put(new ChunkCoord(city.getDimension(),

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetRegistries.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetRegistries.java
@@ -74,6 +74,12 @@ public class AssetRegistries {
         if (loadedPredefined) {
             return;
         }
+        if (level == null) {
+            // Nothing to load without a level (the world-creation preview, chiefly - its
+            // NullDimensionInfo.getWorld() is always null). Don't latch the "loaded" flag on a
+            // no-op: a real level arriving later must still get its predefined cities/spheres (#67).
+            return;
+        }
         PREDEFINED_CITIES.loadAll(level);
         PREDEFINED_SPHERES.loadAll(level);
         loadedPredefined = true;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryAssetRegistry.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryAssetRegistry.java
@@ -4,6 +4,7 @@ import dev.krona.urbex.Urbex;
 import dev.krona.urbex.worldgen.lost.regassets.IAsset;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.CommonLevelAccessor;
@@ -84,6 +85,45 @@ public class RegistryAssetRegistry<T, R> {
         }
         if (t instanceof CityStyle cs) {
             cs.init(level);
+        }
+        return t;
+    }
+
+    /**
+     * Same lookup as {@link #get(CommonLevelAccessor, Identifier)}, but for callers that only have
+     * registry access and no {@link CommonLevelAccessor} - the world-creation preview, chiefly, via
+     * {@code NullDimensionInfo}. Assets that need {@code CityStyle.init(level)} aren't supported
+     * through this path; none of the current preview call sites resolve a CityStyle this way.
+     */
+    @Nullable
+    public T get(RegistryAccess access, String name) {
+        if (name == null) {
+            return null;
+        }
+        return get(access, DataTools.fromName(name));
+    }
+
+    @Nullable
+    public T get(RegistryAccess access, Identifier name) {
+        if (access == null || name == null) {
+            return null;
+        }
+        T t = assets.get(name);
+        if (t == null) {
+            try {
+                Registry<R> registry = access.lookupOrThrow(registryKey);
+                R value = registry.getValueOrThrow(ResourceKey.create(registryKey, name));
+                if (value instanceof IAsset asset) {
+                    asset.setRegistryName(name);
+                }
+                t = assetConstructor.apply(value);
+            } catch (Exception e) {
+                throw new RuntimeException("Error getting resource " + name + "!", e);
+            }
+            T raced = assets.putIfAbsent(name, t);
+            if (raced != null) {
+                t = raced;
+            }
         }
         return t;
     }

--- a/src/main/resources/META-INF/urbex.accesswidener
+++ b/src/main/resources/META-INF/urbex.accesswidener
@@ -1,5 +1,5 @@
 accessWidener v2 official
 
-# CreateWorldScreen "Cities" button injection
-accessible field net/minecraft/client/gui/screens/worldselection/CreateWorldScreen tabManager Lnet/minecraft/client/gui/components/tabs/TabManager;
-accessible class net/minecraft/client/gui/screens/worldselection/CreateWorldScreen$MoreTab
+# Nothing is widened right now: the "Cities" entry point in world creation used to be a button
+# injected into the More tab (which needed CreateWorldScreen#tabManager and MoreTab), and is now a
+# real tab added through CreateWorldScreenTabMixin using only public API.

--- a/src/main/resources/assets/urbex/lang/en_us.json
+++ b/src/main/resources/assets/urbex/lang/en_us.json
@@ -2,5 +2,7 @@
   "urbex.preview.legend.city": "City",
   "urbex.preview.legend.building": "Building",
   "urbex.preview.legend.water": "Water",
-  "urbex.preview.unavailable": "No preview available"
+  "urbex.preview.unavailable": "No preview available",
+  "urbex.preset.disabled": "Disabled",
+  "urbex.preset.custom": "Custom"
 }

--- a/src/main/resources/assets/urbex/lang/en_us.json
+++ b/src/main/resources/assets/urbex/lang/en_us.json
@@ -1,0 +1,6 @@
+{
+  "urbex.preview.legend.city": "City",
+  "urbex.preview.legend.building": "Building",
+  "urbex.preview.legend.water": "Water",
+  "urbex.preview.unavailable": "No preview available"
+}

--- a/src/main/resources/assets/urbex/lang/en_us.json
+++ b/src/main/resources/assets/urbex/lang/en_us.json
@@ -1,8 +1,15 @@
 {
+  "urbex.tab.cities": "Cities",
   "urbex.preview.legend.city": "City",
   "urbex.preview.legend.building": "Building",
   "urbex.preview.legend.water": "Water",
   "urbex.preview.unavailable": "No preview available",
+  "urbex.preview.reroll": "⟳ New preview seed",
+  "urbex.preview.seed_locked": "The preview follows the world seed you typed. Clear the Seed field to roll preview seeds.",
   "urbex.preset.disabled": "Disabled",
-  "urbex.preset.custom": "Custom"
+  "urbex.preset.disabled.info": "Urbex leaves this world alone: no cities, no ruins, no highways.",
+  "urbex.preset.custom": "Custom",
+  "urbex.preset.custom_prefix": "✎ ",
+  "urbex.preset.custom_suffix": " (based on %s)",
+  "urbex.screen.customize": "Customize this preset…"
 }

--- a/src/main/resources/urbex.mixins.json
+++ b/src/main/resources/urbex.mixins.json
@@ -9,6 +9,7 @@
   ],
   "client": [
     "CreateWorldScreenAccessor",
+    "CreateWorldScreenTabMixin",
     "WorldListEntryMixin"
   ],
   "injectors": {

--- a/src/main/resources/urbex.mixins.json
+++ b/src/main/resources/urbex.mixins.json
@@ -8,6 +8,7 @@
     "StructureStartMixin"
   ],
   "client": [
+    "CreateWorldScreenAccessor",
     "WorldListEntryMixin"
   ],
   "injectors": {

--- a/src/test/java/dev/krona/urbex/gui/CitiesTabTest.java
+++ b/src/test/java/dev/krona/urbex/gui/CitiesTabTest.java
@@ -1,0 +1,72 @@
+package dev.krona.urbex.gui;
+
+import dev.krona.urbex.config.UrbexProfile;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextColor;
+import net.minecraft.network.chat.contents.TranslatableContents;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The detail panel is widget code, but the blurb it shows is a pure function of the selected entry:
+ * the old editor's three-part colouring (plain description, aqua extra, red warning) has to survive
+ * the move, and profiles that leave a part empty must not get a blank line for it.
+ */
+class CitiesTabTest {
+
+    private static PresetSelection.Entry entryFor(UrbexProfile profile) {
+        return new PresetSelection.Entry("test", Component.literal("test"), false, "", Optional.of(profile));
+    }
+
+    private static UrbexProfile profile(String description, String extra, String warning) {
+        UrbexProfile profile = new UrbexProfile("test", true);
+        profile.setDescription(description);
+        profile.setExtraDescription(extra);
+        profile.setWarning(warning);
+        return profile;
+    }
+
+    @Test
+    void theDisabledEntryExplainsItselfInsteadOfShowingAProfileBlurb() {
+        PresetSelection.Entry disabled = new PresetSelection.Entry(PresetSelection.DISABLED_ID,
+                Component.translatable("urbex.preset.disabled"), false, "", Optional.empty());
+        TranslatableContents contents = assertInstanceOf(TranslatableContents.class,
+                CitiesTab.describe(disabled).getContents());
+        assertEquals("urbex.preset.disabled.info", contents.getKey());
+    }
+
+    @Test
+    void aDescriptionOnlyProfileGetsNoExtraLines() {
+        Component described = CitiesTab.describe(entryFor(profile("Common cities", "", "")));
+        assertEquals("Common cities", described.getString());
+        assertTrue(described.getSiblings().isEmpty(), "empty extra/warning must not add blank lines");
+    }
+
+    @Test
+    void extraAndWarningKeepTheOldEditorsColours() {
+        Component described = CitiesTab.describe(entryFor(profile("Base", "Harder than it looks", "Needs a caves world")));
+        List<Component> siblings = described.getSiblings();
+        // description, then (newline, extra), then (newline, warning)
+        assertEquals(4, siblings.size());
+        assertEquals("Harder than it looks", siblings.get(1).getString());
+        assertEquals(TextColor.fromLegacyFormat(ChatFormatting.AQUA), siblings.get(1).getStyle().getColor());
+        assertEquals("Needs a caves world", siblings.get(3).getString());
+        assertEquals(TextColor.fromLegacyFormat(ChatFormatting.RED), siblings.get(3).getStyle().getColor());
+    }
+
+    @Test
+    void aWarningWithoutAnExtraDescriptionStillRenders() {
+        Component described = CitiesTab.describe(entryFor(profile("Base", "", "Careful")));
+        List<Component> siblings = described.getSiblings();
+        assertEquals(2, siblings.size(), "expected exactly one newline plus the warning");
+        assertEquals("Careful", siblings.get(1).getString());
+        assertEquals(TextColor.fromLegacyFormat(ChatFormatting.RED), siblings.get(1).getStyle().getColor());
+    }
+}

--- a/src/test/java/dev/krona/urbex/gui/CitiesTabTest.java
+++ b/src/test/java/dev/krona/urbex/gui/CitiesTabTest.java
@@ -5,12 +5,14 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.chat.contents.TranslatableContents;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,6 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the move, and profiles that leave a part empty must not get a blank line for it.
  */
 class CitiesTabTest {
+
+    @AfterEach
+    void clearReopenRequest() {
+        // Static one-shot flag; tests must not leak it into each other or into a later run.
+        CitiesTab.forgetReopenOnCitiesTab();
+    }
 
     private static PresetSelection.Entry entryFor(UrbexProfile profile) {
         return new PresetSelection.Entry("test", Component.literal("test"), false, "", Optional.of(profile));
@@ -68,5 +76,27 @@ class CitiesTabTest {
         assertEquals(2, siblings.size(), "expected exactly one newline plus the warning");
         assertEquals("Careful", siblings.get(1).getString());
         assertEquals(TextColor.fromLegacyFormat(ChatFormatting.RED), siblings.get(1).getStyle().getColor());
+    }
+
+    @Test
+    void noReopenIsRequestedUntilTheEditorIsOpened() {
+        assertFalse(CitiesTab.consumeReopenOnCitiesTab(),
+                "a plain Create World screen must not be redirected to the Cities tab");
+    }
+
+    @Test
+    void theReopenRequestIsConsumedExactlyOnce() {
+        // CreateWorldScreen.init() re-runs on every window resize, not only on the way back from
+        // the editor, so a request that stayed set would hijack the tab on every resize.
+        CitiesTab.requestReopenOnCitiesTab();
+        assertTrue(CitiesTab.consumeReopenOnCitiesTab());
+        assertFalse(CitiesTab.consumeReopenOnCitiesTab());
+    }
+
+    @Test
+    void aRequestBelongingToAnAbandonedEditorTripCanBeDropped() {
+        CitiesTab.requestReopenOnCitiesTab();
+        CitiesTab.forgetReopenOnCitiesTab();
+        assertFalse(CitiesTab.consumeReopenOnCitiesTab());
     }
 }

--- a/src/test/java/dev/krona/urbex/gui/ClientProfileSetupTest.java
+++ b/src/test/java/dev/krona/urbex/gui/ClientProfileSetupTest.java
@@ -1,0 +1,40 @@
+package dev.krona.urbex.gui;
+
+import dev.krona.urbex.config.ProfileSetup;
+import dev.krona.urbex.config.UrbexProfile;
+import net.minecraft.server.packs.repository.PackRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Covers issue #66: {@code toggleWorldStyle} used to crash with an {@link IndexOutOfBoundsException}
+ * whenever the scanned packs had no {@code urbex/worldstyles} jsons at all (styles.get(0) on an
+ * empty list, reached only once a profile is actually selected), and leaked the
+ * {@code MultiPackResourceManager} it opened on every call.
+ */
+class ClientProfileSetupTest {
+
+    private static final String TEST_PROFILE_ID = "toggle-worldstyle-test-profile";
+
+    @AfterEach
+    void cleanupProfile() {
+        ProfileSetup.STANDARD_PROFILES.remove(TEST_PROFILE_ID);
+    }
+
+    @Test
+    void toggleWorldStyleDoesNotCrashWhenNoWorldstylesAreVisible() {
+        ProfileSetup.STANDARD_PROFILES.put(TEST_PROFILE_ID, new UrbexProfile(TEST_PROFILE_ID, true));
+        ClientProfileSetup setup = new ClientProfileSetup(() -> {});
+        setup.setProfile(TEST_PROFILE_ID);
+
+        // No RepositorySource registered, so this repository has no available (and so no
+        // selected) packs - openAllSelected() is empty, and listResources("urbex/worldstyles", ...)
+        // therefore finds nothing. get().isPresent() is true (a profile is selected above), which
+        // is what used to reach the unguarded styles.get(0) on an empty list.
+        PackRepository emptyRepository = new PackRepository();
+
+        assertDoesNotThrow(() -> setup.toggleWorldStyle(emptyRepository));
+    }
+}

--- a/src/test/java/dev/krona/urbex/gui/PresetListWidgetTest.java
+++ b/src/test/java/dev/krona/urbex/gui/PresetListWidgetTest.java
@@ -1,0 +1,80 @@
+package dev.krona.urbex.gui;
+
+import dev.krona.urbex.config.UrbexProfile;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.contents.TranslatableContents;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The row widgets themselves need a running client to exercise, but the rule for what a row is
+ * <em>called</em> is pure and worth pinning: built-ins render their bare name, customs get the
+ * pencil prefix, and the "based on" suffix only appears when the lineage is actually known.
+ */
+class PresetListWidgetTest {
+
+    private static PresetSelection.Entry builtIn(String id) {
+        return new PresetSelection.Entry(id, Component.literal(id), false, "",
+                Optional.of(new UrbexProfile(id, true)));
+    }
+
+    private static PresetSelection.Entry custom(String basedOn) {
+        return new PresetSelection.Entry(PresetSelection.CUSTOM_ID, Component.translatable("urbex.preset.custom"),
+                true, basedOn, Optional.of(new UrbexProfile(PresetSelection.CUSTOM_ID, false)));
+    }
+
+    private static String keyOf(Component component) {
+        TranslatableContents contents = assertInstanceOf(TranslatableContents.class, component.getContents(),
+                "expected a translatable component, got: " + component);
+        return contents.getKey();
+    }
+
+    @Test
+    void builtInPresetsKeepTheirBareName() {
+        PresetSelection.Entry entry = builtIn("rare");
+        Component label = PresetListWidget.buildLabel(entry);
+        assertSame(entry.name(), label, "a built-in row must not decorate its name at all");
+    }
+
+    @Test
+    void customPresetsGetThePencilPrefix() {
+        Component label = PresetListWidget.buildLabel(custom("rare"));
+        assertEquals("urbex.preset.custom_prefix", keyOf(label));
+        List<Component> siblings = label.getSiblings();
+        assertEquals(2, siblings.size(), "expected name + based-on suffix after the prefix");
+        assertEquals("urbex.preset.custom", keyOf(siblings.get(0)));
+    }
+
+    @Test
+    void customPresetsNameTheBuiltInTheyStartedFrom() {
+        Component label = PresetListWidget.buildLabel(custom("rare"));
+        Component suffix = label.getSiblings().get(1);
+        assertEquals("urbex.preset.custom_suffix", keyOf(suffix));
+        TranslatableContents contents = (TranslatableContents) suffix.getContents();
+        assertEquals(1, contents.getArgs().length);
+        assertEquals("rare", contents.getArgs()[0]);
+    }
+
+    @Test
+    void customPresetsWithUnknownLineageGetNoSuffix() {
+        // PresetSelection uses CUSTOM_ID as the "restored from saved world data, origin unknown"
+        // marker; echoing that marker back at the player would say nothing.
+        Component label = PresetListWidget.buildLabel(custom(PresetSelection.CUSTOM_ID));
+        assertEquals(1, label.getSiblings().size(), "expected the name only, with no based-on suffix");
+        assertTrue(label.getSiblings().stream().noneMatch(c -> c.getContents() instanceof TranslatableContents t
+                && "urbex.preset.custom_suffix".equals(t.getKey())));
+    }
+
+    @Test
+    void customPresetsWithNoLineageGetNoSuffix() {
+        Component label = PresetListWidget.buildLabel(custom(""));
+        assertEquals(1, label.getSiblings().size(), "expected the name only, with no based-on suffix");
+    }
+}

--- a/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
+++ b/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.gui;
 
 import dev.krona.urbex.config.ProfileSetup;
 import dev.krona.urbex.config.UrbexProfile;
+import dev.krona.urbex.setup.Config;
 import net.minecraft.SharedConstants;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
@@ -14,13 +15,13 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * PresetSelection is pure state (no widgets), so it's exercised directly against a fresh instance
- * per test. STANDARD_PROFILES is a shared static map, so each test seeds it explicitly and restores
- * it afterwards rather than relying on production data (which would make these tests brittle to
- * unrelated profile changes).
+ * per test. STANDARD_PROFILES and Config are shared static state, so each test seeds/resets them
+ * explicitly rather than relying on production data or leftover state from other tests.
  */
 class PresetSelectionTest {
 
@@ -40,11 +41,14 @@ class PresetSelectionTest {
         ProfileSetup.STANDARD_PROFILES.put("alpha", new UrbexProfile("alpha", true));
         ProfileSetup.STANDARD_PROFILES.put("cavern", new UrbexProfile("cavern", true));
         ProfileSetup.STANDARD_PROFILES.put("hidden", new UrbexProfile("hidden", false));
+        ProfileSetup.STANDARD_PROFILES.put("rare", new UrbexProfile("rare", true));
+        Config.reset();
     }
 
     @AfterEach
     void clearProfiles() {
         ProfileSetup.STANDARD_PROFILES.clear();
+        Config.reset();
     }
 
     private static String keyOf(Component component) {
@@ -59,7 +63,7 @@ class PresetSelectionTest {
 
         List<String> ids = selection.entries().stream().map(PresetSelection.Entry::id).toList();
 
-        assertEquals(List.of("disabled", "default", "alpha", "cavern", "zeta"), ids);
+        assertEquals(List.of("disabled", "default", "alpha", "cavern", "rare", "zeta"), ids);
     }
 
     @Test
@@ -69,7 +73,7 @@ class PresetSelectionTest {
 
         List<String> ids = selection.entries().stream().map(PresetSelection.Entry::id).toList();
 
-        assertEquals(List.of("disabled", "default", "alpha", "cavern", "zeta", "customized"), ids);
+        assertEquals(List.of("disabled", "default", "alpha", "cavern", "rare", "zeta", "customized"), ids);
     }
 
     @Test
@@ -90,6 +94,16 @@ class PresetSelectionTest {
         selection.restore("totally-bogus-profile", "");
 
         assertEquals("cavern", selection.selected().id());
+    }
+
+    @Test
+    void restoreWithUnknownProfileLeavesConfigUnpublished() {
+        PresetSelection selection = new PresetSelection();
+
+        selection.restore("totally-bogus-profile", "");
+
+        assertNull(Config.profileFromClient);
+        assertNull(Config.jsonFromClient);
     }
 
     @Test
@@ -117,14 +131,38 @@ class PresetSelectionTest {
         assertTrue(selection.selected().profile().isPresent());
     }
 
+    /**
+     * Issue #85 regression: the Re-Create flow must reach the server even if the player never
+     * opens the Cities tab, so restore() has to publish immediately - not just update the
+     * in-memory selection for a screen that might never open.
+     */
     @Test
-    void disabledEntryPublishesEmptyProfileName() {
+    void restoreOfABuiltInProfilePublishesImmediately() {
+        PresetSelection selection = new PresetSelection();
+
+        selection.restore("rare", "");
+
+        assertEquals("rare", Config.profileFromClient);
+    }
+
+    @Test
+    void restoreWithJsonPublishesImmediately() {
+        PresetSelection selection = new PresetSelection();
+
+        selection.restore("customized", "{\"citychance\":0.9}");
+
+        assertEquals("customized", Config.profileFromClient);
+        assertTrue(Config.jsonFromClient != null && !Config.jsonFromClient.isEmpty());
+    }
+
+    @Test
+    void disabledEntryPublishesNullProfileNameMatchingTheOldContract() {
         PresetSelection selection = new PresetSelection();
         selection.select("cavern");
         selection.select("disabled");
 
         selection.publish();
 
-        assertEquals("", dev.krona.urbex.setup.Config.profileFromClient);
+        assertNull(Config.profileFromClient);
     }
 }

--- a/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
+++ b/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
@@ -1,0 +1,130 @@
+package dev.krona.urbex.gui;
+
+import dev.krona.urbex.config.ProfileSetup;
+import dev.krona.urbex.config.UrbexProfile;
+import net.minecraft.SharedConstants;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PresetSelection is pure state (no widgets), so it's exercised directly against a fresh instance
+ * per test. STANDARD_PROFILES is a shared static map, so each test seeds it explicitly and restores
+ * it afterwards rather than relying on production data (which would make these tests brittle to
+ * unrelated profile changes).
+ */
+class PresetSelectionTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        // publish() touches CityFeature, which extends the vanilla Feature<> registry base class -
+        // its class init needs the registries bootstrapped, same as other registry-touching tests.
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @BeforeEach
+    void seedProfiles() {
+        ProfileSetup.STANDARD_PROFILES.clear();
+        ProfileSetup.STANDARD_PROFILES.put("zeta", new UrbexProfile("zeta", true));
+        ProfileSetup.STANDARD_PROFILES.put("default", new UrbexProfile("default", true));
+        ProfileSetup.STANDARD_PROFILES.put("alpha", new UrbexProfile("alpha", true));
+        ProfileSetup.STANDARD_PROFILES.put("cavern", new UrbexProfile("cavern", true));
+        ProfileSetup.STANDARD_PROFILES.put("hidden", new UrbexProfile("hidden", false));
+    }
+
+    @AfterEach
+    void clearProfiles() {
+        ProfileSetup.STANDARD_PROFILES.clear();
+    }
+
+    private static String keyOf(Component component) {
+        assertTrue(component.getContents() instanceof TranslatableContents,
+                "expected a translatable component, got: " + component);
+        return ((TranslatableContents) component.getContents()).getKey();
+    }
+
+    @Test
+    void entriesAreOrderedDisabledFirstThenDefaultThenAlphabeticalPublics() {
+        PresetSelection selection = new PresetSelection();
+
+        List<String> ids = selection.entries().stream().map(PresetSelection.Entry::id).toList();
+
+        assertEquals(List.of("disabled", "default", "alpha", "cavern", "zeta"), ids);
+    }
+
+    @Test
+    void customEntrySortsLast() {
+        PresetSelection selection = new PresetSelection();
+        selection.applyCustomized(new UrbexProfile("customized", false), "default");
+
+        List<String> ids = selection.entries().stream().map(PresetSelection.Entry::id).toList();
+
+        assertEquals(List.of("disabled", "default", "alpha", "cavern", "zeta", "customized"), ids);
+    }
+
+    @Test
+    void selectUnknownIdIsNoOp() {
+        PresetSelection selection = new PresetSelection();
+        selection.select("cavern");
+
+        selection.select("nope");
+
+        assertEquals("cavern", selection.selected().id());
+    }
+
+    @Test
+    void restoreWithUnknownProfileLeavesSelectionUntouched() {
+        PresetSelection selection = new PresetSelection();
+        selection.select("cavern");
+
+        selection.restore("totally-bogus-profile", "");
+
+        assertEquals("cavern", selection.selected().id());
+    }
+
+    @Test
+    void restoreWithJsonProducesACustomEntryWithAGenericLabelNotTiedToTheBasedOnText() {
+        PresetSelection selection = new PresetSelection();
+
+        selection.restore("customized", "{\"citychance\":0.9}");
+
+        PresetSelection.Entry entry = selection.selected();
+        assertTrue(entry.custom());
+        assertEquals("customized", entry.id());
+        assertEquals("customized", entry.basedOn());
+        // The label must not just dump the internal basedOn marker ("customized") back at the
+        // player - it's a generic "Custom" label, independent of basedOn's value.
+        assertEquals("urbex.preset.custom", keyOf(entry.name()));
+    }
+
+    @Test
+    void restoreWithoutJsonSelectsTheNamedBuiltInProfile() {
+        PresetSelection selection = new PresetSelection();
+
+        selection.restore("cavern", "");
+
+        assertEquals("cavern", selection.selected().id());
+        assertTrue(selection.selected().profile().isPresent());
+    }
+
+    @Test
+    void disabledEntryPublishesEmptyProfileName() {
+        PresetSelection selection = new PresetSelection();
+        selection.select("cavern");
+        selection.select("disabled");
+
+        selection.publish();
+
+        assertEquals("", dev.krona.urbex.setup.Config.profileFromClient);
+    }
+}

--- a/src/test/java/dev/krona/urbex/gui/preview/CityPreviewKeyTest.java
+++ b/src/test/java/dev/krona/urbex/gui/preview/CityPreviewKeyTest.java
@@ -1,0 +1,32 @@
+package dev.krona.urbex.gui.preview;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The cache key and the seed-parsing rule are the two pieces of CityPreview that don't need a
+ * running game (no GL, no registries) to verify, so they're covered directly rather than through a
+ * full recompute.
+ */
+public class CityPreviewKeyTest {
+
+    @Test
+    public void needsRecomputeOnlyWhenTheKeyActuallyChanges() {
+        CityPreview preview = new CityPreview(null);
+
+        // A key seen for the first time always needs a recompute.
+        assertTrue(preview.needsRecompute(7, "standard", 42L));
+        // The exact same (profileJsonHash, worldStyle, seed) triple again: no-op.
+        assertFalse(preview.needsRecompute(7, "standard", 42L));
+    }
+
+    @Test
+    public void seedFromUiParsesNumericTextAsTheLongItself() {
+        // Vanilla's rule (WorldOptions.parseSeed): a numeric string is Long.parseLong'd, not hashed -
+        // "1337" must come back as the number 1337, not "1337".hashCode().
+        assertEquals(1337L, CityPreview.seedFromUi("1337", 999L));
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/CityPredefinedCacheLatchTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/CityPredefinedCacheLatchTest.java
@@ -1,0 +1,148 @@
+package dev.krona.urbex.worldgen.lost;
+
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.CommonLevelAccessor;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.WorldGenLevel;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for the "Important" review finding on Task 1: City's four static
+ * ready-flags (predefinedCityMapReady, predefinedBuildingMapReady, occupiedBuildingReady,
+ * occupiedStreetReady) must not latch to true off a preview call (a null level/world) - doing so
+ * would permanently stop a later real dimension from ever loading its predefined content, exactly
+ * the #67-style bug already fixed for AssetRegistries.loadedPredefined.
+ * <p>
+ * AssetRegistries.loadedPredefined is forced true in {@link #resetState()} so that every call here
+ * reaches City's own guard directly, without needing real datapack-registered
+ * PredefinedCity/PredefinedSphere content just to exercise the flag logic in isolation.
+ * <p>
+ * Bootstrapped ({@link Bootstrap#bootStrap()}) because {@code ChunkCoord}/{@code Level.OVERWORLD}
+ * and the vanilla registries City touches need it; done in {@code @BeforeAll} rather than a static
+ * field so it runs before any class - including this one - references {@code Level}.
+ */
+class CityPredefinedCacheLatchTest {
+
+    private ChunkCoord coord;
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @BeforeEach
+    void resetState() throws Exception {
+        coord = new ChunkCoord(Level.OVERWORLD, 3, 4);
+        City.cleanPredefinedCache();
+        setStaticBoolean(AssetRegistries.class, "loadedPredefined", true);
+    }
+
+    @Test
+    void nullLevelDoesNotLatchPredefinedCityMapReady() throws Exception {
+        City.getPredefinedCity(null, coord);
+        assertFalse(getStaticBoolean(City.class, "predefinedCityMapReady"),
+                "a preview call (null level) must not latch the ready flag");
+
+        City.getPredefinedCity(harmlessLevel(), coord);
+        assertTrue(getStaticBoolean(City.class, "predefinedCityMapReady"),
+                "a real level must still be able to latch it afterwards");
+    }
+
+    @Test
+    void nullLevelDoesNotLatchPredefinedBuildingMapReady() throws Exception {
+        City.getPredefinedBuildingAtTopLeft(null, coord);
+        assertFalse(getStaticBoolean(City.class, "predefinedBuildingMapReady"),
+                "a preview call (null level) must not latch the ready flag");
+
+        City.getPredefinedBuildingAtTopLeft(harmlessLevel(), coord);
+        assertTrue(getStaticBoolean(City.class, "predefinedBuildingMapReady"),
+                "a real level must still be able to latch it afterwards");
+    }
+
+    @Test
+    void nullLevelDoesNotLatchPredefinedStreetMapReady() throws Exception {
+        City.getPredefinedStreet((CommonLevelAccessor) null, coord);
+        assertFalse(getStaticBoolean(City.class, "predefinedStreetMapReady"),
+                "a preview call (null level) must not latch the ready flag");
+
+        City.getPredefinedStreet(harmlessLevel(), coord);
+        assertTrue(getStaticBoolean(City.class, "predefinedStreetMapReady"),
+                "a real level must still be able to latch it afterwards");
+    }
+
+    @Test
+    void nullWorldDoesNotLatchOccupiedBuildingOrStreetReady() throws Exception {
+        City.isChunkOccupied(fakeProvider(null), coord);
+        assertFalse(getStaticBoolean(City.class, "occupiedBuildingReady"),
+                "a preview call (null world) must not latch the ready flag");
+        assertFalse(getStaticBoolean(City.class, "occupiedStreetReady"),
+                "a preview call (null world) must not latch the ready flag");
+
+        City.isChunkOccupied(fakeProvider(harmlessLevel()), coord);
+        assertTrue(getStaticBoolean(City.class, "occupiedBuildingReady"),
+                "a real world must still be able to latch it afterwards");
+        assertTrue(getStaticBoolean(City.class, "occupiedStreetReady"),
+                "a real world must still be able to latch it afterwards");
+    }
+
+    private static void setStaticBoolean(Class<?> owner, String field, boolean value) throws Exception {
+        Field f = owner.getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    private static boolean getStaticBoolean(Class<?> owner, String field) throws Exception {
+        Field f = owner.getDeclaredField(field);
+        f.setAccessible(true);
+        return f.getBoolean(null);
+    }
+
+    /**
+     * A non-null CommonLevelAccessor/WorldGenLevel that's never actually invoked here:
+     * AssetRegistries.loadedPredefined is forced true above, so AssetRegistries.loadPredefinedStuff
+     * short-circuits before touching it, and City's own guarded bodies only read from the
+     * (empty, but present) AssetRegistries iterables - only its non-nullness matters for this test.
+     */
+    private static WorldGenLevel harmlessLevel() {
+        return (WorldGenLevel) Proxy.newProxyInstance(
+                WorldGenLevel.class.getClassLoader(),
+                new Class<?>[]{WorldGenLevel.class},
+                (proxy, method, args) -> {
+                    throw new AssertionError("Unexpected call to " + method + " - AssetRegistries.loadedPredefined "
+                            + "should have short-circuited before any level method was needed");
+                });
+    }
+
+    private static IDimensionInfo fakeProvider(WorldGenLevel world) {
+        return (IDimensionInfo) Proxy.newProxyInstance(
+                IDimensionInfo.class.getClassLoader(),
+                new Class<?>[]{IDimensionInfo.class},
+                (proxy, method, args) -> {
+                    if ("getWorld".equals(method.getName())) {
+                        return world;
+                    }
+                    if (method.getDeclaringClass() == Object.class) {
+                        return switch (method.getName()) {
+                            case "toString" -> "fake-provider";
+                            case "hashCode" -> System.identityHashCode(proxy);
+                            case "equals" -> proxy == args[0];
+                            default -> null;
+                        };
+                    }
+                    throw new AssertionError("Unexpected call to " + method + " on the fake IDimensionInfo");
+                });
+    }
+}


### PR DESCRIPTION
Phase 1 of the world-creation GUI redesign (spec + plan in `docs/superpowers/specs/2026-08-10-gui-redesign-design.md` / `docs/superpowers/plans/2026-08-10-gui-redesign.md`). Closes #66, closes #67, closes #68.

This is a **stacked, phased** delivery: Phase 1 adds the real Cities tab and fixes the preview/selection bugs while "Customize this preset…" still opens the *existing* editor. Phase 2 (same branch, follow-up commits) replaces that editor with the metadata-driven one and closes #64/#65.

## What's in Phase 1
- **Cities tab** in Create New World (client mixin `@ModifyArg` on `MenuTabBar$Builder.addTabs` — verified byte-identical to the mapped jar; `require=1`). The old More-tab injected button is deleted. The tab is the state display: selected preset, icon, description, warning, live preview, and "based on X" for customs are always visible.
- **Preset list** (`ObjectSelectionList`) — Disabled first, public built-ins (18 shipped icons now rendered), customs last; selecting publishes via `PresetSelection.CLIENT`.
- **Honest cached preview** (#67, #68): uses the real world seed when set (reroll button disabled+tooltip when the seed is fixed); worldstyle multiplier and height gating now apply in-preview; one `NullDimensionInfo`/texture per (config, seed) instead of a per-frame rebuild; released on screen close (no leaked texture or pinned world RegistryAccess); 3-swatch legend.
- **#66**: `toggleWorldStyle` leak/crash fixed (try-with-resources, empty guard) and now sources the world's own datapacks via a `CreateWorldScreen` `@Accessor`.
- **Re-Create** (#85) retargeted to the new selection state and publishes immediately, so a restored profile reaches the server even without opening the tab.

## Verification
- `./gradlew build` green; **21 new headless tests** across the 3 tasks (preview cache key + seed rule, City predefined-cache latching, PresetSelection ordering/publish/restore, worldstyle #66 regression) — all mutation-checked, not vacuous.
- `./gradlew runDigestCheck` → `URBEX-DIGEST-CHECK: OK DRIVERDIGEST=8d354d804f08f12a`, unchanged — this is all client-side, worldgen is byte-identical.
- **Runtime**: the dev client boots cleanly — the `require=1` tab mixin applies without the hard-crash that a wrong target would cause, confirming the injection point at runtime.
- Every vanilla API touched was `javap`-verified against the mapped 26.2 jar (blit semantics, tab-bar builder, `WorldCreationUiState.getSeed`, the `@Accessor` field, `selectTab`), and each task passed an adversarial review + fix round.

**Pending on my side:** I could not capture in-game screenshots (the dev client's process resolves only as `java`, which macOS screen-control can't target here). A 30-second visual pass — tab shows at GUI scale 4, selecting a preset updates the preview, fixed seed disables reroll — would be worth doing before merge; everything it would check is statically verified but not eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)