### PR TITLE
fix(data): replace Forge tag #forge:stone with Fabric convention #c:stones

### DIFF
--- a/src/main/resources/data/urbex/urbex/stuff/example.json
+++ b/src/main/resources/data/urbex/urbex/stuff/example.json
@@ -15,7 +15,7 @@
   },
   "blocks": {
     "if_any": [
-      "#forge:stone",
+      "#c:stones",
       "minecraft:andesite"
     ]
   },


### PR DESCRIPTION
## Summary
- `src/main/resources/data/urbex/urbex/stuff/example.json` still referenced the Forge block tag `#forge:stone` in its `blocks.if_any` matcher — Forge tags don't exist on Fabric, so the matcher entry silently matched nothing.
- Replaced with `#c:stones`, the Fabric convention tag. Verified `data/c/tags/block/stones.json` ships in the exact Fabric API version this build uses (fabric-convention-tags-v2 inside fabric-api 0.155.2+26.2) and covers the same "any stone" intent (stone, granite, diorite, andesite, tuff).
- This was the only `#forge:` reference in the whole `data/urbex/` datapack.

## Verification
- `./gradlew build` — passed
- `./gradlew runDigestCheck` — `URBEX-DIGEST-CHECK: OK`, `digest.golden` unchanged (the example stuff is seesky-gated and doesn't affect the digest scene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)