### PR TITLE
docs(build): correct two stale claims about the digest check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,10 +55,14 @@ loom {
             ideConfigGenerated(false)
             runDir('runs/digestcheck')
             vmArg '-Durbex.digestCheck=3,rowmajor,100'
-            // Single worker thread: parallel chunk generation is not yet run-to-run
-            // deterministic (issue #24 - shared mutable ChunkHeightmap and friends), so the
-            // regression pin is taken on a serial baseline. Lifting this flag - two parallel
-            // runs agreeing - is the acceptance test for fixing #24.
+            // This runs on the parallel path, deliberately. Generation used to be pinned to one
+            // core here with -XX:ActiveProcessorCount=1, because a chunk's decoration step could
+            // run before or after its neighbours' passes and output was not run-to-run
+            // reproducible (issue #18). Moving city generation to the tail of applyCarvers fixed
+            // that; 15dba5f2 removed the pin and ran #18's acceptance test - three parallel fresh
+            // runs and one shuffled-order run all agreeing. So this check has been exercising
+            // concurrent generation ever since, which is the point: a regression that only shows
+            // up under worker scheduling has to be able to reach it.
             // Pinned DRIVERDIGEST for seed 1337; regenerate deliberately on world-changing
             // changes by deleting the file, running runDigestCheck twice (results must match)
             // and committing the new value.
@@ -104,9 +108,11 @@ loom {
 }
 
 // A fresh, fully pinned dedicated-server environment for every digest run: fixed seed, default
-// (noise) world type, the 'default' urbex profile on the overworld, and no watchdog (the check
-// generates its whole chunk square on the server thread). Shared by every digest run config, each
-// against its own run directory so the two checks cannot clobber each other's world.
+// (noise) world type, the 'default' urbex profile on the overworld, and no watchdog. The watchdog
+// is off because DigestRunner drives its whole chunk square from the server thread in one blocking
+// loop, holding that thread far past max-tick-time; the generation itself still fans out to the
+// worker pool, so this is not a serial baseline. Shared by every digest run config, each against
+// its own run directory so the two checks cannot clobber each other's world.
 def registerPrepareDigestCheck = { String taskName, String runDirPath ->
     tasks.register(taskName) {
         notCompatibleWithConfigurationCache("writes the run directory")


### PR DESCRIPTION
Closes #102.

`15dba5f2` removed `-XX:ActiveProcessorCount=1` and ran #18's acceptance test — three parallel fresh runs and one shuffled-order run all agreeing — but only half-rewrote the comment above it. The surviving text still opened "Single worker thread", still instructed the reader to lift a flag that same commit deleted, and attributed it to #24 rather than #18.

The `prepareDigestCheck` comment was wrong the other way: it said the check "generates its whole chunk square on the server thread", which reads as a serial baseline. Run logs show seven or more `Worker-Main` threads generating. What holds the server thread is `DigestRunner`'s blocking request loop — the actual reason the watchdog is off.

Re-confirmed on merged `main` before rewriting. Same window and seed; the digest hashes in canonical sorted order, so only *generation* order can affect it:

| Order | Digest |
|---|---|
| `rowmajor` | `1be5211b0009554d` |
| `reverse` | `1be5211b0009554d` |
| `shuffled` | `1be5211b0009554d` |

Comments only — no build or generation behaviour changes. Digest verified green after the edit.

## Not included

CI runs `rowmajor` only. The shuffled-order run that proved order-independence was a one-off in `15dba5f2` and is not repeated anywhere. A third run configuration using `shuffled` against the same `digest.golden` would make order-independence a standing check rather than a result from August, at one extra server boot on the cheap 49-chunk window. Left out of this PR as a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)