### PR TITLE
ci: attach the built jar to the release for a v* tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: build
 on:
   push:
     branches: [main]
+    # Tags build like any other push - same suite, same two digest checks - and then the release
+    # job below attaches the jar that build produced. A release is never built from a separate,
+    # unverified run.
+    tags: ['v*']
   pull_request:
 
 jobs:
@@ -39,3 +43,55 @@ jobs:
         with:
           name: jar
           path: build/libs/*.jar
+
+  # Attaches the built jar to the GitHub release for a v* tag. Modrinth and CurseForge are
+  # uploaded by hand from that same jar, so this job publishes nothing outside GitHub and needs no
+  # secrets beyond the workflow token.
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: The tag must name the version this build produced
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          # gradle.properties carries the Minecraft prefix (26.2-0.1.0); the tag names the mod
+          # version alone (v0.1.0), which is the convention v0.1.0 already set.
+          gradle_version="$(sed -n 's/^version=//p' gradle.properties)"
+          mod_version="${gradle_version#*-}"
+          if [ "$tag_version" != "$mod_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME names $tag_version, but gradle.properties says $mod_version (version=$gradle_version). Bump one to match the other."
+            exit 1
+          fi
+      - uses: actions/download-artifact@v4
+        with:
+          name: jar
+          path: dist
+      - name: Attach the jar to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="$GITHUB_REF_NAME"
+          version="${tag#v}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            # The release already exists - drafted by hand, or created from the GitHub UI, which
+            # creates the tag and so triggers this run. Only the asset is ours to add.
+            gh release upload "$tag" dist/*.jar --clobber
+          else
+            # A draft, deliberately: every release so far has had a hand-written body (see v0.1.0),
+            # and generated commit notes would be a downgrade. This puts the verified jar somewhere
+            # ready, and publishing stays a decision.
+            prerelease=""
+            case "$version" in
+              0.*) prerelease="--prerelease" ;;
+            esac
+            gh release create "$tag" dist/*.jar \
+              --draft $prerelease \
+              --title "$version" \
+              --notes "Built by \`${GITHUB_WORKFLOW}\` run [\`${GITHUB_RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}), after the test suite and both worldgen digest checks passed.
+
+          Write the notes from \`CHANGELOG.md\` before publishing."
+          fi

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ preset format specifically.
 
 Requires JDK 25. The jar lands in `build/libs/`.
 
+## Releasing
+
+Tags name the mod version, without the Minecraft prefix `gradle.properties` carries: `v0.1.0` for
+`version=26.2-0.1.0`. CI refuses a tag that says anything else.
+
+1. Bump `version` in `gradle.properties`, move the `CHANGELOG.md` entries under a heading for it.
+2. Push the tag. The tagged commit builds like any other — full suite, both worldgen digest
+   checks — and only then does the release job run, so a release is never built from an unverified
+   run.
+3. That job leaves a **draft** GitHub release with the jar attached. Write the notes from
+   `CHANGELOG.md` and publish. (Creating the release from GitHub's own UI works too: it creates the
+   tag, which triggers the same run, and the job attaches the jar to the release you started.)
+4. Upload that same jar to Modrinth and CurseForge by hand.
+
 ## License
 
 MIT. See `LICENSE` — both the original and the fork's notices apply.


### PR DESCRIPTION
The last open item of #78. Closes it.

`mavenJava` was reachable only through the `local_maven` env var and nothing ran on a tag, so the jar on the [v0.1.0](https://github.com/Arilas/urbex/releases/tag/v0.1.0) release was uploaded by hand.

## What it does

A `v*` tag builds like any other push — full suite, both worldgen digest checks — and the `release` job runs `needs: build`, so **a release is never built from an unverified run**; it downloads the artifact that build produced rather than rebuilding.

It leaves a **draft** release with the jar attached. Deliberate: v0.1.0's body is hand-written prose, and `--generate-notes` commit lists would be a downgrade for this repo. The job puts the verified jar somewhere ready and leaves publishing a decision.

If the release already exists — drafted by hand, or created from GitHub's UI, which creates the tag and so triggers this run — the job only `gh release upload --clobber`s the asset onto it. Both directions work.

## The tag guard

Tags name the mod version alone (`v0.1.0`), which is the convention v0.1.0 set, while `gradle.properties` carries the Minecraft prefix (`version=26.2-0.1.0`). The job fails on a tag that disagrees with the version the build actually produced, rather than attaching a jar whose filename contradicts the tag it hangs under. Checked locally:

| tag | `version=26.2-0.1.0` |
|---|---|
| `v0.1.0` | accepted |
| `v0.2.0` | rejected — tag says `0.2.0`, build produced `0.1.0` |
| `v26.2-0.1.0` | rejected — that is the gradle version, not the tag convention |

`0.x` is marked pre-release, matching v0.1.0 and the README's "Early". One `case` line, trivial to drop at 1.0.

## Not in scope

Modrinth and CurseForge stay manual, from that same jar — no tokens, no third-party actions, nothing published outside GitHub. `permissions: contents: write` on the release job only; everything else keeps the default token.

The README gains a Releasing section recording the whole sequence, manual uploads included.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)