### PR TITLE
Presets, world styles and city styles can name themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **Presets, world styles and city styles can name themselves again.** Making every asset reference
+  fully qualified (0.2.0) also made the Cities tab and the world-style picker show those ids: the
+  preset list read `urbex:default`, `urbex:tallbuildings`, `urbex:wasteland`, and the selector read
+  *World Style: urbex:standard*. All three registries now take an optional top-level **`name`** — a
+  plain human label, not an id and not a translation key — and it is what the UI shows.
+  - *Nothing is required to have one.* A file that declares no `name` is labelled by its
+    fully-qualified id, which is exactly what it read as before, so an unnamed third-party pack is
+    drab rather than blank. An empty string counts as "no name" for the same reason.
+  - *It is inherited, like every other scalar*, which is a trap worth stating: a world style
+    extending `urbex:standard` without a `name` of its own is now listed as **Standard**. The
+    bundled pack therefore names all twelve presets, its world style and its three *selectable*
+    city styles, and deliberately leaves the two abstract bases (`urbex:citystyle_common`,
+    `urbex:citystyle_config`) unnamed so an unnamed child of theirs keeps its own id.
+    `ShippedPresetsTest` fails the build if a shipped preset omits its name or shares one.
+  - *The id is still reachable where it matters.* The world-style dropdown shows the name over the
+    id in grey — two packs may pick the same label, and the id is what an author has to type — and
+    a preset row narrates as "*name* (*id*)". `/urbex debug` prints the city style as
+    `name (id)`; before this it printed the id alone and city styles had no label at all.
+  - *No worldgen change*: both digest goldens are unchanged, verified by running `runDigestCheck`.
+    `PresetRE` did have to fold its six metadata keys behind a `MapCodec` to get past
+    `RecordCodecBuilder`'s sixteen-field limit; the keys stay top-level in the JSON and no preset
+    file changes shape.
+
 - **The README's usage instructions were describing 0.1.0.** They named a **More** tab and a
   **Cities** button (it is a Cities tab now), the `dimensionsWithProfiles` config option (the key is
   `dimensionsWithPresets`), and gave `minecraft:overworld=default` as the example — an unqualified

--- a/docs/datapacks.md
+++ b/docs/datapacks.md
@@ -52,6 +52,9 @@ Every one of them accepts `extends`, and every one of them merges by the same ru
 uniformity is deliberate: you should never have to look up whether *this* asset type supports
 extension.
 
+Three of them — `presets`, `worldstyles` and `citystyles` — also accept an optional `name`. See
+[Display names](#display-names) below.
+
 The last column is what the load-time check enforces, and it is not quite the same as "what a
 working asset needs". Three city-style fields are needed but unchecked: `style`, which names the
 `styles` entry its buildings are painted from, and the `streetblocks` characters `street` and
@@ -182,6 +185,36 @@ The alternative is shipping `data/urbex/tags/block/rotatable.json`, which merges
 `urbex:rotatable` itself and therefore changes **every** world style including `urbex:standard`,
 whether or not the player selected yours. That is why this field exists: a pack that needs banners
 or trapdoors to rotate should be able to say so without reaching into Urbex's namespace.
+
+## Display names
+
+`presets`, `worldstyles` and `citystyles` accept an optional top-level `name`: the human label the
+game shows in place of the id.
+
+<!-- example: worldstyles -->
+
+```json
+{
+  "name": "Modern Tweaks",
+  "outsidestyle": "urbex:outside"
+}
+```
+
+Plain text, not an id and not a translation key — anything you'd want a player to read. Without it
+the Cities tab and the world-style picker show the fully-qualified id, which is what they showed
+before the field existed. That fallback is why `name` is optional rather than required: an unnamed
+asset is drab, not broken.
+
+Set one on **everything a player picks from**. The picker shows the name over the id, so two packs
+naming a style "Standard" still tell each other apart there — but a preset list shows the name
+alone, and two identical rows is a real problem.
+
+**It is inherited, like every other scalar: the last entry in the chain that declares one wins.**
+That is the trap. A world style extending `urbex:standard` without a `name` of its own is listed as
+**Standard**, because that is the name Urbex's own file declares. Restate it. For the same reason,
+leave `name` **off** the abstract bases meant to be extended (`urbex:citystyle_common`,
+`urbex:citystyle_config`): a base with no name lets an unnamed child fall back to its own id, which
+is wrong but at least unique, instead of borrowing a label that belongs to something else.
 
 ### When each asset is resolved
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -28,12 +28,18 @@ or selectable.
 
 Every field in the file is **optional**. A preset only needs to state what it changes; anything
 left out falls through to what it `extends` (see [Resolution rules](#resolution-rules) below). The
-top-level object has five plain metadata fields (`extends`, `description`, `extraDescription`,
+top-level object has six plain metadata fields (`extends`, `name`, `description`, `extraDescription`,
 `warning`, `icon`) plus eleven **sections**, each grouping related settings: `terrain`, `cities`,
 `buildings`, `roads`, `highways`, `railways`, `destruction`, `decoration`, `spawn`, `atmosphere`,
 `misc`. A section is only applied if it's present in the file, and within a present section only
 the fields you actually write are overridden — you never have to restate a whole section to change
 one number in it.
+
+`name` is what the Cities tab puts on the row: a plain human label like `Tall Buildings`, not an id
+and not a translation key. Leave it out and the list falls back to showing the fully-qualified id,
+which is what every preset looked like before the field existed. Set it — and set it on **every**
+preset you ship, because like all the others it is inherited: a preset extending `urbex:default`
+that doesn't restate `name` is listed as **Default**, next to the real one.
 
 The full field list, types, numeric ranges and enum values are documented in the JSON Schema at
 [`docs/schema/preset.schema.json`](schema/preset.schema.json) (see [IDE wiring](#ide-wiring) to get
@@ -85,6 +91,7 @@ the fields that change from `urbex:default` need to be listed:
 ```json
 {
   "extends": "urbex:default",
+  "name": "Ruins",
   "description": "Heavily ruined cities, no spawners",
   "destruction": {
     "ruinChance": 0.6,
@@ -113,7 +120,8 @@ rather than overwriting it:
 
 Zip the `myruinspack` folder's contents (not the folder itself) into `myruinspack.zip`, drop it in
 your world's `datapacks/` folder (or the global `resourcepacks`-style datapack folder your server
-uses), and `mypack:ruins` appears in the **Cities** tab's preset list next to the built-ins.
+uses), and **Ruins** appears in the **Cities** tab's preset list next to the built-ins. (Drop the
+`name` and the row reads `mypack:ruins` instead.)
 
 ## Resolution rules
 

--- a/docs/schema/preset.schema.json
+++ b/docs/schema/preset.schema.json
@@ -16,6 +16,10 @@
       "$ref": "#/$defs/qualifiedIdentifier",
       "description": "Asset this preset builds on. Fully qualified, e.g. `urbex:default`."
     },
+    "name": {
+      "type": "string",
+      "description": "The label shown for this preset in the Cities tab, e.g. `Tall Buildings`. Falls back to the fully-qualified id when no entry in the 'extends' chain declares one. Inherited like every other field, so a preset extending 'urbex:default' that does not restate this is labelled `Default` — restate it."
+    },
     "description": {
       "type": "string",
       "description": "The description of this preset, shown in the profile-selection UI."

--- a/src/main/java/dev/krona/urbex/commands/CommandDebug.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandDebug.java
@@ -13,6 +13,7 @@ import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.BuildingInfo;
 import dev.krona.urbex.worldgen.lost.PrimaryBridgePlanner;
 import dev.krona.urbex.worldgen.lost.Railway;
+import dev.krona.urbex.worldgen.lost.cityassets.CityStyle;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.server.level.ServerPlayer;
@@ -67,7 +68,10 @@ public class CommandDebug implements Command<CommandSourceStack> {
         line(context, "isCity = " + info.isCity);
         line(context, "chunkX = " + info.coord.chunkX());
         line(context, "chunkZ = " + info.coord.chunkZ());
-        line(context, "getCityStyle() = " + BuildingInfo.getChunkCharacteristics(info.coord, info.provider).cityStyle.getName());
+        CityStyle cityStyle = BuildingInfo.getChunkCharacteristics(info.coord, info.provider).cityStyle;
+        // Name first, id after: the id is what you edit, the name is what the world-style picker
+        // showed you, and a debug dump is the one place both are worth having side by side.
+        line(context, "getCityStyle() = " + cityStyle.getDisplayName() + " (" + cityStyle.getName() + ")");
         line(context, "streetType = " + info.streetType);
         line(context, "ruinHeight = " + info.ruinHeight);
         line(context, "tunnel0 = " + info.isTunnel(0));

--- a/src/main/java/dev/krona/urbex/config/Preset.java
+++ b/src/main/java/dev/krona/urbex/config/Preset.java
@@ -38,6 +38,7 @@ public class Preset {
 
     private final Identifier id;
 
+    private String name = "";
     private String description = "Default generation, common cities, explosions";
     private String extraDescription = "";
     private String warning = "";
@@ -180,6 +181,29 @@ public class Preset {
         return id;
     }
 
+    /**
+     * The authored display name, or {@code ""} when nothing in the {@code extends} chain declared
+     * one. Callers rendering a label want {@link #getDisplayName()}, which fills that gap in; this
+     * raw form exists so {@link #toRE()} round-trips "no name was authored" as an empty string
+     * rather than inventing the id as an authored value.
+     */
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * What a UI should label this preset: the authored {@code name}, falling back to the
+     * fully-qualified id. The fallback is what every preset showed before the field existed, so a
+     * datapack that declares no name reads exactly as it did then rather than going blank.
+     */
+    public String getDisplayName() {
+        return name == null || name.isEmpty() ? id.toString() : name;
+    }
+
     public String getDescription() {
         return description;
     }
@@ -265,6 +289,7 @@ public class Preset {
     /** Field-by-field clone, used by the GUI editor to stage changes without mutating the original. */
     public Preset copy() {
         Preset p = new Preset(id);
+        p.name = name;
         p.description = description;
         p.extraDescription = extraDescription;
         p.warning = warning;
@@ -560,6 +585,7 @@ public class Preset {
 
         return new PresetRE(
                 Optional.empty(),
+                Optional.of(name),
                 Optional.of(description),
                 Optional.of(extraDescription),
                 Optional.of(warning),

--- a/src/main/java/dev/krona/urbex/gui/CitiesTab.java
+++ b/src/main/java/dev/krona/urbex/gui/CitiesTab.java
@@ -4,6 +4,8 @@ import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.Presets;
 import dev.krona.urbex.gui.preview.CityPreview;
 import dev.krona.urbex.setup.CustomRegistries;
+import dev.krona.urbex.worldgen.lost.cityassets.ExtendsChain;
+import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
 import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
 import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
 import net.minecraft.ChatFormatting;
@@ -34,7 +36,9 @@ import net.minecraft.util.RandomSource;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -98,6 +102,13 @@ public class CitiesTab extends GridLayoutTab {
     private final CityPreview preview;
     private final RandomSource random = RandomSource.create();
 
+    /**
+     * Fully-qualified worldStyle id -> the label to show for it, in the order the selector lists
+     * them. Read once in the constructor: the registry cannot change while this tab is alive (a
+     * datapack toggle rebuilds the whole screen, and with it this tab).
+     */
+    private final Map<String, String> worldStyleNames;
+
     private final PresetListWidget list;
     private final StringWidget nameLabel;
     private final MultiLineTextWidget infoText;
@@ -143,7 +154,8 @@ public class CitiesTab extends GridLayoutTab {
         // being created, read straight off the load context's registry - the state layer only needs
         // the enumerated lists, so the tab injects them rather than have PresetSelection reach into a
         // registry it can't see.
-        List<String> worldStyles = registeredWorldStyles(screen);
+        this.worldStyleNames = registeredWorldStyles(screen);
+        List<String> worldStyles = List.copyOf(worldStyleNames.keySet());
         PresetSelection.CLIENT.setAvailableWorldStyles(worldStyles);
         PresetSelection.CLIENT.setAvailablePresets(registeredPresets(screen));
 
@@ -320,7 +332,7 @@ public class CitiesTab extends GridLayoutTab {
         List<String> choices = PresetSelection.CLIENT.styleChoices();
         String current = PresetSelection.CLIENT.effectiveWorldStyle();
         Minecraft.getInstance().gui.setScreen(
-                new WorldStyleDialog(screen, choices, current, this::onWorldStyleChanged));
+                new WorldStyleDialog(screen, choices, worldStyleNames, current, this::onWorldStyleChanged));
     }
 
     /**
@@ -338,41 +350,57 @@ public class CitiesTab extends GridLayoutTab {
         }
     }
 
-    /** The selector's label: the lang-keyed "World Style" prefix followed by the effective style id. */
-    private static Component worldStyleLabel(String style) {
+    /**
+     * The selector's label: the lang-keyed "World Style" prefix followed by the effective style's
+     * display name (its id when the datapack declares no {@code name}).
+     */
+    private Component worldStyleLabel(String style) {
         return Component.translatable("urbex.tab.worldstyle")
                 .append(": ")
-                .append(Component.literal(style));
+                .append(Component.literal(worldStyleNames.getOrDefault(style, style)));
     }
 
     /**
-     * The registered worldStyle ids, read from the datapack registry loaded for the world being
-     * created (short {@code urbex}-namespace names, others kept as {@code namespace:path}), ordered
-     * {@code standard} first then alphabetical. Empty when the registry isn't reachable yet - the
-     * selector then just stays hidden.
+     * The registered worldStyles, read from the datapack registry loaded for the world being
+     * created: fully-qualified id -> the label to show for it, ordered {@code standard} first then
+     * alphabetical <em>by id</em> (not by label - the order must not shuffle when a pack renames
+     * itself). Empty when the registry isn't reachable yet - the selector then just stays hidden.
+     * <p>
+     * Ids stay the currency everywhere else: {@link PresetSelection} stores and publishes them, and
+     * this map only decides what the player reads. See {@link #worldStyleDisplayName}.
      */
-    private static List<String> registeredWorldStyles(CreateWorldScreen screen) {
+    private static Map<String, String> registeredWorldStyles(CreateWorldScreen screen) {
         RegistryAccess access = screen.getUiState().getSettings().worldgenLoadContext();
         Optional<Registry<WorldStyleRE>> registry = access.lookup(CustomRegistries.WORLDSTYLES_REGISTRY_KEY);
         if (registry.isEmpty()) {
-            return List.of();
+            return Map.of();
         }
-        List<String> ids = new ArrayList<>();
-        for (Identifier key : registry.get().keySet()) {
-            ids.add(worldStyleName(key));
+        List<Identifier> keys = new ArrayList<>(registry.get().keySet());
+        keys.sort(Comparator.comparingInt((Identifier k) -> STANDARD_STYLE.equals(k.toString()) ? 0 : 1)
+                .thenComparing(Comparator.comparing(Identifier::toString)));
+        Map<String, String> names = new LinkedHashMap<>();
+        for (Identifier key : keys) {
+            names.put(key.toString(), worldStyleDisplayName(registry.get(), key));
         }
-        ids.sort(Comparator.comparingInt((String s) -> STANDARD_STYLE.equals(s) ? 0 : 1)
-                .thenComparing(Comparator.naturalOrder()));
-        return ids;
+        return names;
     }
 
     /**
-     * The name a worldStyle registry key is shown/published as: its full {@code namespace:path},
-     * unabbreviated - once a second datapack is installed, a bare "standard" next to a bare
-     * "moderntweaks" would not say which pack owns which, so every entry is qualified.
+     * The label for one worldStyle: its {@code name}, folded over the {@code extends} chain by the
+     * same {@link WorldStyle#displayNameOf} worldgen uses, falling back to the fully-qualified id.
+     * <p>
+     * A chain this screen cannot walk - a dangling {@code extends}, or a cycle - falls back to the
+     * id rather than propagating: the world will refuse to load with a message that names the real
+     * cause, and a dropdown that throws out of its own constructor would take the create-world
+     * screen down before the player ever got that message.
      */
-    private static String worldStyleName(Identifier key) {
-        return key.toString();
+    private static String worldStyleDisplayName(Registry<WorldStyleRE> registry, Identifier id) {
+        try {
+            return WorldStyle.displayNameOf(
+                    ExtendsChain.resolve(id, registry::getValue, WorldStyleRE::getExtends), id);
+        } catch (RuntimeException e) {
+            return id.toString();
+        }
     }
 
     /**
@@ -399,7 +427,9 @@ public class CitiesTab extends GridLayoutTab {
         List<PresetSelection.Entry> entries = new ArrayList<>();
         for (Identifier id : Presets.listBrowsable(access)) {
             Preset preset = Presets.resolve(id, registry.get()::getValue);
-            entries.add(new PresetSelection.Entry(id, Component.literal(id.toString()), preset));
+            // The preset's authored name, falling back to the id for a datapack that declares none -
+            // which is what every row read as before the field existed.
+            entries.add(new PresetSelection.Entry(id, Component.literal(preset.getDisplayName()), preset));
         }
         return entries;
     }

--- a/src/main/java/dev/krona/urbex/gui/CustomizeScreen.java
+++ b/src/main/java/dev/krona/urbex/gui/CustomizeScreen.java
@@ -75,7 +75,7 @@ public class CustomizeScreen extends Screen {
     private final Screen parent;
     @Nullable
     private final CreateWorldScreen createWorldScreen;
-    /** Display name only ({@code base.getId().toString()}) - not the editor's own state. */
+    /** Display name only ({@code base.getDisplayName()}) - not the editor's own state. */
     private final String baseName;
     private final Preset base;
     private Preset copy;
@@ -104,11 +104,11 @@ public class CustomizeScreen extends Screen {
     private boolean suppressSearchResponder;
 
     public CustomizeScreen(Screen parent, Preset base) {
-        super(Component.translatable("urbex.screen.customize.title", base.getId().toString()));
+        super(Component.translatable("urbex.screen.customize.title", base.getDisplayName()));
         this.parent = parent;
         this.createWorldScreen = parent instanceof CreateWorldScreen cws ? cws : null;
         this.base = base;
-        this.baseName = base.getId().toString();
+        this.baseName = base.getDisplayName();
         this.copy = base.copy();
         this.preview = new CityPreview(previewRegistries(createWorldScreen));
         this.previewSeedFallback = random.nextLong();

--- a/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
@@ -164,6 +164,9 @@ public class NullDimensionInfo implements IDimensionInfo {
     private static WorldStyleRE placeholderStyle() {
         return new WorldStyleRE(
                 Optional.empty(),
+                // No display name: this style is never offered in the picker, so nothing would read
+                // one, and inventing a label here would put a name on screen if that ever changed.
+                Optional.empty(),
                 // Fully qualified, like every other asset reference: a bare name throws out of
                 // DataTools.fromName the moment anything resolves it.
                 Optional.of(PLACEHOLDER_OUTSIDE_STYLE),

--- a/src/main/java/dev/krona/urbex/gui/PresetListWidget.java
+++ b/src/main/java/dev/krona/urbex/gui/PresetListWidget.java
@@ -120,9 +120,14 @@ public class PresetListWidget extends ObjectSelectionList<PresetListWidget.Row> 
             return entry;
         }
 
+        /**
+         * The label plus the preset's id. The row itself shows only the label - since presets grew a
+         * {@code name}, that is a human phrase and no longer says which datapack owns the preset -
+         * and this is where the id stays reachable without costing the row a second line.
+         */
         @Override
         public Component getNarration() {
-            return label;
+            return Component.literal(label.getString() + " (" + entry.id() + ")");
         }
 
         @Override

--- a/src/main/java/dev/krona/urbex/gui/WorldStyleDialog.java
+++ b/src/main/java/dev/krona/urbex/gui/WorldStyleDialog.java
@@ -14,14 +14,19 @@ import net.minecraft.network.chat.Component;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
  * The modal "Select World Style" picker raised from the {@link CitiesTab} world-style button: a
- * scrollable {@link ObjectSelectionList} of the registered style ids plus a cancel button. Vanilla
+ * scrollable {@link ObjectSelectionList} of the registered styles plus a cancel button. Vanilla
  * ships no combobox, so this is the dropdown - a click on a row hands the chosen id to the caller and
  * closes; cancel (or Escape) leaves the current style untouched. The currently effective style opens
  * pre-selected and tinted, so the player sees what generates now before changing it.
+ * <p>
+ * A row shows the style's <em>display name</em> over its id in grey. The id stays on screen because
+ * it is the thing a datapack author has to type, and because two packs are free to give their
+ * styles the same name - the id is what tells them apart.
  * <p>
  * {@link #preselectIndex} is the one pure, headless-testable piece ({@code WorldStyleDialogTest});
  * everything else is GL widget code exercised only manually. Nothing here lays widgets at fixed
@@ -30,21 +35,27 @@ import java.util.function.Consumer;
  */
 public class WorldStyleDialog extends Screen {
 
-    /** Beyond this the single-column list of short ids just gets emptier; cap and centre instead. */
+    /** Beyond this the single-column list just gets emptier; cap and centre instead. */
     private static final int MAX_WIDTH = 220;
     private static final int SCREEN_MARGIN = 20;
-    private static final int ROW_HEIGHT = 20;
+    /** Two stacked text lines (name over id) plus 4px of breathing room above and below. */
+    private static final int ROW_HEIGHT = 26;
     private static final int BUTTON_HEIGHT = 20;
     private static final int GAP = 6;
     private static final int TITLE_GAP = 8;
     private static final int TEXT_INSET = 6;
+    private static final int LINE_GAP = 1;
 
     private static final int STYLE_COLOR = 0xffffffff;
     /** The style that generates right now, so it reads as "current" even after the player arrows away. */
     private static final int CURRENT_STYLE_COLOR = 0xffffff55;
+    /** The id line: present but subordinate to the name above it. */
+    private static final int ID_COLOR = 0xff9f9f9f;
 
     private final Screen parent;
     private final List<String> styles;
+    /** Style id -> label; a style missing from it falls back to showing its id as the name. */
+    private final Map<String, String> names;
     private final String current;
     private final Consumer<String> onSelect;
 
@@ -52,12 +63,19 @@ public class WorldStyleDialog extends Screen {
     private StyleList list;
     private int titleY;
 
-    public WorldStyleDialog(Screen parent, List<String> styles, String current, Consumer<String> onSelect) {
+    public WorldStyleDialog(Screen parent, List<String> styles, Map<String, String> names,
+                            String current, Consumer<String> onSelect) {
         super(Component.translatable("urbex.screen.worldstyle.title"));
         this.parent = parent;
         this.styles = List.copyOf(styles);
+        this.names = Map.copyOf(names);
         this.current = current == null ? "" : current;
         this.onSelect = onSelect;
+    }
+
+    /** The label for a style id, falling back to the id itself when the caller supplied none. */
+    private String nameOf(String style) {
+        return names.getOrDefault(style, style);
     }
 
     /**
@@ -167,7 +185,7 @@ public class WorldStyleDialog extends Screen {
 
             @Override
             public Component getNarration() {
-                return Component.literal(style);
+                return Component.literal(nameOf(style) + " (" + style + ")");
             }
 
             @Override
@@ -179,9 +197,20 @@ public class WorldStyleDialog extends Screen {
             @Override
             public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float partialTick) {
                 Font font = Minecraft.getInstance().font;
-                int textY = getContentY() + Math.max(0, (getContentHeight() - font.lineHeight) / 2);
+                String name = nameOf(style);
+                int x = getContentX() + TEXT_INSET;
                 int color = style.equals(current) ? CURRENT_STYLE_COLOR : STYLE_COLOR;
-                graphics.text(font, Component.literal(style), getContentX() + TEXT_INSET, textY, color);
+                // A style with no name of its own is already labelled by its id, so the second line
+                // would repeat it verbatim; draw the single line centred instead.
+                if (name.equals(style)) {
+                    int textY = getContentY() + Math.max(0, (getContentHeight() - font.lineHeight) / 2);
+                    graphics.text(font, Component.literal(style), x, textY, color);
+                    return;
+                }
+                int block = font.lineHeight * 2 + LINE_GAP;
+                int top = getContentY() + Math.max(0, (getContentHeight() - block) / 2);
+                graphics.text(font, Component.literal(name), x, top, color);
+                graphics.text(font, Component.literal(style), x, top + font.lineHeight + LINE_GAP, ID_COLOR);
             }
         }
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyle.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyle.java
@@ -15,6 +15,9 @@ public class CityStyle {
 
     private final Identifier name;
 
+    /** The last {@code name} declared anywhere in the chain; null until {@code applyFrom} sees one. */
+    private String displayName;
+
     /**
      * Sorted, not a {@code HashSet}: {@code Stuff.generateStuff} iterates these tags and assigns a
      * running {@code stuffOrdinal} across all of them, and that ordinal is the RNG slot address
@@ -125,6 +128,9 @@ public class CityStyle {
      * that omits a field does not blank out what an earlier entry set.
      */
     private void applyFrom(CityStyleRE object) {
+        if (object.getDisplayName() != null) {
+            displayName = object.getDisplayName();
+        }
         if (object.getStyle() != null) {
             style = object.getStyle();
         }
@@ -269,6 +275,14 @@ public class CityStyle {
     /** The fully-qualified id, e.g. {@code "urbex:citystyle_common"}. */
     public String getName() {
         return name.toString();
+    }
+
+    /**
+     * What a UI should label this city style: the {@code name} the last declaring link in the chain
+     * authored, or the fully-qualified id when nothing did. Never null and never empty.
+     */
+    public String getDisplayName() {
+        return displayName == null || displayName.isEmpty() ? name.toString() : displayName;
     }
 
     public Identifier getId() {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 public class WorldStyle {
 
     private final Identifier name;
+    private final String displayName;
     private final String outsideStyle;
 
     private final ScatteredSettings scatteredSettings;
@@ -85,6 +86,7 @@ public class WorldStyle {
                 Mergeable.apply(multipliers, object.getCityBiomeMultipliers());
             }
         }
+        this.displayName = displayNameOf(chainRootFirst, name);
         this.outsideStyle = Resolved.require(outside, name, "outsidestyle");
         Resolved.require(anySelectors ? selectors : null, name, "citystyles");
         this.scatteredSettings = scattered;
@@ -106,6 +108,28 @@ public class WorldStyle {
         }
     }
 
+    /**
+     * Folds a resolved chain's {@code name} declarations the same way every other scalar field is
+     * folded - last declaring link wins - and fills the gap with {@code id} when nothing declared
+     * one. {@code name} is optional like {@code rotatable} rather than required like
+     * {@code outsidestyle}: a chain that names itself nowhere is labelled by its id, exactly as
+     * every world style was before the field existed.
+     * <p>
+     * Static and taking the chain rather than reading instance state, because the world-style
+     * picker needs the same label from a registry it cannot build a whole {@link WorldStyle} out of
+     * (that would require the chain to be complete, which is worldgen's check to make, not a
+     * dropdown's).
+     */
+    public static String displayNameOf(List<WorldStyleRE> chainRootFirst, Identifier id) {
+        String display = null;
+        for (WorldStyleRE object : chainRootFirst) {
+            if (object.getDisplayName() != null) {
+                display = object.getDisplayName();
+            }
+        }
+        return display == null || display.isEmpty() ? id.toString() : display;
+    }
+
     /** The fully-qualified id, e.g. {@code "urbex:standard"}. */
     public String getName() {
         return name.toString();
@@ -113,6 +137,14 @@ public class WorldStyle {
 
     public Identifier getId() {
         return name;
+    }
+
+    /**
+     * What a UI should label this world style: the {@code name} the last declaring link in the chain
+     * authored, or the fully-qualified id when nothing did. Never null and never empty.
+     */
+    public String getDisplayName() {
+        return displayName;
     }
 
     public String getOutsideStyle() {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/CityStyleRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/CityStyleRE.java
@@ -16,6 +16,7 @@ public class CityStyleRE implements IAsset<CityStyleRE>, Extendable {
                     Codec.FLOAT.optionalFieldOf("explosionchance").forGetter(l -> Optional.ofNullable(l.explosionChance)),
                     Codec.STRING.optionalFieldOf("style").forGetter(l -> Optional.ofNullable(l.style)),
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(CityStyleRE::getExtends),
+                    Codec.STRING.optionalFieldOf("name").forGetter(l -> Optional.ofNullable(l.displayName)),
                     Codec.STRING.listOf().optionalFieldOf("stuff_tags").forGetter(l -> Optional.ofNullable(l.stuffTags)),
                     GeneralSettings.CODEC.optionalFieldOf("generalblocks").forGetter(l -> Optional.ofNullable(l.generalSettings)),
                     BuildingSettings.CODEC.optionalFieldOf("buildingsettings").forGetter(l -> Optional.ofNullable(l.buildingSettings)),
@@ -35,6 +36,10 @@ public class CityStyleRE implements IAsset<CityStyleRE>, Extendable {
     private final String style;
     private final Optional<Identifier> extendsId;
 
+    // The human-readable label for this city style. Null means "not declared here", so the chain
+    // reads it from an ancestor; a chain that declares none anywhere falls back to the id.
+    private final String displayName;
+
     private final List<String> stuffTags;
 
     private final GeneralSettings generalSettings;
@@ -50,6 +55,7 @@ public class CityStyleRE implements IAsset<CityStyleRE>, Extendable {
             Optional<Float> explosionChance,
             Optional<String> style,
             Optional<Identifier> extendsId,
+            Optional<String> displayName,
             Optional<List<String>> stuffTags,
             Optional<GeneralSettings> generalSettings,
             Optional<BuildingSettings> buildingSettings,
@@ -61,6 +67,7 @@ public class CityStyleRE implements IAsset<CityStyleRE>, Extendable {
         this.explosionChance = explosionChance.orElse(null);
         this.style = style.orElse(null);
         this.extendsId = extendsId;
+        this.displayName = displayName.orElse(null);
         this.stuffTags = stuffTags.orElse(null);
         this.generalSettings = generalSettings.orElse(null);
         this.buildingSettings = buildingSettings.orElse(null);
@@ -73,6 +80,11 @@ public class CityStyleRE implements IAsset<CityStyleRE>, Extendable {
 
     public Float getExplosionChance() {
         return explosionChance;
+    }
+
+    @Nullable
+    public String getDisplayName() {
+        return displayName;
     }
 
     @Nullable

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PresetRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PresetRE.java
@@ -1,6 +1,7 @@
 package dev.krona.urbex.worldgen.lost.regassets;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.AtmosphereSettings;
@@ -29,17 +30,40 @@ import java.util.Set;
  */
 public class PresetRE implements IAsset<PresetRE>, Extendable {
 
-    public static final Set<String> KEYS = Set.of("extends", "description", "extraDescription", "warning", "icon",
-            "terrain", "cities", "buildings", "roads", "highways", "railways", "destruction", "decoration",
+    public static final Set<String> KEYS = Set.of("extends", "name", "description", "extraDescription", "warning",
+            "icon", "terrain", "cities", "buildings", "roads", "highways", "railways", "destruction", "decoration",
             "spawn", "atmosphere", "misc");
+
+    /**
+     * The six non-section keys, as one {@link MapCodec} inlined into the preset's own JSON object -
+     * {@code "name"} and its five neighbours stay top-level keys, exactly where they were authored.
+     * <p>
+     * Not a shape anyone asked for: {@code RecordCodecBuilder.group} tops out at sixteen fields, and
+     * adding {@code name} made seventeen. Bundling the metadata behind a {@code MapCodec} is the one
+     * way to buy a field back without moving a key or nesting one, so this record exists purely to
+     * be flattened again and never appears in the format.
+     */
+    private record Meta(Optional<Identifier> extendsId,
+                        Optional<String> name,
+                        Optional<String> description,
+                        Optional<String> extraDescription,
+                        Optional<String> warning,
+                        Optional<String> icon) {
+    }
+
+    private static final MapCodec<Meta> META = RecordCodecBuilder.mapCodec(instance ->
+            instance.group(
+                    DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(Meta::extendsId),
+                    Codec.STRING.optionalFieldOf("name").forGetter(Meta::name),
+                    Codec.STRING.optionalFieldOf("description").forGetter(Meta::description),
+                    Codec.STRING.optionalFieldOf("extraDescription").forGetter(Meta::extraDescription),
+                    Codec.STRING.optionalFieldOf("warning").forGetter(Meta::warning),
+                    Codec.STRING.optionalFieldOf("icon").forGetter(Meta::icon)
+            ).apply(instance, Meta::new));
 
     private static final Codec<PresetRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
-                    DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(PresetRE::getExtends),
-                    Codec.STRING.optionalFieldOf("description").forGetter(PresetRE::description),
-                    Codec.STRING.optionalFieldOf("extraDescription").forGetter(PresetRE::extraDescription),
-                    Codec.STRING.optionalFieldOf("warning").forGetter(PresetRE::warning),
-                    Codec.STRING.optionalFieldOf("icon").forGetter(PresetRE::icon),
+                    META.forGetter(PresetRE::meta),
                     TerrainSettings.CODEC.optionalFieldOf("terrain").forGetter(PresetRE::terrain),
                     CitySettings.CODEC.optionalFieldOf("cities").forGetter(PresetRE::cities),
                     BuildingSettings.CODEC.optionalFieldOf("buildings").forGetter(PresetRE::buildings),
@@ -66,6 +90,7 @@ public class PresetRE implements IAsset<PresetRE>, Extendable {
     private Identifier name;
 
     private final Optional<Identifier> extendsId;
+    private final Optional<String> displayName;
     private final Optional<String> description;
     private final Optional<String> extraDescription;
     private final Optional<String> warning;
@@ -83,6 +108,7 @@ public class PresetRE implements IAsset<PresetRE>, Extendable {
     private final Optional<MiscSettings> misc;
 
     public PresetRE(Optional<Identifier> extendsId,
+                     Optional<String> displayName,
                      Optional<String> description,
                      Optional<String> extraDescription,
                      Optional<String> warning,
@@ -98,11 +124,30 @@ public class PresetRE implements IAsset<PresetRE>, Extendable {
                      Optional<SpawnSettings> spawn,
                      Optional<AtmosphereSettings> atmosphere,
                      Optional<MiscSettings> misc) {
-        this.extendsId = extendsId;
-        this.description = description;
-        this.extraDescription = extraDescription;
-        this.warning = warning;
-        this.icon = icon;
+        this(new Meta(extendsId, displayName, description, extraDescription, warning, icon),
+                terrain, cities, buildings, roads, highways, railways, destruction, decoration,
+                spawn, atmosphere, misc);
+    }
+
+    /** The codec's own constructor; see {@link Meta} for why the metadata arrives bundled. */
+    private PresetRE(Meta meta,
+                     Optional<TerrainSettings> terrain,
+                     Optional<CitySettings> cities,
+                     Optional<BuildingSettings> buildings,
+                     Optional<RoadSettings> roads,
+                     Optional<HighwaySettings> highways,
+                     Optional<RailwaySettings> railways,
+                     Optional<DestructionSettings> destruction,
+                     Optional<DecorationSettings> decoration,
+                     Optional<SpawnSettings> spawn,
+                     Optional<AtmosphereSettings> atmosphere,
+                     Optional<MiscSettings> misc) {
+        this.extendsId = meta.extendsId();
+        this.displayName = meta.name();
+        this.description = meta.description();
+        this.extraDescription = meta.extraDescription();
+        this.warning = meta.warning();
+        this.icon = meta.icon();
         this.terrain = terrain;
         this.cities = cities;
         this.buildings = buildings;
@@ -119,6 +164,19 @@ public class PresetRE implements IAsset<PresetRE>, Extendable {
     @Override
     public Optional<Identifier> getExtends() {
         return extendsId;
+    }
+
+    private Meta meta() {
+        return new Meta(extendsId, displayName, description, extraDescription, warning, icon);
+    }
+
+    /**
+     * The human-readable label the Cities tab shows instead of the id. Inherited through
+     * {@code extends} exactly like {@link #description()}, so a pack that extends
+     * {@code urbex:default} and forgets to restate it is labelled "Default" - restate it.
+     */
+    public Optional<String> displayName() {
+        return displayName;
     }
 
     public Optional<String> description() {
@@ -183,6 +241,7 @@ public class PresetRE implements IAsset<PresetRE>, Extendable {
 
     /** Applies metadata (if present) then each present section's {@code apply}, onto {@code p}. */
     public void applyTo(Preset p) {
+        displayName.ifPresent(p::setName);
         description.ifPresent(p::setDescription);
         extraDescription.ifPresent(p::setExtraDescription);
         warning.ifPresent(p::setWarning);

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleRE.java
@@ -23,6 +23,7 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
     private static final Codec<WorldStyleRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
+                    Codec.STRING.optionalFieldOf("name").forGetter(l -> Optional.ofNullable(l.displayName)),
                     Codec.STRING.optionalFieldOf("outsidestyle").forGetter(l -> Optional.ofNullable(l.outsideStyle)),
                     MultiSettings.CODEC.optionalFieldOf("multisettings").forGetter(l -> Optional.ofNullable(l.multiSettings)),
                     WorldSettings.CODEC.optionalFieldOf("settings").forGetter(l -> Optional.ofNullable(l.worldSettings)),
@@ -38,6 +39,10 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
 
     private Identifier name;
     private final Optional<Identifier> extendsId;
+    // The human-readable label the world-style picker shows instead of the id. Null means "not
+    // declared here", so the chain reads it from an ancestor; a chain that declares none anywhere
+    // falls back to the id in WorldStyle, which is what the picker showed before the field existed.
+    private final String displayName;
     // Null on either of these means "not declared here", so the chain reads it from an ancestor.
     private final String outsideStyle;
     private final MultiSettings multiSettings;
@@ -52,6 +57,7 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
     private final TagKey<Block> rotatable;
 
     public WorldStyleRE(Optional<Identifier> extendsId,
+                        Optional<String> displayName,
                         Optional<String> outsideStyle,
                         Optional<MultiSettings> multiSettings,
                         Optional<WorldSettings> worldSettings,
@@ -61,6 +67,7 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
                         Optional<Mergeable<CityBiomeMultiplier>> cityBiomeMultipliers,
                         Optional<TagKey<Block>> rotatable) {
         this.extendsId = extendsId;
+        this.displayName = displayName.orElse(null);
         this.outsideStyle = outsideStyle.orElse(null);
         this.multiSettings = multiSettings.orElse(null);
         this.worldSettings = worldSettings.orElse(null);
@@ -69,6 +76,11 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
         this.cityStyleSelectors = cityStyleSelector.orElse(null);
         this.cityBiomeMultipliers = cityBiomeMultipliers.orElse(null);
         this.rotatable = rotatable.orElse(null);
+    }
+
+    @Nullable
+    public String getDisplayName() {
+        return displayName;
     }
 
     @Nullable

--- a/src/main/resources/data/urbex/urbex/citystyles/citystyle_border.json
+++ b/src/main/resources/data/urbex/urbex/citystyles/citystyle_border.json
@@ -1,4 +1,5 @@
 {
+  "name": "Border",
   "style": "urbex:standard_border",
   "extends": "urbex:citystyle_common",
   "buildingsettings": {

--- a/src/main/resources/data/urbex/urbex/citystyles/citystyle_desert.json
+++ b/src/main/resources/data/urbex/urbex/citystyles/citystyle_desert.json
@@ -1,4 +1,5 @@
 {
+  "name": "Desert",
   "style": "urbex:desert",
   "extends": "urbex:citystyle_common"
 }

--- a/src/main/resources/data/urbex/urbex/citystyles/citystyle_standard.json
+++ b/src/main/resources/data/urbex/urbex/citystyles/citystyle_standard.json
@@ -1,4 +1,5 @@
 {
+  "name": "Standard",
   "style": "urbex:standard",
   "extends": "urbex:citystyle_common"
 }

--- a/src/main/resources/data/urbex/urbex/presets/ancient.json
+++ b/src/main/resources/data/urbex/urbex/presets/ancient.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Ancient",
   "description": "Ancient jungle city, leafs, ruined buildings",
   "icon": "textures/gui/icon_ancient.png",
   "decoration": {

--- a/src/main/resources/data/urbex/urbex/presets/atlantis.json
+++ b/src/main/resources/data/urbex/urbex/presets/atlantis.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Atlantis",
   "description": "Drowned cities, raised waterlevel (to 89)",
   "warning": "Preferably use this in combination with the Lost Worlds 'atlantis' world type",
   "icon": "textures/gui/icon_atlantis.png",

--- a/src/main/resources/data/urbex/urbex/presets/cavern.json
+++ b/src/main/resources/data/urbex/urbex/presets/cavern.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Cavern",
   "description": "This profile is meant for a cavern type world. There are lights in the building but the outside is very dark.",
   "extraDescription": "This is very hard. It's recommended you enable a bonus chest!",
   "warning": "Use this in combination with the Lost Worlds 'caves' world type",

--- a/src/main/resources/data/urbex/urbex/presets/default.json
+++ b/src/main/resources/data/urbex/urbex/presets/default.json
@@ -1,4 +1,5 @@
 {
+  "name": "Default",
   "description": "Default generation, common cities, explosions",
   "icon": "textures/gui/icon_default.png",
   "roads": {

--- a/src/main/resources/data/urbex/urbex/presets/floating.json
+++ b/src/main/resources/data/urbex/urbex/presets/floating.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Floating",
   "description": "Cities on floating islands",
   "extraDescription": "Note! No mineshafts or strongholds in this profile!",
   "warning": "Preferably use this in combination with the Lost Worlds 'islands' world type",

--- a/src/main/resources/data/urbex/urbex/presets/largecities.json
+++ b/src/main/resources/data/urbex/urbex/presets/largecities.json
@@ -1,5 +1,7 @@
 {
   "extends": "urbex:default",
+  "name": "Large Cities",
+  "description": "Large sprawling cities, taller buildings, more lighting",
   "icon": "textures/gui/icon_default.png",
   "cities": {
     "cityChance": -1,

--- a/src/main/resources/data/urbex/urbex/presets/nodamage.json
+++ b/src/main/resources/data/urbex/urbex/presets/nodamage.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "No Damage",
   "description": "Like default but no explosion damage",
   "extraDescription": "Ruins and rubble are disabled and ravines are disabled in cities",
   "icon": "textures/gui/icon_nodamage.png",

--- a/src/main/resources/data/urbex/urbex/presets/onlycities.json
+++ b/src/main/resources/data/urbex/urbex/presets/onlycities.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Only Cities",
   "description": "The entire world is a city",
   "icon": "textures/gui/icon_onlycities.png",
   "cities": {

--- a/src/main/resources/data/urbex/urbex/presets/rarecities.json
+++ b/src/main/resources/data/urbex/urbex/presets/rarecities.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Rare Cities",
   "description": "Cities are rare",
   "icon": "textures/gui/icon_rarecities.png",
   "cities": { "cityChance": 0.001 },

--- a/src/main/resources/data/urbex/urbex/presets/safe.json
+++ b/src/main/resources/data/urbex/urbex/presets/safe.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Safe",
   "description": "Safe mode: no spawners, lighting but no loot",
   "icon": "textures/gui/icon_safe.png",
   "buildings": {

--- a/src/main/resources/data/urbex/urbex/presets/tallbuildings.json
+++ b/src/main/resources/data/urbex/urbex/presets/tallbuildings.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Tall Buildings",
   "description": "Very tall buildings (performance heavy)",
   "icon": "textures/gui/icon_tallbuildings.png",
   "buildings": {

--- a/src/main/resources/data/urbex/urbex/presets/wasteland.json
+++ b/src/main/resources/data/urbex/urbex/presets/wasteland.json
@@ -1,5 +1,6 @@
 {
   "extends": "urbex:default",
+  "name": "Wasteland",
   "description": "Wasteland, no water, bare land",
   "extraDescription": "This profile works best with Biomes O Plenty and the Wastify mod",
   "icon": "textures/gui/icon_wasteland.png",

--- a/src/main/resources/data/urbex/urbex/worldstyles/standard.json
+++ b/src/main/resources/data/urbex/urbex/worldstyles/standard.json
@@ -1,4 +1,5 @@
 {
+  "name": "Standard",
   "outsidestyle": "urbex:outside",
   "settings": {
     "railwayavoidance": "ignore",

--- a/src/test/java/dev/krona/urbex/config/DisplayNameTest.java
+++ b/src/test/java/dev/krona/urbex/config/DisplayNameTest.java
@@ -1,0 +1,136 @@
+package dev.krona.urbex.config;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import net.minecraft.resources.Identifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The preset half of the {@code name} field: how it resolves, and what a UI reads when nothing
+ * declared one.
+ * <p>
+ * The fallback is the part worth pinning. Before {@code name} existed the Cities tab labelled every
+ * row with the fully-qualified id, and a datapack that declares no name must still read exactly that
+ * way - a blank row would be a worse regression than the namespacing this field exists to fix.
+ * <p>
+ * Headless: {@code Presets.resolve(Identifier, Function)} needs no registry or level.
+ */
+class DisplayNameTest {
+
+    private static PresetRE decode(String json) {
+        JsonElement element = JsonParser.parseString(json);
+        return PresetRE.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
+    }
+
+    private static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath("urbex", path);
+    }
+
+    @Test
+    void anAuthoredNameIsWhatTheUiShows() {
+        Identifier presetId = id("tallbuildings");
+        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{\"name\": \"Tall Buildings\"}"));
+
+        Preset p = Presets.resolve(presetId, lookup::get);
+
+        assertEquals("Tall Buildings", p.getName());
+        assertEquals("Tall Buildings", p.getDisplayName());
+    }
+
+    @Test
+    void noNameAnywhereFallsBackToTheFullyQualifiedId() {
+        Identifier presetId = id("tallbuildings");
+        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{}"));
+
+        Preset p = Presets.resolve(presetId, lookup::get);
+
+        assertEquals("", p.getName(), "nothing was authored, so the raw field stays empty");
+        assertEquals("urbex:tallbuildings", p.getDisplayName(),
+                "the fallback is the id, which is what every row showed before the field existed");
+    }
+
+    @Test
+    void anEmptyStringIsTreatedAsNoNameRatherThanAsABlankLabel() {
+        Identifier presetId = id("blank");
+        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{\"name\": \"\"}"));
+
+        assertEquals("urbex:blank", Presets.resolve(presetId, lookup::get).getDisplayName());
+    }
+
+    /**
+     * {@code name} inherits like {@code description} does. Documented rather than merely observed:
+     * it is the reason every shipped preset declares one, and the reason the two abstract city-style
+     * bases deliberately declare none.
+     */
+    @Test
+    void aChildInheritsItsParentsNameWhenItDeclaresNone() {
+        Identifier parent = id("default");
+        Identifier child = id("largecities");
+        Map<Identifier, PresetRE> lookup = Map.of(
+                parent, decode("{\"name\": \"Default\"}"),
+                child, decode("{\"extends\": \"urbex:default\"}"));
+
+        assertEquals("Default", Presets.resolve(child, lookup::get).getDisplayName());
+    }
+
+    @Test
+    void aChildsOwnNameWinsOverTheOneItExtends() {
+        Identifier parent = id("default");
+        Identifier child = id("largecities");
+        Map<Identifier, PresetRE> lookup = Map.of(
+                parent, decode("{\"name\": \"Default\"}"),
+                child, decode("{\"extends\": \"urbex:default\", \"name\": \"Large Cities\"}"));
+
+        assertEquals("Large Cities", Presets.resolve(child, lookup::get).getDisplayName());
+    }
+
+    /**
+     * The customized-preset path: the Cities tab's "Customize this preset…" entry is published as a
+     * {@code PresetRE} overlay built by {@code toRE()}, and rebuilt from it on a Re-Create. A name
+     * dropped anywhere along that round trip would rename the row on reload.
+     */
+    @Test
+    void theNameSurvivesCopyAndTheToReRoundTrip() {
+        Identifier presetId = id("wasteland");
+        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{\"name\": \"Wasteland\"}"));
+        Preset resolved = Presets.resolve(presetId, lookup::get);
+
+        assertEquals("Wasteland", resolved.copy().getDisplayName());
+
+        Preset rebuilt = Presets.applyOverrides(new Preset(presetId), resolved.toRE());
+        assertEquals("Wasteland", rebuilt.getDisplayName());
+    }
+
+    /** A name is free text; nothing may try to read it as an id. */
+    @Test
+    void aNameNeedsNoNamespaceAndMayContainSpacesAndPunctuation() {
+        Identifier presetId = id("fancy");
+        Map<Identifier, PresetRE> lookup =
+                Map.of(presetId, decode("{\"name\": \"Cities & Ruins (heavy)\"}"));
+
+        assertEquals("Cities & Ruins (heavy)", Presets.resolve(presetId, lookup::get).getDisplayName());
+    }
+
+    @Test
+    void nameIsEncodedUnderItsOwnKeyAndNowhereElse() {
+        Preset p = new Preset(id("x"));
+        p.setName("Example");
+
+        JsonElement json = PresetRE.CODEC.encodeStart(JsonOps.INSTANCE, p.toRE()).getOrThrow();
+
+        assertTrue(json.getAsJsonObject().has("name"), "toRE() must carry the name");
+        assertEquals("Example", json.getAsJsonObject().get("name").getAsString());
+        // The metadata block is a MapCodec purely to buy a seventeenth field back from
+        // RecordCodecBuilder's sixteen-field limit; it must stay flattened into the file's own
+        // object, or every existing preset's 'description' and 'icon' would need renesting.
+        assertTrue(json.getAsJsonObject().has("description"),
+                "the metadata MapCodec must inline its keys, not nest them");
+    }
+}

--- a/src/test/java/dev/krona/urbex/config/PresetResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetResolutionTest.java
@@ -31,7 +31,7 @@ class PresetResolutionTest {
         return new PresetRE(Optional.of(extendsId), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.empty());
+                Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     @Test

--- a/src/test/java/dev/krona/urbex/config/ShippedPresetsTest.java
+++ b/src/test/java/dev/krona/urbex/config/ShippedPresetsTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShippedPresetsTest {
@@ -122,5 +123,55 @@ class ShippedPresetsTest {
         Set<Identifier> presetIds = presets.keySet();
         assertEquals(presetIds, tagValues,
                 "Tag values do not match shipped presets");
+    }
+
+    /**
+     * Every shipped preset declares its own {@code name}, and no two share one.
+     * <p>
+     * Both halves matter, and both are consequences of the field being inherited. A preset that
+     * omits it is not blank - it silently wears {@code urbex:default}'s "Default", because eleven
+     * of the twelve extend it - so the omission shows up as two identical rows in the Cities tab
+     * rather than as anything the loader would complain about. Uniqueness is the check that
+     * actually catches it, and stating it per file is what keeps it true.
+     */
+    @Test
+    void everyShippedPresetDeclaresItsOwnUniqueName() throws Exception {
+        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        assertFalse(presets.isEmpty(), "No preset files found");
+
+        Map<String, Identifier> byName = new HashMap<>();
+        for (var entry : presets.entrySet()) {
+            Identifier id = entry.getKey();
+            var name = entry.getValue().displayName();
+            assertTrue(name.isPresent() && !name.get().isBlank(),
+                    "Preset " + id + " declares no 'name', so the Cities tab shows the name it "
+                            + "inherits from urbex:default instead of its own");
+            Identifier clash = byName.put(name.get(), id);
+            assertNull(clash, "Presets " + clash + " and " + id + " both call themselves '"
+                    + name.get() + "'; the Cities tab shows the name alone, so they would be "
+                    + "two identical rows");
+        }
+    }
+
+    /**
+     * Every shipped preset declares its own {@code description}, for the same reason it declares its
+     * own {@code name}: the field is inherited, so omitting it is not blank but wrong.
+     * <p>
+     * {@code largecities} was exactly that - the only one of the twelve without one, so the Cities
+     * tab printed {@code urbex:default}'s "Default generation, common cities, explosions" under the
+     * heading "Large Cities". Nothing in the loader could have flagged it; it reads as a plausible
+     * blurb until you notice it is the same blurb as the row above.
+     */
+    @Test
+    void everyShippedPresetDeclaresItsOwnDescription() throws Exception {
+        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        assertFalse(presets.isEmpty(), "No preset files found");
+
+        for (var entry : presets.entrySet()) {
+            var description = entry.getValue().description();
+            assertTrue(description.isPresent() && !description.get().isBlank(),
+                    "Preset " + entry.getKey() + " declares no 'description', so the Cities tab "
+                            + "shows the one it inherits from urbex:default instead of its own");
+        }
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/TestProfiles.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/TestProfiles.java
@@ -40,6 +40,7 @@ final class TestProfiles {
         return new CityStyle(List.of(new CityStyleRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.of(TestWiring.streetSettings()), Optional.empty())));
+                Optional.empty(), Optional.empty(), Optional.of(TestWiring.streetSettings()),
+                Optional.empty())));
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyleInheritSelectorsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyleInheritSelectorsTest.java
@@ -77,7 +77,8 @@ class CityStyleInheritSelectorsTest {
         return new CityStyleRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.of(TestWiring.streetSettings()), Optional.of(selectors));
+                Optional.empty(), Optional.empty(), Optional.of(TestWiring.streetSettings()),
+                Optional.of(selectors));
     }
 
     private static List<String> values(CityStyle style, CityStyle.Sel kind) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
@@ -216,7 +216,7 @@ class RegistryChainResolutionTest {
 
     private static CityStyleRE cityStyleWithTags(String... tags) {
         return new CityStyleRE(
-                Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(List.of(tags)),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(List.of(tags)),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.of(TestWiring.streetSettings()), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "citystyle_" + tags[0]));
@@ -336,14 +336,14 @@ class RegistryChainResolutionTest {
     @Test
     void worldStyleChildInheritsTheSelectorsAndSettingsItDoesNotDeclare() {
         ScatteredSettings scattered = new ScatteredSettings(24, 0.25f, 4, List.of());
-        WorldStyleRE parent = new WorldStyleRE(Optional.empty(), Optional.of("urbex:standard"),
+        WorldStyleRE parent = new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:standard"),
                 Optional.empty(), Optional.empty(), Optional.of(scattered),
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
                         List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
                 Optional.empty(), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "standard"));
-        WorldStyleRE child = new WorldStyleRE(Optional.empty(), Optional.of("urbex:bleak"),
+        WorldStyleRE child = new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:bleak"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "bleak"));

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java
@@ -300,7 +300,7 @@ class RequiredAfterResolutionTest {
     private static WorldStyleRE worldStyle(Optional<String> outsideStyle,
                                            Optional<Mergeable<CityStyleSelector>> cityStyles,
                                            Optional<ScatteredSettings> scattered) {
-        return new WorldStyleRE(Optional.empty(), outsideStyle,
+        return new WorldStyleRE(Optional.empty(), Optional.empty(), outsideStyle,
                 Optional.empty(), Optional.empty(), scattered,
                 Optional.of(TestWiring.partSelector()),
                 cityStyles, Optional.empty(), Optional.empty())

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/StyleDisplayNameTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/StyleDisplayNameTest.java
@@ -1,0 +1,187 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The world-style and city-style half of {@code name}: folded root-first like every other scalar,
+ * falling back to the fully-qualified id when the chain declares none.
+ * <p>
+ * The fallback is what these mostly pin. Both pickers showed the id before the field existed, and
+ * both must keep doing so for an asset that never grew a name - the field is there to remove the
+ * namespacing from what a player reads, not to make an unnamed asset unreadable.
+ * <p>
+ * Like the other chain tests here, these build the chain by hand and let the constructor apply it
+ * root-first rather than resolving ids through a registry: the fold itself needs no world.
+ */
+class StyleDisplayNameTest {
+
+    /** {@code WorldStyle}'s rotatable fallback resolves a {@code TagKey}, which needs the registries. */
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static Identifier id(String namespace, String path) {
+        return Identifier.fromNamespaceAndPath(namespace, path);
+    }
+
+    private static WorldStyleRE worldStyle(Identifier registryName, Optional<String> name) {
+        return new WorldStyleRE(Optional.empty(), name, Optional.of("urbex:outside"),
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.of(TestWiring.partSelector()),
+                Optional.of(new Mergeable<>(true,
+                        List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
+                Optional.empty(), Optional.empty())
+                .setRegistryName(registryName);
+    }
+
+    private static CityStyleRE cityStyle(Identifier registryName, Optional<String> name) {
+        return new CityStyleRE(
+                Optional.empty(), Optional.empty(), Optional.empty(), name,
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.of(TestWiring.streetSettings()),
+                Optional.empty())
+                .setRegistryName(registryName);
+    }
+
+    // ---------------------------------------------------------------- world styles
+
+    @Test
+    void aWorldStyleDeclaringNoNameIsLabelledByItsId() {
+        WorldStyle resolved = new WorldStyle(
+                List.of(worldStyle(id("urbex", "standard"), Optional.empty())));
+
+        assertEquals("urbex:standard", resolved.getDisplayName(),
+                "every world style written before this field existed must keep reading as its id");
+    }
+
+    @Test
+    void aWorldStyleShowsTheNameItDeclares() {
+        WorldStyle resolved = new WorldStyle(
+                List.of(worldStyle(id("urbex", "standard"), Optional.of("Standard"))));
+
+        assertEquals("Standard", resolved.getDisplayName());
+    }
+
+    /**
+     * The case Urbex-Zombie-Apocalypse-Essentials actually hits: its world style extends
+     * {@code urbex:standard}, which ships {@code "name": "Standard"}, so without one of its own it
+     * would be offered in the picker as "Standard".
+     */
+    @Test
+    void aWorldStyleWithoutANameInheritsItsParents() {
+        WorldStyle resolved = new WorldStyle(List.of(
+                worldStyle(id("urbex", "standard"), Optional.of("Standard")),
+                worldStyle(id("urbexza", "zombie_apocalypse"), Optional.empty())));
+
+        assertEquals("Standard", resolved.getDisplayName(),
+                "the inheritance is why every shipped world style restates its own name");
+    }
+
+    @Test
+    void aWorldStylesOwnNameWinsOverTheOneItExtends() {
+        WorldStyle resolved = new WorldStyle(List.of(
+                worldStyle(id("urbex", "standard"), Optional.of("Standard")),
+                worldStyle(id("urbexza", "zombie_apocalypse"), Optional.of("Zombie Apocalypse"))));
+
+        assertEquals("Zombie Apocalypse", resolved.getDisplayName());
+    }
+
+    @Test
+    void anEmptyWorldStyleNameIsTreatedAsNoneRatherThanAsABlankLabel() {
+        WorldStyle resolved = new WorldStyle(
+                List.of(worldStyle(id("urbex", "standard"), Optional.of(""))));
+
+        assertEquals("urbex:standard", resolved.getDisplayName());
+    }
+
+    /**
+     * The world-style picker labels rows from a registry it cannot build whole {@link WorldStyle}s
+     * out of - doing so would demand a complete chain, which is worldgen's check to make and not a
+     * dropdown's. It calls this instead, so the two must agree.
+     */
+    @Test
+    void theStaticFoldTheGuiUsesMatchesWhatTheConstructorResolves() {
+        Identifier leaf = id("urbexmt", "moderntweaks");
+        List<WorldStyleRE> chain = List.of(
+                worldStyle(id("urbex", "standard"), Optional.of("Standard")),
+                worldStyle(leaf, Optional.of("Modern Tweaks")));
+
+        assertEquals(new WorldStyle(chain).getDisplayName(), WorldStyle.displayNameOf(chain, leaf));
+        assertEquals("urbexmt:moderntweaks",
+                WorldStyle.displayNameOf(List.of(worldStyle(leaf, Optional.empty())), leaf));
+    }
+
+    // ---------------------------------------------------------------- city styles
+
+    @Test
+    void aCityStyleDeclaringNoNameIsLabelledByItsId() {
+        CityStyle resolved = new CityStyle(
+                List.of(cityStyle(id("urbex", "citystyle_standard"), Optional.empty())));
+
+        assertEquals("urbex:citystyle_standard", resolved.getDisplayName());
+    }
+
+    @Test
+    void aCityStyleShowsTheNameItDeclares() {
+        CityStyle resolved = new CityStyle(
+                List.of(cityStyle(id("urbex", "citystyle_desert"), Optional.of("Desert"))));
+
+        assertEquals("Desert", resolved.getDisplayName());
+    }
+
+    /**
+     * Why the two abstract bases ({@code urbex:citystyle_common}, {@code urbex:citystyle_config})
+     * deliberately declare no name: an unnamed child of a named base borrows a label belonging to
+     * something else, where an unnamed child of an unnamed base falls back to its own id.
+     */
+    @Test
+    void aCityStyleWithoutANameInheritsItsParents() {
+        CityStyle borrowed = new CityStyle(List.of(
+                cityStyle(id("urbex", "citystyle_common"), Optional.of("Common")),
+                cityStyle(id("mypack", "downtown"), Optional.empty())));
+        assertEquals("Common", borrowed.getDisplayName());
+
+        CityStyle ownId = new CityStyle(List.of(
+                cityStyle(id("urbex", "citystyle_common"), Optional.empty()),
+                cityStyle(id("mypack", "downtown"), Optional.empty())));
+        assertEquals("mypack:downtown", ownId.getDisplayName(),
+                "an unnamed base is what lets an unnamed child keep its own identity");
+    }
+
+    @Test
+    void aCityStylesOwnNameWinsOverTheOneItExtends() {
+        CityStyle resolved = new CityStyle(List.of(
+                cityStyle(id("urbex", "citystyle_common"), Optional.of("Common")),
+                cityStyle(id("urbexmt", "citystyle_desert"), Optional.of("Modern Desert"))));
+
+        assertEquals("Modern Desert", resolved.getDisplayName());
+    }
+
+    /** {@code getName()} stays the id: worldgen, logs and conditions all key off it. */
+    @Test
+    void namingAStyleDoesNotChangeWhatGetNameReturns() {
+        CityStyle city = new CityStyle(
+                List.of(cityStyle(id("urbex", "citystyle_desert"), Optional.of("Desert"))));
+        assertEquals("urbex:citystyle_desert", city.getName());
+
+        WorldStyle world = new WorldStyle(
+                List.of(worldStyle(id("urbex", "standard"), Optional.of("Standard"))));
+        assertEquals("urbex:standard", world.getName());
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java
@@ -254,12 +254,12 @@ class WiringRequiredTest {
         return new CityStyleRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.ofNullable(settings), Optional.empty())
+                Optional.empty(), Optional.empty(), Optional.ofNullable(settings), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "citystyle_" + name));
     }
 
     private static WorldStyleRE worldStyle(String name, PartSelector.Decl parts) {
-        return new WorldStyleRE(Optional.empty(), Optional.of("urbex:outside"),
+        return new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.ofNullable(parts),
                 Optional.of(new Mergeable<>(true, List.of())), Optional.empty(), Optional.empty())
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", name));

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java
@@ -42,7 +42,7 @@ class WorldStyleRotatableTagTest {
     }
 
     private static WorldStyleRE worldStyle(String name, Optional<TagKey<Block>> rotatable) {
-        return new WorldStyleRE(Optional.empty(), Optional.of("urbex:outside"),
+        return new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,


### PR DESCRIPTION
Making every asset reference fully qualified (0.2.0) also made the Cities tab and the world-style picker show those ids: the preset list read `urbex:default`, `urbex:tallbuildings`, `urbex:wasteland`, and the selector read *World Style: urbex:standard*.

All three registries now take an optional top-level **`name`** — a plain human label, not an id and not a translation key — and that is what the UI shows.

## The rules

- **Nothing is required to have one.** A file declaring no `name` is labelled by its fully-qualified id, which is exactly what it read as before, so an unnamed third-party pack is drab rather than blank. An empty string counts as "no name" for the same reason.
- **It is inherited, like every other scalar** — the trap worth stating up front. A world style extending `urbex:standard` without a `name` of its own is now listed as **Standard**. The bundled pack therefore names all twelve presets, its world style and its three *selectable* city styles, and deliberately leaves the two abstract bases (`urbex:citystyle_common`, `urbex:citystyle_config`) unnamed so an unnamed child of theirs keeps its own id.
- **The id stays reachable where it matters.** The world-style dropdown shows the name over the id in grey — two packs may pick the same label, and the id is what an author has to type — and a preset row narrates as *name (id)*. `/urbex debug` prints the city style as `name (id)`; before this it printed the id alone, and city styles had no label at all.

## Also in here

`largecities` was the only shipped preset with no `description` of its own, so the tab printed `urbex:default`'s "Default generation, common cities, explosions" under the heading "Large Cities". It has one now, guarded the same way as `name`: both fields are inherited, so omitting either is not blank but wrong.

## One structural note

`PresetRE` was already at `RecordCodecBuilder.group`'s sixteen-field limit, so `name` made seventeen. Its six metadata keys now go through a `MapCodec` that inlines back into the same object — **the keys stay top-level in the JSON and no preset file changes shape**. The flat public constructor stays, delegating to a private codec-facing one, so call sites did not churn.

## Verification

- Full test suite green, including two new classes (`DisplayNameTest`, `StyleDisplayNameTest` — 19 cases covering the fold, the id fallback, the inheritance trap and the `toRE()` round trip) and two new `ShippedPresetsTest` guards.
- **Both digest goldens unchanged**, verified by running `runDigestCheck` — this is a display-only field and nothing about worldgen moves.
- The companion pack changes are separate MRs in `urbex-moderntweaks` and `urbex-zombie-apocalypse-essentials`; both packs' JVM validators decode against this branch and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)