### PR TITLE
refactor: post-generation todos onto the originating ChunkGenContext (#127 part a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Post-generation block writes belong to the generation that queued them.** The deferred writes a
+  chunk queues for after its driver has run — POI blocks, loot chests, command blocks, saplings, the
+  place-twice light refresh — were stored on the cached `BuildingInfo` for that chunk, and the
+  drain re-fetched that cache entry to find them. Three things could go wrong with that and now
+  cannot: the entry could be evicted between the write and the drain, taking the callbacks with it;
+  a second generation of the same chunk found the first one's callbacks still queued and applied
+  them to its own region; and a callback added on a worker thread while another cleared the map was
+  simply lost. They are now owned by the `ChunkGenContext` that queued them, which refuses both a
+  late enqueue and a second drain (issue #127, part a). *No worldgen change*: both digest goldens
+  are unchanged, verified by running `runDigestCheck` and `runDigestCheckFeatures`.
+
 - **Presets, world styles and city styles can name themselves again.** Making every asset reference
   fully qualified (0.2.0) also made the Cities tab and the world-style picker show those ids: the
   preset list read `urbex:default`, `urbex:tallbuildings`, `urbex:wasteland`, and the selector read

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -46,7 +46,7 @@ public class ChunkDriver {
     //
     // What this does NOT cover: writes this mod makes straight to the world, bypassing the
     // driver. Those are invisible here and so invisible to the digest. Today that is two things:
-    // the post-todo callbacks run out of BuildingInfo.getPostTodo, which write through the
+    // the post-todo callbacks ChunkFixer drains off the ChunkGenContext, which write through the
     // WorldGenLevel; and the border-block shape updates this class defers to vanilla
     // postprocessing (see updateAdjacent) - a matching DRIVERDIGEST no longer proves fence, wall
     // and stair connections at chunk borders are unchanged, because postprocessing writes them

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkFixer.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkFixer.java
@@ -1,23 +1,23 @@
 package dev.krona.urbex.worldgen;
 
-import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.lost.BuildingInfo;
-import net.minecraft.world.level.WorldGenLevel;
-
 public class ChunkFixer {
 
-
-    private static void executePostTodo(ChunkCoord coord, IDimensionInfo provider, WorldGenLevel region) {
-        BuildingInfo info = BuildingInfo.getBuildingInfo(coord, provider);
-        info.getPostTodo().forEach((pos, todo) -> todo.accept(region));
-        info.clearPostTodo();
+    private ChunkFixer() {
     }
 
     /**
-     * The region, not {@code info.getWorld()}: the post-todos read and write blocks, and only the
-     * region generating this chunk is guaranteed to have the chunks they touch.
+     * Runs the post-generation todos this context queued, once.
+     *
+     * <p>The context, not a re-fetched {@code BuildingInfo}: the todos belong to this generation of
+     * this chunk and nothing else may see them. Draining through the cache was how an evicted entry
+     * lost them and how a second generation of the same chunk inherited the first one's (issue
+     * #127); {@link PostTodoQueue} now refuses a second drain outright.</p>
+     *
+     * <p>They are applied to {@code ctx.region} rather than {@code provider.getWorld()}: the todos
+     * read and write blocks, and only the region generating this chunk is guaranteed to have the
+     * chunks they touch.</p>
      */
-    public static void fix(IDimensionInfo info, ChunkCoord coord, WorldGenLevel region) {
-        executePostTodo(coord, info, region);
+    public static void fix(ChunkGenContext ctx) {
+        ctx.drainPostTodo().forEach((pos, todo) -> todo.accept(ctx.region));
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
@@ -9,11 +9,14 @@ import dev.krona.urbex.worldgen.lost.cityassets.LightPool;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Everything one chunk's generation needs, built at the start of that generation and discarded at
@@ -32,6 +35,11 @@ public final class ChunkGenContext {
     public final CompiledPalette palette;
     public final char street;
     public final NoiseBuffers buffers;
+    /**
+     * Deferred writes this generation queues for after the driver has run. Owned here, not on the
+     * cached {@link BuildingInfo}: see {@link PostTodoQueue}.
+     */
+    private final PostTodoQueue postTodo = new PostTodoQueue();
     /**
      * Scratch for {@link CityGenerator#moveDown}'s top-of-column stash. Lives here
      * because the feature instance is shared across worldgen worker threads: as an instance
@@ -67,6 +75,18 @@ public final class ChunkGenContext {
 
     List<LightTodoQueue.Todo> drainLightTodo() {
         return lightTodo.closeAndDrain();
+    }
+
+    /**
+     * Queue a block write for after this chunk has been driven, addressed by {@code pos}. A second
+     * todo at the same position replaces the first.
+     */
+    void addPostTodo(BlockPos pos, Consumer<WorldGenLevel> todo) {
+        postTodo.add(pos, todo);
+    }
+
+    Map<BlockPos, Consumer<WorldGenLevel>> drainPostTodo() {
+        return postTodo.closeAndDrain();
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -309,7 +309,7 @@ public class CityGenerator {
         generateDebris(ctx, info);
 
         ctx.driver.actuallyGenerate(chunk);
-        ChunkFixer.fix(provider, coord, region);
+        ChunkFixer.fix(ctx);
         // After the fixer, so the post-todos have placed their blocks and what we see is final
         forgetOverwrittenBlockEntities(chunk);
 
@@ -417,7 +417,7 @@ public class CityGenerator {
                         .canSurvive(snapshotLevel(snapshotLevel, delegate, stateAt), marker));
         for (DeferredLightPlacer.Planned light : planned) {
             driver.currentAbsolute(light.pos()).block(light.state());
-            updateNeeded(info, light.pos(), Block.UPDATE_CLIENTS);
+            updateNeeded(ctx, light.pos(), Block.UPDATE_CLIENTS);
         }
     }
 
@@ -1864,20 +1864,20 @@ public class CityGenerator {
                                     // NBT into a chunk, which only the generating region has.
                                     b = handleSpawner(ctx, info, part, oy, ctx.region, rx, rz, y, b, inf);
                                 } else if (inf.tag() != null) {
-                                    b = handleBlockEntity(info, oy, ctx.region, rx, rz, y, b, inf);
+                                    b = handleBlockEntity(ctx, info, oy, ctx.region, rx, rz, y, b, inf);
                                 }
                             } else if (getStatesNeedingPoiUpdate().contains(b)) {
                                 // If this block has POI data we need to delay setting it
                                 BlockState finalB = b;
                                 BlockPos p = driver.getCurrentCopy();
-                                info.addPostTodo(p, inWorld -> {
+                                ctx.addPostTodo(p, inWorld -> {
                                     if (inWorld.getBlockState(p).getBlock() == Blocks.DIRT) {
                                         inWorld.setBlock(p, finalB, Block.UPDATE_NONE);
                                     }
                                 });
                                 b = Blocks.DIRT.defaultBlockState();
                             } else if (getStatesNeedingLightingUpdate().contains(b)) {
-                                updateNeeded(info, driver.getCurrentCopy(), Block.UPDATE_CLIENTS);
+                                updateNeeded(ctx, driver.getCurrentCopy(), Block.UPDATE_CLIENTS);
                             } else if (getStatesNeedingTodo().contains(b)) {
                                 b = handleTodo(ctx, info, oy, ctx.region, rx, rz, y, b);
                             }
@@ -1927,7 +1927,7 @@ public class CityGenerator {
         return null;
     }
 
-    private BlockState handleBlockEntity(BuildingInfo info, int oy, WorldGenLevel world, int rx, int rz, int y, BlockState b, Palette.Info inf) {
+    private BlockState handleBlockEntity(ChunkGenContext ctx, BuildingInfo info, int oy, WorldGenLevel world, int rx, int rz, int y, BlockState b, Palette.Info inf) {
         BlockPos pos = info.getRelativePos(rx, oy + y, rz);
         BlockEntityType type = getTypeForBlock(b);
         if (type == null) {
@@ -1941,7 +1941,7 @@ public class CityGenerator {
         tag.putString("id", BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(type).toString());
         world.getChunk(pos).setBlockEntityNbt(tag);
         if (b.getBlock() == Blocks.COMMAND_BLOCK) {
-            info.addPostTodo(pos, inWorld -> {
+            ctx.addPostTodo(pos, inWorld -> {
                 ((ServerChunkCache) inWorld.getLevel().getChunkSource()).blockChanged(pos);
                 inWorld.scheduleTick(pos, b.getBlock(), 1);
             });
@@ -2010,7 +2010,7 @@ public class CityGenerator {
         if (!SpecialMarkerPolicy.populateLoot(provider.getSeed(), pos, info.profile)) {
             return;
         }
-        info.addPostTodo(pos, inWorld -> {
+        ctx.addPostTodo(pos, inWorld -> {
             if (!inWorld.getBlockState(pos).isAir()) {
                 inWorld.setBlock(pos, block, Block.UPDATE_CLIENTS);
                 generateLoot(info, inWorld, pos,
@@ -2045,7 +2045,7 @@ public class CityGenerator {
                             }
                         });
                     } else {
-                        info.addPostTodo(pos, inWorld -> {
+                        ctx.addPostTodo(pos, inWorld -> {
                             BlockState state = finalB.setValue(SaplingBlock.STAGE, 1);
                             inWorld.setBlock(pos, state, Block.UPDATE_ALL_IMMEDIATE);
                         });
@@ -2418,8 +2418,14 @@ public class CityGenerator {
         return (x == 0 || x == 15) && (z == 0 || z == 15);
     }
 
-    public static void updateNeeded(BuildingInfo info, BlockPos pos, int flags) {
-        info.addPostTodo(pos, world -> {
+    /**
+     * Queue a place-twice refresh at {@code pos} on the context generating this chunk.
+     * <p>
+     * Takes the context rather than the chunk's {@code BuildingInfo}: the refresh belongs to one
+     * generation, and a cached planning value is not allowed to hold it (issue #127).
+     */
+    public static void updateNeeded(ChunkGenContext ctx, BlockPos pos, int flags) {
+        ctx.addPostTodo(pos, world -> {
             BlockState state = world.getBlockState(pos);
             if (!state.isAir()) {
                 world.setBlock(pos, Blocks.AIR.defaultBlockState(), flags);

--- a/src/main/java/dev/krona/urbex/worldgen/PostTodoQueue.java
+++ b/src/main/java/dev/krona/urbex/worldgen/PostTodoQueue.java
@@ -1,0 +1,60 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.WorldGenLevel;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Deferred block writes owned by one chunk-generation context, drained at the end of that same
+ * generation.
+ *
+ * <p>These used to live on the cached {@code BuildingInfo} for the chunk, and {@code ChunkFixer}
+ * re-fetched that cache entry to drain them. Three things could go wrong with that, and the queue
+ * being per-context is what removes all three (issue #127): the cache entry could be evicted between
+ * the write and the drain, taking the callbacks with it; a second generation of the same chunk found
+ * the first generation's callbacks still queued and ran them against its own region; and a callback
+ * added on a worker thread while another thread cleared the map was simply lost.</p>
+ *
+ * <p>Keyed by position and last-write-wins, which is what the map on {@code BuildingInfo} did:
+ * a position written twice in one generation gets the later callback only. Iteration order is
+ * deliberately the {@link ConcurrentHashMap} one rather than insertion order - the drain applies
+ * these to the world in that order, and preserving it keeps this change a pure ownership move. The
+ * write-recording digest does not cover post-todos at all (they go through the region, not the
+ * {@link ChunkDriver}), so it would not have noticed a reordering here either way.</p>
+ *
+ * <p>The closed flag is the same guarantee {@link LightTodoQueue} makes: a racing enqueue either
+ * completes before the drain and is in that snapshot, or observes the closed state and fails loudly.
+ * Nothing can be admitted into a context that has already been drained and discarded.</p>
+ */
+final class PostTodoQueue {
+
+    private final Map<BlockPos, Consumer<WorldGenLevel>> pending = new ConcurrentHashMap<>();
+    private boolean closed;
+
+    synchronized void add(BlockPos pos, Consumer<WorldGenLevel> todo) {
+        if (closed) {
+            throw new IllegalStateException("Cannot admit a post-generation todo at " + pos
+                    + " after the generation queue was drained");
+        }
+        pending.put(pos, todo);
+    }
+
+    /**
+     * Closes the queue and hands back what it holds, once.
+     *
+     * <p>A view of the live map rather than a copy: {@code Map.copyOf} would rehash into a
+     * different iteration order, and the drain order is the order these callbacks reach the world.
+     * The queue is discarded with its context immediately afterwards, so the view outlives nothing.</p>
+     */
+    synchronized Map<BlockPos, Consumer<WorldGenLevel>> closeAndDrain() {
+        if (closed) {
+            throw new IllegalStateException("Generation post-todo queue was already drained");
+        }
+        closed = true;
+        return Collections.unmodifiableMap(pending);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Corridors.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Corridors.java
@@ -45,7 +45,7 @@ public class Corridors {
                         Character glowstoneChar = info.getCityStyle().getGlowstoneBlock();
                         BlockState glowstone = glowstoneChar == null ? Blocks.GLOWSTONE.defaultBlockState() : ctx.paletteHere(palette, glowstoneChar);
                         driver.add(glowstone);
-                        CityGenerator.updateNeeded(info, pos, Block.UPDATE_CLIENTS);
+                        CityGenerator.updateNeeded(ctx, pos, Block.UPDATE_CLIENTS);
                     } else {
                         BlockState roof = ctx.paletteHere(palette, corridorRoofBlock);
                         driver.add(roof).add(roof);

--- a/src/main/java/dev/krona/urbex/worldgen/lost/BuildingInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/BuildingInfo.java
@@ -28,8 +28,6 @@ import net.minecraft.world.level.block.Blocks;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 
 import static dev.krona.urbex.worldgen.CityGenerator.FLOORHEIGHT;
 
@@ -119,9 +117,11 @@ public class BuildingInfo {
     private volatile MinMax desiredTerrainCorrectionHeights = null;
     private volatile MinMax desiredMaxHeight1 = null;
 
-    // The todos run after the chunk is driven, and they need the region that is generating - which
-    // is not something a cached BuildingInfo can know. So it is handed to them.
-    private final Map<BlockPos, Consumer<WorldGenLevel>> postTodo = new ConcurrentHashMap<>();
+    // No per-generation runtime state here, and specifically no post-generation callbacks: those
+    // belong to the ChunkGenContext that queued them (see PostTodoQueue). A BuildingInfo is a
+    // cached, coordinate-addressed planning value shared by every generation that reads this chunk,
+    // so anything on it that belonged to one generation could be evicted, drained by the wrong
+    // region, or lost to a concurrent clear (issue #127).
 
     public static class ConditionTodo {
         private final String condition;
@@ -149,18 +149,6 @@ public class BuildingInfo {
         public String getBuilding() {
             return building;
         }
-    }
-
-    public void addPostTodo(BlockPos index, Consumer<WorldGenLevel> inf) {
-        postTodo.put(index, inf);
-    }
-
-    public Map<BlockPos, Consumer<WorldGenLevel>> getPostTodo() {
-        return postTodo;
-    }
-
-    public void clearPostTodo() {
-        postTodo.clear();
     }
 
     public BlockPos getCenter(int y) {

--- a/src/test/java/dev/krona/urbex/worldgen/PostTodoOwnershipTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/PostTodoOwnershipTest.java
@@ -1,0 +1,69 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.worldgen.lost.BuildingInfo;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where post-generation work is allowed to live, pinned structurally.
+ * <p>
+ * {@link PostTodoQueueTest} covers what the queue does. This covers the part of issue #127 that a
+ * behaviour test cannot: the callbacks are on the generation context and reachable only from there.
+ * Both halves are needed, because the defect was never that the queue misbehaved - it was that the
+ * queue was hanging off a cached, shared, coordinate-addressed planning value, and any future edit
+ * that puts one back there would leave every behaviour test green.
+ */
+class PostTodoOwnershipTest {
+
+    /**
+     * A {@code BuildingInfo} is cached per coordinate and shared by every generation that reads the
+     * chunk, so nothing belonging to a single generation may be stored on it. Callbacks are the case
+     * that actually bit (post-todos), and they are what this scans for.
+     */
+    @Test
+    void buildingInfoHoldsNoRuntimeCallbacks() {
+        for (Field field : BuildingInfo.class.getDeclaredFields()) {
+            assertTrue(Consumer.class != field.getType(),
+                    "BuildingInfo." + field.getName() + " is a callback on a cached planning value; "
+                            + "per-generation work belongs on the ChunkGenContext");
+            assertTrue(!field.getGenericType().toString().contains(Consumer.class.getName()),
+                    "BuildingInfo." + field.getName() + " holds callbacks (" + field.getGenericType()
+                            + ") on a cached planning value; per-generation work belongs on the "
+                            + "ChunkGenContext");
+        }
+        assertArrayEquals(new String[0],
+                Arrays.stream(BuildingInfo.class.getDeclaredMethods())
+                        .map(Method::getName)
+                        .filter(name -> name.toLowerCase().contains("posttodo"))
+                        .sorted()
+                        .toArray(String[]::new),
+                "BuildingInfo must expose no post-todo API at all - an accessor is how the drain "
+                        + "found its way back into the cache");
+    }
+
+    /**
+     * The drain takes the context and nothing else. A {@code (coord, provider)} pair - what
+     * {@code ChunkFixer.fix} used to take - is an instruction to look the work up again in
+     * {@code DimensionCaches}, which is the re-fetch that could return a different, or empty,
+     * entry than the one the generation wrote to.
+     */
+    @Test
+    void chunkFixerDrainsTheContextRatherThanLookingWorkUpAgain() {
+        Method[] fix = Arrays.stream(ChunkFixer.class.getDeclaredMethods())
+                .filter(method -> method.getName().equals("fix"))
+                .toArray(Method[]::new);
+
+        assertEquals(1, fix.length, "one drain entry point, not several");
+        assertArrayEquals(new Class<?>[]{ChunkGenContext.class}, fix[0].getParameterTypes(),
+                "ChunkFixer.fix must be handed the originating generation context; anything it "
+                        + "could use to re-derive the work from a cache is the defect in issue #127");
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/PostTodoQueueTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/PostTodoQueueTest.java
@@ -1,0 +1,165 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.WorldGenLevel;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The three ways the old arrangement could lose or misdirect a post-generation callback, and why a
+ * queue owned by the {@link ChunkGenContext} closes all three (issue #127).
+ * <p>
+ * Post-todos used to be stored on the cached {@code BuildingInfo} for the chunk, which
+ * {@code ChunkFixer} re-fetched through {@code DimensionCaches} in order to drain. That cache entry
+ * outlives the generation that wrote to it and is shared by every generation that reads the chunk,
+ * so the work could be evicted before the drain, inherited by a second generation, or cleared out
+ * from under a concurrent enqueue.
+ */
+class PostTodoQueueTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        // DimensionCaches -> TimedCache -> Config, and BlockPos, both want the vanilla registries.
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void closeAndDrainRejectsLateEnqueueInsteadOfSilentlyDroppingIt() {
+        PostTodoQueue queue = new PostTodoQueue();
+        BlockPos admitted = new BlockPos(49, 70, -31);
+        queue.add(admitted, recordInto(new ArrayList<>(), admitted));
+
+        Map<BlockPos, Consumer<WorldGenLevel>> drained = queue.closeAndDrain();
+
+        assertEquals(List.of(admitted), List.copyOf(drained.keySet()));
+        assertThrows(IllegalStateException.class,
+                () -> queue.add(new BlockPos(50, 70, -31), level -> { }));
+    }
+
+    /**
+     * The drain happens once, on the context that owns the work. A second drain is a bug - the
+     * callbacks would run twice against a region that has already been finished - and the old
+     * cache-fetching drain could not tell the difference between the first and the second.
+     */
+    @Test
+    void aGenerationQueueCanOnlyBeDrainedOnce() {
+        PostTodoQueue queue = new PostTodoQueue();
+        queue.add(new BlockPos(49, 70, -31), level -> { });
+
+        queue.closeAndDrain();
+
+        assertThrows(IllegalStateException.class, queue::closeAndDrain);
+    }
+
+    /**
+     * Duplicate generation of one chunk. Both generations address the same position - the same
+     * building part, driven twice - and each must see only what it queued itself. Sharing one map
+     * on the cached {@code BuildingInfo} meant the first drain took the second generation's
+     * callback with it and applied it to the wrong region.
+     */
+    @Test
+    void twoGenerationsOfTheSameChunkDoNotSeeEachOthersWork() {
+        BlockPos contested = new BlockPos(49, 70, -31);
+        List<String> ran = new ArrayList<>();
+        PostTodoQueue first = new PostTodoQueue();
+        PostTodoQueue second = new PostTodoQueue();
+        first.add(contested, level -> ran.add("first"));
+        second.add(contested, level -> ran.add("second"));
+
+        first.closeAndDrain().forEach((pos, todo) -> todo.accept(null));
+        assertEquals(List.of("first"), ran);
+
+        second.closeAndDrain().forEach((pos, todo) -> todo.accept(null));
+        assertEquals(List.of("first", "second"), ran);
+    }
+
+    /**
+     * Forced eviction of everything the dimension caches hold, in the window between queueing the
+     * work and draining it. That window used to be fatal: the callbacks lived in the evicted
+     * {@code BuildingInfo}, and the drain re-fetched the cache and found a fresh, empty one.
+     */
+    @Test
+    void forcedCacheEvictionBetweenQueueingAndDrainingCannotLoseWork() {
+        DimensionCaches caches = new DimensionCaches(1337L);
+        PostTodoQueue queue = new PostTodoQueue();
+        BlockPos pos = new BlockPos(49, 70, -31);
+        List<BlockPos> ran = new ArrayList<>();
+        queue.add(pos, recordInto(ran, pos));
+
+        caches.clear();
+
+        queue.closeAndDrain().forEach((p, todo) -> todo.accept(null));
+        assertEquals(List.of(pos), ran);
+    }
+
+    /** Last write wins per position, which is what the map on {@code BuildingInfo} did. */
+    @Test
+    void aSecondTodoAtOnePositionReplacesTheFirst() {
+        PostTodoQueue queue = new PostTodoQueue();
+        BlockPos pos = new BlockPos(49, 70, -31);
+        List<String> ran = new ArrayList<>();
+        queue.add(pos, level -> ran.add("earlier"));
+        queue.add(pos, level -> ran.add("later"));
+
+        queue.closeAndDrain().forEach((p, todo) -> todo.accept(null));
+
+        assertEquals(List.of("later"), ran);
+    }
+
+    /**
+     * An enqueue racing the drain is linearizable: it either lands before the close and is in the
+     * snapshot, or it is refused. What it may not do is succeed into a queue nobody will ever drain.
+     */
+    @Test
+    void racingEnqueueIsEitherInTheDrainOrExplicitlyRejected() throws Exception {
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int iteration = 0; iteration < 100; iteration++) {
+                PostTodoQueue queue = new PostTodoQueue();
+                BlockPos pos = new BlockPos(49, 70, -31);
+                CyclicBarrier start = new CyclicBarrier(2);
+                Future<Boolean> enqueue = executor.submit(() -> {
+                    start.await();
+                    try {
+                        queue.add(pos, level -> { });
+                        return true;
+                    } catch (IllegalStateException e) {
+                        return false;
+                    }
+                });
+                Future<Map<BlockPos, Consumer<WorldGenLevel>>> drain = executor.submit(() -> {
+                    start.await();
+                    return queue.closeAndDrain();
+                });
+
+                boolean accepted = enqueue.get();
+                Map<BlockPos, Consumer<WorldGenLevel>> drained = drain.get();
+                if (accepted) {
+                    assertEquals(List.of(pos), List.copyOf(drained.keySet()));
+                } else {
+                    assertTrue(drained.isEmpty());
+                }
+            }
+        }
+    }
+
+    /** The callbacks here only record that they ran; nothing in this suite has a world to write to. */
+    private static Consumer<WorldGenLevel> recordInto(List<BlockPos> ran, BlockPos pos) {
+        return level -> ran.add(pos);
+    }
+}


### PR DESCRIPTION
Part **a** of #127. First step of the phase-1 ordering in epic #134.

## What was wrong

Deferred block writes queued during a chunk's generation — POI blocks, loot chests, command
blocks, saplings, the place-twice light refresh — were stored on the **cached `BuildingInfo`** for
that chunk, and `ChunkFixer` re-fetched that cache entry through `DimensionCaches` in order to
drain them. A `BuildingInfo` outlives the generation that wrote to it and is shared by every
generation that reads the chunk, so:

- an eviction between the write and the drain took the callbacks with it;
- a second generation of the same chunk found the first one's callbacks still queued and applied
  them to its own region;
- a callback added on a worker thread while another thread cleared the map was simply lost.

## What changed

The queue belongs to the `ChunkGenContext` that queued the work, the same owner-chunk pattern
`LightTodoQueue` already used. `PostTodoQueue` refuses a late enqueue and a second drain rather
than losing or repeating work, and `ChunkFixer.fix` takes the context, so nothing can look the
work up again.

`BuildingInfo` now holds no runtime callbacks at all.

## Determinism

Iteration order is deliberately left as the `ConcurrentHashMap` one, so this stays a pure ownership
move. Post-todos write through the region rather than the `ChunkDriver`, so they are outside
`DRIVERDIGEST` either way.

- `./gradlew test` — pass
- `./gradlew runDigestCheck` — `688914e862e938fb`, unchanged
- `./gradlew runDigestCheckFeatures` — `7b5348f28e0a6d23`, unchanged

## Tests

`PostTodoQueueTest` covers the three failure modes by name (duplicate generation, forced cache
eviction, racing enqueue during the drain) plus drain-once and last-write-wins.
`PostTodoOwnershipTest` is the structural half: `BuildingInfo` declares no callback field or
post-todo method, and `ChunkFixer.fix` takes nothing it could re-derive the work from.
