### PR TITLE
feat: let a world style name its own rotatable block tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **A world style can name its own `rotatable` block tag.** New optional `rotatable` field on
+  `worldstyles`, holding a `#`-prefixed block tag id; `CityGenerator.transformBlockState` reads the
+  resolved tag from the active world style instead of the hardcoded `UrbexTags.ROTATABLE_TAG`. A
+  chain that declares none resolves `urbex:rotatable`, so nothing that already exists changes
+  meaning.
+  - *Why.* Previously the only way for a pack to widen the rotatable set was to ship
+    `data/urbex/tags/block/rotatable.json`, and a tag file in Urbex's namespace merges into
+    `urbex:rotatable` itself — so it took effect in **every** world style, including
+    `urbex:standard`, whether or not the player selected that pack's style. A pack whose palettes
+    place directional banners, trapdoors or ladders had to choose between shipping mis-facing blocks
+    and changing stock generation for everyone.
+  - *Replaces rather than merges.* A pack that wants Urbex's own set writes `"#urbex:rotatable"` into
+    its own tag's `values`. Tags reference tags across namespaces, so nothing is lost and the
+    composition is visible in data rather than implied by a merge rule.
+  - *Not `TagKey.hashedCodec`.* It decodes the same `#ns:path` shape, but parses the remainder with
+    `Identifier.read`, so `"#rotatable"` would silently become `minecraft:rotatable`. The new
+    `DataTools.BLOCK_TAG_CODEC` goes through `DataTools.fromName`, making an unqualified tag
+    reference the same load error as any other unqualified reference.
+  - *Both goldens unchanged.* `digest.golden` (`eb6253f3f5363937`) and `digest-features.golden`
+    (`203d8a44769da0c7`) are byte-identical after the change. The styles those runs exercise declare
+    no `rotatable`, so an identical digest across 849k and 4.6M placed blocks is the evidence that
+    the default path is untouched.
+
 - **Open lots generate at street level, not one block above it.** `urbex:default` now sets
   `roads.parkElevation: false`. Reported from a live world: a raised lot next to a building stands a
   one-block lip directly across the doorway, so the door opens into a wall of dirt. The same

--- a/docs/datapacks.md
+++ b/docs/datapacks.md
@@ -34,7 +34,7 @@ string every other file uses to name it. Directory names are the registry names 
 
 | Registry | What one file is | Required after the chain resolves |
 |---|---|---|
-| `worldstyles` | The top of the tree: which city styles apply in which biomes, the highway and railway wiring, and what gets scattered outside cities | `outsidestyle`, `citystyles`, `parts.highways` (all six), `parts.railways` (all sixteen) |
+| `worldstyles` | The top of the tree: which city styles apply in which biomes, the highway and railway wiring, what gets scattered outside cities, and which blocks rotate with their part | `outsidestyle`, `citystyles`, `parts.highways` (all six), `parts.railways` (all sixteen) — `rotatable` is optional |
 | `citystyles` | What a city is made of: street materials and street parts, plus weighted selectors for buildings, parks, bridges, fountains, stairs | `streetblocks.parts` (all eight) |
 | `buildings` | An ordered stack of parts, with floor and cellar limits | `filler`, `parts` |
 | `parts` | A block of geometry, up to 16×16, written as character slices | `xsize`, `zsize`, `slices` |
@@ -142,6 +142,46 @@ error is worded that way on purpose — the fix might be in any file in it.
 One consequence worth knowing: a value that is present but malformed is still a decode failure, not
 an absence. `"maxfloors": "three"` fails the file; it does not read as "unset" and silently inherit
 an ancestor's number.
+
+### `rotatable`: which blocks turn with their part
+
+A part placed at a rotation only turns the blocks named by a block tag; everything else keeps the
+facing its palette entry authored. That tag is `urbex:rotatable` unless the world style names
+another:
+
+<!-- example: worldstyles -->
+
+```json
+{
+  "outsidestyle": "urbex:outside",
+  "rotatable": "#mypack:rotatable"
+}
+```
+
+Written with the leading `#`, like every other tag reference, and fully qualified — `#rotatable` is
+a load error, not `minecraft:rotatable`. Like `outsidestyle`, it is a scalar: the last entry in the
+chain that declares one wins, and a chain declaring none resolves `urbex:rotatable`.
+
+**Declaring it replaces; it does not merge.** To keep Urbex's own set, name it from your own tag —
+this one is an ordinary Minecraft block tag at `data/mypack/tags/block/rotatable.json`, not a
+registry asset:
+
+<!-- example: none -->
+
+```json
+{
+  "values": [
+    "#urbex:rotatable",
+    "#minecraft:trapdoors",
+    "minecraft:ladder"
+  ]
+}
+```
+
+The alternative is shipping `data/urbex/tags/block/rotatable.json`, which merges into
+`urbex:rotatable` itself and therefore changes **every** world style including `urbex:standard`,
+whether or not the player selected yours. That is why this field exists: a pack that needs banners
+or trapdoors to rotate should be able to say so without reaching into Urbex's namespace.
 
 ### When each asset is resolved
 

--- a/docs/superpowers/plans/2026-08-12-worldstyle-rotatable-tag.md
+++ b/docs/superpowers/plans/2026-08-12-worldstyle-rotatable-tag.md
@@ -1,0 +1,532 @@
+# World Style `rotatable` Tag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a world style name the block tag that decides which blocks rotate with their part, instead of every world style sharing the hardcoded `urbex:rotatable`.
+
+**Architecture:** A new optional `rotatable` field on `WorldStyleRE`, holding a `#namespace:path` block tag reference. `WorldStyle` folds it along the `extends` chain exactly as `outsidestyle` is folded, defaulting to `urbex:rotatable` when nothing in the chain declares one. `CityGenerator.transformBlockState` reads the resolved `TagKey<Block>` from the active world style rather than the constant.
+
+**Tech Stack:** Java 25, Minecraft 26.2, Fabric Loom 1.17.17, Mojang DataFixerUpper codecs, JUnit 5.
+
+## Global Constraints
+
+- Minecraft `26.2`, Fabric Loader `0.19.3`, Java `25` — from `gradle.properties`; do not change them.
+- **`digest.golden` and `digest-features.golden` must be byte-identical after this change.** They are the evidence that stock generation is untouched. If either moves, the change is wrong — do not accept a new golden.
+- The field is **optional**. No existing asset, in this repo or any datapack, may change meaning.
+- Every datapack reference names its namespace. A bare id is a load error, never a `minecraft:` default — see `DataTools.fromName`.
+- Work on branch `feature/worldstyle-rotatable-tag`, never on `main`.
+- Commit messages: imperative mood, lowercase after the type prefix, as in `git log`.
+
+---
+
+### Task 1: `rotatable` decodes, validates, and resolves along the chain
+
+**Files:**
+- Modify: `src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/DataTools.java` (add `BLOCK_TAG_CODEC`)
+- Modify: `src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleRE.java`
+- Modify: `src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java`
+- Modify: `src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java:164` (constructor call site)
+- Modify: `src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java:289`
+- Modify: `src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java:262`
+- Modify: `src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java:338,345`
+- Test: `src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java` (create)
+
+**Interfaces:**
+- Consumes: `DataTools.fromName(String)`, `Resolved.require`, `TestWiring.partSelector()`.
+- Produces: `DataTools.BLOCK_TAG_CODEC` (a `Codec<TagKey<Block>>`), and `WorldStyle.getRotatableTag()` returning a non-null `TagKey<Block>`. Task 2 calls `getRotatableTag()`.
+
+**Why not `TagKey.hashedCodec(Registries.BLOCK)`:** it exists and decodes the same `#ns:path` shape, but it parses the remainder with `Identifier.read`, which resolves a bare `#rotatable` to `minecraft:rotatable` instead of erroring. That is the exact defaulting `DataTools.STRICT_IDENTIFIER_CODEC` was written to prevent. Put this reasoning in the javadoc — the next person will reach for `hashedCodec`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java`:
+
+```java
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import com.mojang.serialization.JsonOps;
+import com.google.gson.JsonParser;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A world style may name the block tag that decides what rotates with its part.
+ * <p>
+ * The default is what matters most here: every asset written before this field existed, and every
+ * asset that simply does not care, must keep resolving to {@code urbex:rotatable}. The field is
+ * how a pack says "these blocks are rotatable <em>in my world style</em>" without shipping a file
+ * in Urbex's namespace, which is a merge into every other style whether it wants it or not.
+ */
+class WorldStyleRotatableTagTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static TagKey<Block> tag(String namespace, String path) {
+        return TagKey.create(Registries.BLOCK, Identifier.fromNamespaceAndPath(namespace, path));
+    }
+
+    private static WorldStyleRE worldStyle(String name, Optional<TagKey<Block>> rotatable) {
+        return new WorldStyleRE(Optional.empty(), Optional.of("urbex:outside"),
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.of(TestWiring.partSelector()),
+                Optional.of(new Mergeable<>(true,
+                        List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
+                Optional.empty(), rotatable)
+                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", name));
+    }
+
+    @Test
+    void aChainDeclaringNothingResolvesToUrbexRotatable() {
+        WorldStyle resolved = new WorldStyle(List.of(worldStyle("standard", Optional.empty())));
+
+        assertEquals(tag("urbex", "rotatable"), resolved.getRotatableTag(),
+                "every asset written before this field existed must keep the old behaviour");
+    }
+
+    @Test
+    void whatTheChildDeclaresWins() {
+        WorldStyle resolved = new WorldStyle(List.of(
+                worldStyle("standard", Optional.empty()),
+                worldStyle("zombie", Optional.of(tag("urbexza", "rotatable")))));
+
+        assertEquals(tag("urbexza", "rotatable"), resolved.getRotatableTag());
+    }
+
+    @Test
+    void aChildThatOmitsItInheritsRatherThanResettingToTheDefault() {
+        WorldStyle resolved = new WorldStyle(List.of(
+                worldStyle("standard", Optional.of(tag("urbexza", "rotatable"))),
+                worldStyle("child", Optional.empty())));
+
+        assertEquals(tag("urbexza", "rotatable"), resolved.getRotatableTag(),
+                "absence means inherit, not revert");
+    }
+
+    @Test
+    void aReferenceWithoutTheHashIsALoadError() {
+        var result = WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+                {"outsidestyle": "urbex:outside", "rotatable": "urbexza:rotatable"}
+                """));
+
+        assertTrue(result.isError(), "a tag reference is written with a leading '#'");
+        assertTrue(result.error().orElseThrow().message().contains("#"),
+                "the message should show the shape it wanted: " + result.error().orElseThrow().message());
+    }
+
+    @Test
+    void anUnqualifiedReferenceIsALoadErrorRatherThanAMinecraftDefault() {
+        var result = WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+                {"outsidestyle": "urbex:outside", "rotatable": "#rotatable"}
+                """));
+
+        assertTrue(result.isError(),
+                "TagKey.hashedCodec would silently make this minecraft:rotatable; we do not");
+        assertTrue(result.error().orElseThrow().message().contains("rotatable"),
+                result.error().orElseThrow().message());
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew test --tests '*WorldStyleRotatableTagTest*'`
+Expected: FAIL to compile — `WorldStyleRE` has no nine-argument constructor and `WorldStyle` has no `getRotatableTag()`.
+
+- [ ] **Step 3: Add `BLOCK_TAG_CODEC` to `DataTools`**
+
+Append to `DataTools`, after `STRICT_IDENTIFIER_CODEC`. Add imports for `net.minecraft.core.registries.Registries`, `net.minecraft.tags.TagKey`, `net.minecraft.world.level.block.Block`:
+
+```java
+    /**
+     * Strict codec for a field that always names a block tag, written with the leading {@code #}
+     * every other tag reference in the format uses ({@code biomes.if_any}, a {@code stuff}
+     * matcher). Requiring the {@code #} rather than accepting a bare identifier is deliberate: a
+     * field that only ever takes a tag would otherwise invite a block id, which would decode
+     * cleanly and match nothing.
+     * <p>
+     * Not {@link TagKey#hashedCodec}, which decodes the same shape but parses the remainder with
+     * {@code Identifier.read} - so {@code "#rotatable"} becomes {@code minecraft:rotatable} instead
+     * of failing. Going through {@link #fromName} instead makes an unqualified tag reference the
+     * same load error, with the same message, as any other unqualified reference.
+     */
+    public static final Codec<TagKey<Block>> BLOCK_TAG_CODEC = Codec.STRING.comapFlatMap(
+            s -> {
+                if (!s.startsWith("#")) {
+                    return DataResult.error(() -> "Block tag reference '" + s
+                            + "' must start with '#', e.g. '#" + Urbex.MODID + ":rotatable'");
+                }
+                try {
+                    return DataResult.success(
+                            TagKey.create(Registries.BLOCK, fromName(s.substring(1))));
+                } catch (RuntimeException e) {
+                    return DataResult.error(e::getMessage);
+                }
+            },
+            tag -> "#" + tag.location());
+```
+
+- [ ] **Step 4: Add the field to `WorldStyleRE`**
+
+Add imports for `net.minecraft.tags.TagKey` and `net.minecraft.world.level.block.Block`.
+
+In the `RAW` codec group, append one line after the `citybiomemultipliers` entry (keep the trailing `)` on the group as it is):
+
+```java
+                    DataTools.BLOCK_TAG_CODEC.optionalFieldOf("rotatable").forGetter(l -> Optional.ofNullable(l.rotatable))
+```
+
+Add the field beside `outsideStyle`:
+
+```java
+    // Null means "not declared here", so the chain reads it from an ancestor; a chain that
+    // declares none at all falls back to urbex:rotatable in WorldStyle.
+    private final TagKey<Block> rotatable;
+```
+
+Append the parameter to the constructor and assign it:
+
+```java
+                        Optional<Mergeable<CityBiomeMultiplier>> cityBiomeMultipliers,
+                        Optional<TagKey<Block>> rotatable) {
+        ...
+        this.rotatable = rotatable.orElse(null);
+```
+
+Add the getter beside `getOutsideStyle()`:
+
+```java
+    @Nullable
+    public TagKey<Block> getRotatable() {
+        return rotatable;
+    }
+```
+
+- [ ] **Step 5: Fold it in `WorldStyle`**
+
+Add imports for `net.minecraft.tags.TagKey`, `net.minecraft.world.level.block.Block` and `dev.krona.urbex.worldgen.UrbexTags`.
+
+Add the field beside `outsideStyle`:
+
+```java
+    private final TagKey<Block> rotatableTag;
+```
+
+In the constructor, declare the accumulator beside `String outside = null;`:
+
+```java
+        TagKey<Block> rotatable = null;
+```
+
+Inside the `for` loop over `chainRootFirst`, beside the `getOutsideStyle()` block:
+
+```java
+            if (object.getRotatable() != null) {
+                rotatable = object.getRotatable();
+            }
+```
+
+After the loop, beside `this.outsideStyle = ...`. **Not** `Resolved.require` — this field is optional and has a default, which is the whole point:
+
+```java
+        // Optional, unlike outsidestyle: a chain that declares none keeps the behaviour every
+        // world style had before the field existed.
+        this.rotatableTag = rotatable == null ? UrbexTags.ROTATABLE_TAG : rotatable;
+```
+
+Add the getter beside `getOutsideStyle()`:
+
+```java
+    /** The block tag deciding what rotates with its part. Never null; defaults to {@code urbex:rotatable}. */
+    public TagKey<Block> getRotatableTag() {
+        return rotatableTag;
+    }
+```
+
+- [ ] **Step 6: Update the five constructor call sites**
+
+Each gains one trailing `Optional.empty()` argument. They are:
+
+- `src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java` — `placeholderStyle()`
+- `src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java` — the `worldStyle(...)` helper
+- `src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java` — the `worldStyle(...)` helper
+- `src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java` — both `parent` and `child` in `worldStyleChildInheritsTheSelectorsAndSettingsItDoesNotDeclare`
+
+Compile-driven: `./gradlew compileJava compileTestJava` names every one that is still short an argument.
+
+- [ ] **Step 7: Run the new test and the whole asset suite**
+
+Run: `./gradlew test --tests '*WorldStyleRotatableTagTest*' --tests '*RequiredAfterResolutionTest*' --tests '*RegistryChainResolutionTest*' --tests '*WiringRequiredTest*' --tests '*UrbexDataCodecTest*'`
+Expected: PASS, all five classes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/DataTools.java src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleRE.java src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java src/test/java/dev/krona/urbex/worldgen/lost/cityassets/
+git commit -m "feat: let a world style name its own rotatable block tag
+
+Optional, defaulting to urbex:rotatable, so nothing that exists changes
+meaning. Without it a pack can only widen the set by shipping a file in
+Urbex's namespace, which merges into every other world style too."
+```
+
+---
+
+### Task 2: Generation reads the resolved tag
+
+**Files:**
+- Modify: `src/main/java/dev/krona/urbex/worldgen/CityGenerator.java:2055-2058`
+- Test: `digest.golden` and `digest-features.golden` (unchanged — that is the test)
+
+**Interfaces:**
+- Consumes: `WorldStyle.getRotatableTag()` from Task 1, and the existing `provider.getWorldStyle()` (already used at `CityGenerator.java:442`).
+- Produces: nothing new. This is the last task that touches Java.
+
+- [ ] **Step 1: Record the goldens before touching anything**
+
+```bash
+cp digest.golden /tmp/digest.golden.before
+cp digest-features.golden /tmp/digest-features.golden.before
+```
+
+- [ ] **Step 2: Replace the constant with the world style's tag**
+
+In `transformBlockState`, change the single condition:
+
+```java
+    private BlockState transformBlockState(Transform transform, BlockState b) {
+        if (Tools.hasTag(b.getBlock(), rotatableTag())) {
+```
+
+and add, next to `transformBlockState`:
+
+```java
+    /**
+     * The block tag deciding what rotates with its part, from the active world style.
+     * <p>
+     * Resolved once and cached: this is read for every block of every part placed at a transform
+     * other than {@code ROTATE_NONE}, and the world style cannot change under a running generator.
+     * A world style that declares nothing resolves to {@code urbex:rotatable}, which is what this
+     * method returned unconditionally before world styles could name their own.
+     */
+    private TagKey<Block> rotatableTag() {
+        if (cachedRotatableTag == null) {
+            cachedRotatableTag = provider.getWorldStyle().getRotatableTag();
+        }
+        return cachedRotatableTag;
+    }
+```
+
+with the field beside the generator's other cached lookups:
+
+```java
+    private TagKey<Block> cachedRotatableTag;
+```
+
+Add imports for `net.minecraft.tags.TagKey` and `net.minecraft.world.level.block.Block` if the file does not already have them.
+
+- [ ] **Step 3: Run the unit suite**
+
+Run: `./gradlew test`
+Expected: PASS.
+
+- [ ] **Step 4: Run both digest checks**
+
+Run: `./gradlew digestCheck digestCheckFeatures`
+Expected: PASS. Both compare against the committed goldens, and both world styles they exercise declare no `rotatable`, so an identical digest is the proof the default path is untouched.
+
+- [ ] **Step 5: Verify the goldens did not move**
+
+```bash
+diff /tmp/digest.golden.before digest.golden && diff /tmp/digest-features.golden.before digest-features.golden && echo "goldens unchanged"
+```
+
+Expected: `goldens unchanged`. **If either differs, stop.** A moved golden means the default path changed, which this task is specifically not allowed to do. Do not accept the new value; find out why generation moved.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+git commit -m "feat: rotate blocks by the world style's tag, not the constant
+
+Both digest goldens are unchanged: the styles they exercise declare no
+rotatable, so they still resolve urbex:rotatable and place the same blocks."
+```
+
+---
+
+### Task 3: Document the field
+
+**Files:**
+- Modify: `docs/datapacks.md:37` (the `worldstyles` registry row) and the world style example under "A working example of each registry"
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: the field name and shape from Task 1. Nothing consumes this task.
+
+- [ ] **Step 1: Add the field to the registry table**
+
+`docs/datapacks.md:37`, the `worldstyles` row — append to its "Key fields" cell so it reads:
+
+```
+`outsidestyle`, `citystyles`, `parts.highways` (all six), `parts.railways` (all sixteen), `rotatable` (optional)
+```
+
+- [ ] **Step 2: Document what it does**
+
+Add a subsection after "### Absence means inherit" (`docs/datapacks.md:126`):
+
+````markdown
+### `rotatable`: which blocks turn with their part
+
+A part placed at a rotation only turns the blocks named by a block tag; anything else keeps the
+facing its palette entry authored. That tag is `urbex:rotatable` unless the world style names
+another:
+
+```json
+{
+  "outsidestyle": "urbex:outside",
+  "rotatable": "#mypack:rotatable"
+}
+```
+
+Written with the leading `#`, like every other tag reference, and fully qualified — `#rotatable`
+is a load error rather than `minecraft:rotatable`.
+
+**Declaring it replaces, it does not merge.** To keep Urbex's own set, name it from your tag:
+
+```json
+{ "values": ["#urbex:rotatable", "#minecraft:trapdoors", "minecraft:ladder"] }
+```
+
+The alternative to this field is shipping `data/urbex/tags/block/rotatable.json`, which merges into
+`urbex:rotatable` itself and so changes *every* world style including `urbex:standard`, whether or
+not the player selected yours.
+````
+
+- [ ] **Step 3: Add the changelog entry**
+
+Add to `CHANGELOG.md` under the current unreleased heading, matching the surrounding entry style:
+
+```markdown
+- World styles may name their own `rotatable` block tag. Optional, defaulting to `urbex:rotatable`,
+  so nothing that exists changes. Previously the only way to widen the rotatable set was a file in
+  Urbex's namespace, which merged into every world style at once.
+```
+
+- [ ] **Step 4: Check the docs still match the code**
+
+Run: `./gradlew test --tests '*DatapackGuideExamplesTest*' --tests '*DatapackReferenceIntegrityTest*'`
+Expected: PASS. `DatapackGuideExamplesTest` parses the JSON examples in `docs/datapacks.md`, so a malformed snippet fails here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/datapacks.md CHANGELOG.md
+git commit -m "docs: describe the world style rotatable tag and why it replaces"
+```
+
+---
+
+### Task 4: Publish the branch and file the issue
+
+**Files:** none — this task only pushes and files.
+
+- [ ] **Step 1: Confirm the full check suite is green**
+
+Run: `./gradlew check digestCheck digestCheckFeatures`
+Expected: PASS. Do not open the PR on a red run.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feature/worldstyle-rotatable-tag
+```
+
+- [ ] **Step 3: Open the pull request**
+
+```bash
+gh pr create --repo Arilas/urbex --base main --head feature/worldstyle-rotatable-tag \
+  --title "feat: let a world style name its own rotatable block tag" \
+  --body "$(cat <<'BODY'
+A world style may now declare `rotatable`, naming the block tag that decides which blocks rotate
+with their part. Optional; a chain that declares none resolves `urbex:rotatable`, exactly as before.
+
+Declaring it replaces rather than merges — a pack that wants Urbex's own set writes
+`"#urbex:rotatable"` into its own tag's values, so the composition is visible in data.
+
+Without this, the only way for a pack to widen the rotatable set is to ship
+`data/urbex/tags/block/rotatable.json`, which merges into `urbex:rotatable` itself and therefore
+changes generation in *every* world style, including `urbex:standard`, whether or not the player
+selected the pack's style.
+
+`digest.golden` and `digest-features.golden` are unchanged. Both styles they exercise declare no
+`rotatable`, so an identical digest is the evidence the default path is untouched.
+BODY
+)"
+```
+
+- [ ] **Step 4: File the separate tag-contents issue**
+
+This is a distinct defect from the feature above, and it is not fixed by it — stock Urbex hits it with no datapack involved.
+
+```bash
+gh issue create --repo Arilas/urbex \
+  --title "urbex:rotatable names only #minecraft:stairs, so Urbex's own ladders and trapdoor mis-face under rotation" \
+  --body "$(cat <<'BODY'
+`data/urbex/tags/block/rotatable.json` names `#minecraft:stairs` and nothing else, but
+`CityGenerator.transformBlockState` applies the mirror/rotate to any block in that tag. Banners,
+trapdoors and ladders are exactly as directional as stairs.
+
+Urbex's own assets place three directional states the tag does not cover:
+
+| block state | file |
+| --- | --- |
+| `minecraft:ladder[facing=north]` | `data/urbex/urbex/palettes/common.json` |
+| `minecraft:ladder[facing=east]` | `data/urbex/urbex/palettes/oilrig.json` |
+| `minecraft:iron_trapdoor[facing=east,half=bottom,open=false,powered=false]` | `data/urbex/urbex/palettes/oilrig.json` |
+
+So stock generation places mis-facing ladders and a mis-facing trapdoor in every rotated copy of
+the parts holding them, with no datapack involved.
+
+Suggested fix: widen the generated tag to `#minecraft:stairs`, `#minecraft:trapdoors`,
+`#minecraft:banners`, `minecraft:ladder`.
+
+Note this is independent of the world-style `rotatable` field: that lets a pack choose a different
+tag, it does not change what Urbex's own tag contains.
+BODY
+)"
+```
+
+- [ ] **Step 5: Report both URLs**
+
+Print the PR and issue URLs. The port's `PORTING-NOTES.md` links to them.
+
+---
+
+## Self-review
+
+**Spec coverage** (§3 of the port's design doc): `WorldStyleRE` field — Task 1 step 4. `WorldStyle` chain fold with `urbex:rotatable` default — Task 1 step 5. `CityGenerator` resolving once — Task 2 step 2. Replace-not-merge — Task 1 (no merge code) and documented in Task 3 step 2. Digest goldens unchanged — Task 2 steps 1, 4, 5. `docs/schema` — **not applicable**: `docs/schema/` holds only `preset.schema.json`, there is no world style schema to update, so the spec's mention of it is satisfied by `docs/datapacks.md` alone. Issue on `Arilas/urbex` — Task 4 step 4.
+
+**Placeholder scan:** no TBD/TODO; every code step shows the code; every run step names the command and the expected result.
+
+**Type consistency:** `DataTools.BLOCK_TAG_CODEC` is `Codec<TagKey<Block>>` (Task 1 step 3), consumed by `WorldStyleRE`'s `optionalFieldOf("rotatable")` as `Optional<TagKey<Block>>` (step 4), stored `@Nullable TagKey<Block>` and read by `getRotatable()` (step 4), folded into non-null `TagKey<Block> rotatableTag` read by `getRotatableTag()` (step 5), consumed by `CityGenerator.rotatableTag()` returning `TagKey<Block>` (Task 2). Consistent throughout.

--- a/docs/superpowers/plans/2026-08-12-worldstyle-rotatable-tag.md
+++ b/docs/superpowers/plans/2026-08-12-worldstyle-rotatable-tag.md
@@ -351,7 +351,7 @@ Expected: PASS.
 
 - [ ] **Step 4: Run both digest checks**
 
-Run: `./gradlew digestCheck digestCheckFeatures`
+Run: `./gradlew runDigestCheck runDigestCheckFeatures`
 Expected: PASS. Both compare against the committed goldens, and both world styles they exercise declare no `rotatable`, so an identical digest is the proof the default path is untouched.
 
 - [ ] **Step 5: Verify the goldens did not move**
@@ -453,7 +453,7 @@ git commit -m "docs: describe the world style rotatable tag and why it replaces"
 
 - [ ] **Step 1: Confirm the full check suite is green**
 
-Run: `./gradlew check digestCheck digestCheckFeatures`
+Run: `./gradlew check runDigestCheck runDigestCheckFeatures`
 Expected: PASS. Do not open the PR on a red run.
 
 - [ ] **Step 2: Push the branch**

--- a/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
@@ -178,6 +178,9 @@ public class NullDimensionInfo implements IDimensionInfo {
                                 noParts(), noParts(), noParts(), noParts(), noParts(), noParts(),
                                 noParts(), noParts(), noParts(), noParts())))),
                 Optional.of(new Mergeable<>(true, Collections.emptyList())),
+                Optional.empty(),
+                // No 'rotatable': the preview places no parts, so nothing is ever rotated, and
+                // naming a tag here would be a claim about a datapack this path has not loaded.
                 Optional.empty()
                 // Named, so the load error names this placeholder rather than 'null' if a field is
                 // ever added to the required set and not added here.

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -83,6 +83,8 @@ public class CityGenerator {
 
     public final IDimensionInfo provider;
     public final Preset profile;
+    /** Lazily resolved by {@link #rotatableTag()}; see there for why it is safe to cache. */
+    private TagKey<Block> cachedRotatableTag;
 
     private final Statistics statistics = new Statistics();
     private final Map<Block, BlockEntityType> typeCache = new ConcurrentHashMap<>();
@@ -2052,8 +2054,24 @@ public class CityGenerator {
         return b;
     }
 
+    /**
+     * The block tag deciding what rotates with its part, from the active world style.
+     * <p>
+     * Resolved once and cached: {@link #transformBlockState} reads it for every block of every part
+     * placed at a transform other than {@code ROTATE_NONE}, and the world style cannot change under
+     * a running generator. A world style that declares no {@code rotatable} resolves
+     * {@code urbex:rotatable}, which is what this returned unconditionally before world styles could
+     * name their own.
+     */
+    private TagKey<Block> rotatableTag() {
+        if (cachedRotatableTag == null) {
+            cachedRotatableTag = provider.getWorldStyle().getRotatableTag();
+        }
+        return cachedRotatableTag;
+    }
+
     private BlockState transformBlockState(Transform transform, BlockState b) {
-        if (Tools.hasTag(b.getBlock(), UrbexTags.ROTATABLE_TAG)) {
+        if (Tools.hasTag(b.getBlock(), rotatableTag())) {
             // Vanilla structure order: mirror first, then rotate. The mirror used to be
             // approximated with a 180/90 rotation, which turned mirrored stairs/doors/logs
             // the wrong way (issue #45).

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
@@ -3,12 +3,15 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.UrbexTags;
 import dev.krona.urbex.worldgen.lost.BiomeInfo;
 import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.*;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.Identifier;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,6 +32,7 @@ public class WorldStyle {
     private final List<Pair<Predicate<Holder<Biome>>, Float>> cityBiomeMultiplier = new ArrayList<>();
     @Nonnull private final MultiSettings multiSettings;
     @Nonnull private final WorldSettings worldSettings;
+    @Nonnull private final TagKey<Block> rotatableTag;
 
     /**
      * Builds a fully resolved world style from its {@code extends} chain, root first: every
@@ -50,6 +54,7 @@ public class WorldStyle {
         PartSelector parts = null;
         MultiSettings multi = MultiSettings.DEFAULT;
         WorldSettings world = WorldSettings.DEFAULT;
+        TagKey<Block> rotatable = null;
         List<CityStyleSelector> selectors = new ArrayList<>();
         boolean anySelectors = false;
         List<CityBiomeMultiplier> multipliers = new ArrayList<>();
@@ -69,6 +74,9 @@ public class WorldStyle {
             if (object.getWorldSettings() != null) {
                 world = object.getWorldSettings();
             }
+            if (object.getRotatable() != null) {
+                rotatable = object.getRotatable();
+            }
             if (object.getCityStyleSelectors() != null) {
                 Mergeable.apply(selectors, object.getCityStyleSelectors());
                 anySelectors = true;
@@ -83,6 +91,9 @@ public class WorldStyle {
         this.partSelector = Resolved.require(parts, name, "parts").requireComplete(name);
         this.multiSettings = multi;
         this.worldSettings = world;
+        // Optional, unlike outsidestyle: a chain that declares none keeps the behaviour every world
+        // style had before the field existed, rather than being a load error.
+        this.rotatableTag = rotatable == null ? UrbexTags.ROTATABLE_TAG : rotatable;
         for (CityStyleSelector selector : selectors) {
             Predicate<Holder<Biome>> predicate = biomeHolder -> true;
             if (selector.biomeMatcher() != null) {
@@ -106,6 +117,16 @@ public class WorldStyle {
 
     public String getOutsideStyle() {
         return outsideStyle;
+    }
+
+    /**
+     * The block tag deciding which blocks rotate with the part they sit in, rather than keeping the
+     * facing their palette entry authored. Never null: a world style that declares no
+     * {@code rotatable} anywhere in its chain resolves {@code urbex:rotatable}.
+     */
+    @Nonnull
+    public TagKey<Block> getRotatableTag() {
+        return rotatableTag;
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleRE.java
@@ -4,6 +4,8 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.krona.urbex.worldgen.lost.regassets.data.*;
 import net.minecraft.resources.Identifier;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
@@ -27,7 +29,8 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
                     ScatteredSettings.CODEC.optionalFieldOf("scattered").forGetter(l -> Optional.ofNullable(l.scatteredSettings)),
                     PartSelector.Decl.CODEC.optionalFieldOf("parts").forGetter(l -> Optional.ofNullable(l.partSelector)),
                     Mergeable.codec(CityStyleSelector.CODEC).optionalFieldOf("citystyles").forGetter(l -> Optional.ofNullable(l.cityStyleSelectors)),
-                    Mergeable.codec(CityBiomeMultiplier.CODEC).optionalFieldOf("citybiomemultipliers").forGetter(l -> Optional.ofNullable(l.cityBiomeMultipliers))
+                    Mergeable.codec(CityBiomeMultiplier.CODEC).optionalFieldOf("citybiomemultipliers").forGetter(l -> Optional.ofNullable(l.cityBiomeMultipliers)),
+                    DataTools.BLOCK_TAG_CODEC.optionalFieldOf("rotatable").forGetter(l -> Optional.ofNullable(l.rotatable))
             ).apply(instance, WorldStyleRE::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
@@ -43,6 +46,10 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
     private final PartSelector.Decl partSelector;
     private final Mergeable<CityStyleSelector> cityStyleSelectors;
     private final Mergeable<CityBiomeMultiplier> cityBiomeMultipliers;
+    // Null means "not declared here", so the chain reads it from an ancestor. A chain that declares
+    // none at all falls back to urbex:rotatable in WorldStyle -- the behaviour every world style had
+    // before this field existed.
+    private final TagKey<Block> rotatable;
 
     public WorldStyleRE(Optional<Identifier> extendsId,
                         Optional<String> outsideStyle,
@@ -51,7 +58,8 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
                         Optional<ScatteredSettings> scatteredSettings,
                         Optional<PartSelector.Decl> partSelector,
                         Optional<Mergeable<CityStyleSelector>> cityStyleSelector,
-                        Optional<Mergeable<CityBiomeMultiplier>> cityBiomeMultipliers) {
+                        Optional<Mergeable<CityBiomeMultiplier>> cityBiomeMultipliers,
+                        Optional<TagKey<Block>> rotatable) {
         this.extendsId = extendsId;
         this.outsideStyle = outsideStyle.orElse(null);
         this.multiSettings = multiSettings.orElse(null);
@@ -60,11 +68,17 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
         this.partSelector = partSelector.orElse(null);
         this.cityStyleSelectors = cityStyleSelector.orElse(null);
         this.cityBiomeMultipliers = cityBiomeMultipliers.orElse(null);
+        this.rotatable = rotatable.orElse(null);
     }
 
     @Nullable
     public String getOutsideStyle() {
         return outsideStyle;
+    }
+
+    @Nullable
+    public TagKey<Block> getRotatable() {
+        return rotatable;
     }
 
     @Nullable

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/DataTools.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/DataTools.java
@@ -3,7 +3,10 @@ package dev.krona.urbex.worldgen.lost.regassets.data;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import dev.krona.urbex.Urbex;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
 
 import java.util.Optional;
 
@@ -49,4 +52,31 @@ public class DataTools {
                 }
             },
             Identifier::toString);
+
+    /**
+     * Strict codec for a field that always names a block tag, written with the leading {@code #}
+     * every other tag reference in the format uses ({@code biomes.if_any}, a {@code stuff}
+     * matcher). Requiring the {@code #} rather than accepting a bare identifier is deliberate: a
+     * field that only ever takes a tag would otherwise invite a block id, which would decode
+     * cleanly and then match nothing.
+     * <p>
+     * Not {@link TagKey#hashedCodec}, which decodes the same shape but parses the remainder with
+     * {@code Identifier.read} - so {@code "#rotatable"} becomes {@code minecraft:rotatable} instead
+     * of failing. Going through {@link #fromName} instead makes an unqualified tag reference the
+     * same load error, with the same message, as any other unqualified reference.
+     */
+    public static final Codec<TagKey<Block>> BLOCK_TAG_CODEC = Codec.STRING.comapFlatMap(
+            s -> {
+                if (!s.startsWith("#")) {
+                    return DataResult.error(() -> "Block tag reference '" + s
+                            + "' must start with '#', e.g. '#" + Urbex.MODID + ":rotatable'");
+                }
+                try {
+                    return DataResult.success(
+                            TagKey.create(Registries.BLOCK, fromName(s.substring(1))));
+                } catch (RuntimeException e) {
+                    return DataResult.error(e::getMessage);
+                }
+            },
+            tag -> "#" + tag.location());
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
@@ -340,11 +340,11 @@ class RegistryChainResolutionTest {
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
                         List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
-                Optional.empty())
+                Optional.empty(), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "standard"));
         WorldStyleRE child = new WorldStyleRE(Optional.empty(), Optional.of("urbex:bleak"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.empty())
+                Optional.empty(), Optional.empty(), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "bleak"));
 
         WorldStyle resolved = new WorldStyle(List.of(parent, child));

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java
@@ -289,7 +289,7 @@ class RequiredAfterResolutionTest {
         return new WorldStyleRE(Optional.empty(), outsideStyle,
                 Optional.empty(), Optional.empty(), scattered,
                 Optional.of(TestWiring.partSelector()),
-                cityStyles, Optional.empty())
+                cityStyles, Optional.empty(), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_world"));
     }
 

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java
@@ -261,7 +261,7 @@ class WiringRequiredTest {
     private static WorldStyleRE worldStyle(String name, PartSelector.Decl parts) {
         return new WorldStyleRE(Optional.empty(), Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.ofNullable(parts),
-                Optional.of(new Mergeable<>(true, List.of())), Optional.empty())
+                Optional.of(new Mergeable<>(true, List.of())), Optional.empty(), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", name));
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java
@@ -1,0 +1,113 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A world style may name the block tag that decides what rotates with its part.
+ * <p>
+ * The default is what matters most here: every asset written before this field existed, and every
+ * asset that simply does not care, must keep resolving to {@code urbex:rotatable}. The field is how
+ * a pack says "these blocks are rotatable <em>in my world style</em>" without shipping a file in
+ * Urbex's namespace, which is a merge into every other style whether it wants it or not.
+ */
+class WorldStyleRotatableTagTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static TagKey<Block> tag(String namespace, String path) {
+        return TagKey.create(Registries.BLOCK, Identifier.fromNamespaceAndPath(namespace, path));
+    }
+
+    private static WorldStyleRE worldStyle(String name, Optional<TagKey<Block>> rotatable) {
+        return new WorldStyleRE(Optional.empty(), Optional.of("urbex:outside"),
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.of(TestWiring.partSelector()),
+                Optional.of(new Mergeable<>(true,
+                        List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
+                Optional.empty(), rotatable)
+                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", name));
+    }
+
+    @Test
+    void aChainDeclaringNothingResolvesToUrbexRotatable() {
+        WorldStyle resolved = new WorldStyle(List.of(worldStyle("standard", Optional.empty())));
+
+        assertEquals(tag("urbex", "rotatable"), resolved.getRotatableTag(),
+                "every asset written before this field existed must keep the old behaviour");
+    }
+
+    @Test
+    void whatTheChildDeclaresWins() {
+        WorldStyle resolved = new WorldStyle(List.of(
+                worldStyle("standard", Optional.empty()),
+                worldStyle("zombie", Optional.of(tag("urbexza", "rotatable")))));
+
+        assertEquals(tag("urbexza", "rotatable"), resolved.getRotatableTag());
+    }
+
+    @Test
+    void aChildThatOmitsItInheritsRatherThanRevertingToTheDefault() {
+        WorldStyle resolved = new WorldStyle(List.of(
+                worldStyle("standard", Optional.of(tag("urbexza", "rotatable"))),
+                worldStyle("child", Optional.empty())));
+
+        assertEquals(tag("urbexza", "rotatable"), resolved.getRotatableTag(),
+                "absence means inherit, not revert");
+    }
+
+    @Test
+    void aReferenceWithoutTheHashIsALoadError() {
+        var result = WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+                {"outsidestyle": "urbex:outside", "rotatable": "urbexza:rotatable"}
+                """));
+
+        assertTrue(result.isError(), "a tag reference is written with a leading '#'");
+        assertTrue(result.error().orElseThrow().message().contains("#"),
+                "the message should show the shape it wanted: "
+                        + result.error().orElseThrow().message());
+    }
+
+    @Test
+    void anUnqualifiedReferenceIsALoadErrorRatherThanAMinecraftDefault() {
+        var result = WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+                {"outsidestyle": "urbex:outside", "rotatable": "#rotatable"}
+                """));
+
+        assertTrue(result.isError(),
+                "TagKey.hashedCodec would silently make this minecraft:rotatable; we do not");
+        assertTrue(result.error().orElseThrow().message().contains("rotatable"),
+                result.error().orElseThrow().message());
+    }
+
+    @Test
+    void aDeclaredTagRoundTripsThroughTheCodec() {
+        var decoded = WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+                {"outsidestyle": "urbex:outside", "rotatable": "#urbexza:rotatable"}
+                """)).getOrThrow();
+
+        assertEquals(tag("urbexza", "rotatable"), decoded.getRotatable());
+    }
+}


### PR DESCRIPTION
A world style may now declare `rotatable`, naming the block tag that decides which blocks rotate with
their part. Optional; a chain that declares none resolves `urbex:rotatable`, exactly as before.

## Why

Without this, the only way for a pack to widen the rotatable set is to ship
`data/urbex/tags/block/rotatable.json` — and a tag file in Urbex's namespace merges into
`urbex:rotatable` itself, so it takes effect in **every** world style, including `urbex:standard`,
whether or not the player selected that pack's style. A pack whose palettes place directional
banners, trapdoors or ladders had to choose between shipping visibly mis-facing blocks and changing
stock generation for everyone.

The pack that prompted this places 34 distinct directional trapdoor and ladder states, none of them
stairs.

## Shape

Declaring the field **replaces** rather than merges. A pack that wants Urbex's own set writes
`"#urbex:rotatable"` into its own tag's `values` — tags reference tags across namespaces, so nothing
is lost and the composition is visible in data instead of implied by a merge rule.

Not `TagKey.hashedCodec`: it decodes the same `#ns:path` shape, but parses the remainder with
`Identifier.read`, so `"#rotatable"` would silently become `minecraft:rotatable`. The new
`DataTools.BLOCK_TAG_CODEC` goes through `DataTools.fromName`, making an unqualified tag reference
the same load error, with the same message, as any other unqualified reference.

## Both goldens are unchanged

`digest.golden` (`eb6253f3f5363937`) and `digest-features.golden` (`203d8a44769da0c7`) are
byte-identical after the change. The world styles those runs exercise declare no `rotatable`, so an
identical digest across 849k and 4.6M placed blocks is the evidence that the default path is
untouched — a check rather than an assumption.

`./gradlew check runDigestCheck runDigestCheckFeatures` is green.

## Not fixed here

`urbex:rotatable` naming only `#minecraft:stairs` is a separate defect that stock Urbex content hits
on its own; filed separately.