### PR TITLE
docs: the README's usage instructions were describing 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- **The README's usage instructions were describing 0.1.0.** They named a **More** tab and a
+  **Cities** button (it is a Cities tab now), the `dimensionsWithProfiles` config option (the key is
+  `dimensionsWithPresets`), and gave `minecraft:overworld=default` as the example — an unqualified
+  reference, which that option has rejected since references were made to name their namespace. Two
+  of the three would have failed for anyone following them. The same stale key was in the 0.2.0
+  entry that removed the `urbex:city` dimension - written before the preset rework renamed
+  `dimensionsWithProfiles` to `dimensionsWithPresets` - and is corrected there too.
+
 ## 0.2.0 — 2026-08-12 (beta)
 
 - **`urbex:rotatable` covers what the generator actually rotates.** The tag named
@@ -824,9 +834,9 @@
   `config/urbex/profiles/space.json`) will crash on startup with `Bad landscape type: space!`;
   there is no fallback. Delete or edit any such profile file before upgrading.
 - **Removed the `urbex:city` dimension.** It existed for historical reasons only (it was a plain
-  overworld clone). Cities are enabled by picking a profile on the world-creation Cities tab or
-  via the `dimensionsWithProfiles` config. The sleep-on-a-special-bed teleport and its
-  `specialBedBlock` config option are gone with it, and `dimensionsWithProfiles` now defaults to
+  overworld clone). Cities are enabled by picking a preset on the world-creation Cities tab or
+  via the `dimensionsWithPresets` config. The sleep-on-a-special-bed teleport and its
+  `specialBedBlock` config option are gone with it, and `dimensionsWithPresets` now defaults to
   empty. If an existing world has this dimension generated, leave it (return to the overworld)
   before upgrading — the dimension disappears and players still inside it will be relocated by
   vanilla.

--- a/README.md
+++ b/README.md
@@ -31,16 +31,17 @@ read them as features of the current build.
 
 ## Usage
 
-Urbex does not generate anything until you opt in. A new world looks completely untouched
-unless you pick a profile.
+Urbex does not generate anything until you opt in. A new world looks completely untouched unless
+you pick a preset.
 
 To get cities:
 
-- On the world-creation screen, open the **More** tab and use the **Cities** button to pick a
-  profile before creating the world. With no profile selected (the default) the world generates
-  normally.
-- Server owners can map any dimension to a profile with the `dimensionsWithProfiles` config
-  option (entries look like `minecraft:overworld=default`).
+- On the world-creation screen, open the **Cities** tab and pick a preset before creating the
+  world. **Disabled** is the default and leaves the world alone. **Customize this preset…** edits a
+  copy, which is stored in the world rather than in your config, so it travels with the save.
+- Server owners can map any dimension to a preset with the `dimensionsWithPresets` config option.
+  Entries are `dimension=preset`, optionally `dimension=preset@worldstyle`, and **every id names
+  its namespace**: `minecraft:overworld=urbex:default`, not `minecraft:overworld=default`.
 
 ## Status
 


### PR DESCRIPTION
Found while writing the 0.2.0 release notes, which point readers at this section.

Three claims in **Usage**, two of them actively wrong:

| README said | Reality |
|---|---|
| open the **More** tab, use the **Cities** button | it is a **Cities** tab (`CreateWorldScreenTabMixin` appends a tab to the bar) |
| `dimensionsWithProfiles` | the key is `dimensionsWithPresets` (`UrbexConfig:23,56`) |
| `minecraft:overworld=default` | rejected — `DataTools.fromName` requires a namespace, so it must be `urbex:default`. `Config.parseDimensionPresetEntry` logs *Bad preset id in config value* and drops the entry |

Anyone following the last two got no cities and a line in the log.

Also adds what the tab offers, since Disabled-by-default and "a customized preset is stored in the world, not your config" are both things a reader needs before they can predict what a world will do — and the `@worldstyle` suffix, which nothing outside `docs/presets.md` mentioned.

Not in the v0.2.0 tag: the tag is cut and its draft release is waiting, so this lands on main for the next one. The release notes themselves carry the corrected instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)