### PR TITLE
refactor: server- and level-scoped generation runtimes (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+- **Generation state belongs to the server and the level that own it.** `CityFeature` kept the
+  dimension state for the whole process in one map keyed by dimension id, and kept it honest with a
+  `static volatile int` that the client bumped on disconnect, the world-creation screen bumped on
+  publish, and `/reload` bumped on the server thread. Reconciliation ran *from the generation path*,
+  so a bump could reset the asset registries while a worker was midway through a chunk — and that
+  chunk was written, saved and never revisited with everything the emptied stuff index would have
+  placed missing from it. A `GenerationSession` per running server now owns a `DimensionRuntime` per
+  loaded level, published when the level loads and retired when it unloads (issue #125).
+  - *Leaving a single-player world no longer touches the server's generation state.* The disconnect
+    hook fires on the client thread while the integrated server is still draining in-flight
+    generation; it now clears client state only, and the server's own state is retired at
+    `SERVER_STOPPING` with nothing generating.
+  - *`/reload` republishes each level's runtime instead of clearing the registries.* Block tags do
+    reload and `CityGenerator` caches several of them, so a fresh runtime per level is what makes an
+    edited tag take effect. The thirteen asset registries are frozen at world load and cannot change
+    on a reload whatever is done to them (issue #61), so clearing them bought nothing and was how a
+    running worker got an emptied index. A chunk already generating finishes against the epoch it
+    captured.
+  - *Two worlds in one session cannot share state.* Each server start opens a new session; the
+    previous one is closed rather than inherited, and a stopping server can only close its own.
+  - *Where the "no chunk generates against unloaded assets" rule now lives.* The level-load handler
+    resolves the asset registries before it builds the level's runtime, and generation does nothing
+    at all without a published runtime — so there is no longer a path that generates first and loads
+    afterwards, which is what the load on the generation path was compensating for. Verified on a
+    real server: all three dimensions publish before "Preparing spawn area".
+  - *No worldgen change*: both digest goldens are unchanged, verified by running `runDigestCheck`
+    and `runDigestCheckFeatures`.
+
 - **Post-generation block writes belong to the generation that queued them.** The deferred writes a
   chunk queues for after its driver has run — POI blocks, loot chests, command blocks, saplings, the
   place-twice light refresh — were stored on the cached `BuildingInfo` for that chunk, and the

--- a/src/main/java/dev/krona/urbex/commands/CommandCreateBuilding.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandCreateBuilding.java
@@ -1,11 +1,11 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.BuildingInfo;
@@ -60,7 +60,7 @@ public class CommandCreateBuilding implements Command<CommandSourceStack> {
         WorldCoordinates pos = context.getArgument("pos", WorldCoordinates.class);
         BlockPos bottom = pos.getBlockPos(context.getSource());
 
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandCreatePart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandCreatePart.java
@@ -1,11 +1,11 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.Editor;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
@@ -52,7 +52,7 @@ public class CommandCreatePart implements Command<CommandSourceStack> {
 
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandDebug.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandDebug.java
@@ -1,12 +1,12 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.plan.RoadCell;
 import dev.krona.urbex.plan.TertiarySegment;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
 import dev.krona.urbex.worldgen.IDimensionInfo;
@@ -52,7 +52,7 @@ public class CommandDebug implements Command<CommandSourceStack> {
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         ServerPlayer player = context.getSource().getPlayerOrException();
         BlockPos position = player.blockPosition();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo((WorldGenLevel) player.level());
+        IDimensionInfo dimInfo = GenerationSession.planningFor((WorldGenLevel) player.level());
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandEditPart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandEditPart.java
@@ -1,12 +1,12 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.EditModeData;
 import dev.krona.urbex.editor.Editor;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
@@ -37,7 +37,7 @@ public class CommandEditPart implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandExportPart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandExportPart.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.google.gson.*;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.StringArgumentType;
@@ -9,7 +10,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
 import dev.krona.urbex.editor.EditorInfo;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.IDimensionInfo;
@@ -68,7 +68,7 @@ public class CommandExportPart implements Command<CommandSourceStack> {
         BlockPos start = editorInfo.getBottomLocation();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandListParts.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandListParts.java
@@ -1,11 +1,11 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.EditModeData;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import net.minecraft.commands.CommandSourceStack;
@@ -35,7 +35,7 @@ public class CommandListParts implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandLocate.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandLocate.java
@@ -1,11 +1,11 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.BuildingInfo;
@@ -58,7 +58,7 @@ public class CommandLocate implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandLocatePart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandLocatePart.java
@@ -1,12 +1,12 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.EditModeData;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import net.minecraft.commands.CommandSourceStack;
@@ -49,7 +49,7 @@ public class CommandLocatePart implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandMap.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandMap.java
@@ -1,10 +1,10 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.BuildingInfo;
@@ -35,7 +35,7 @@ public class CommandMap implements Command<CommandSourceStack> {
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         ServerPlayer player = context.getSource().getPlayerOrException();
         BlockPos position = player.blockPosition();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo((WorldGenLevel) player.level());
+        IDimensionInfo dimInfo = GenerationSession.planningFor((WorldGenLevel) player.level());
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandResumeEdit.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandResumeEdit.java
@@ -1,12 +1,12 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.EditModeData;
 import dev.krona.urbex.editor.Editor;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
@@ -36,7 +36,7 @@ public class CommandResumeEdit implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandSavePreset.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandSavePreset.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.mojang.brigadier.Command;
@@ -8,7 +9,6 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.JsonOps;
 import dev.krona.urbex.config.Preset;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
 import net.fabricmc.loader.api.FabricLoader;
@@ -37,7 +37,7 @@ public class CommandSavePreset implements Command<CommandSourceStack> {
     @Override
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         // The source's own level, not the player's: this has to work from the server console too.
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(context.getSource().getLevel());
+        IDimensionInfo dimInfo = GenerationSession.planningFor(context.getSource().getLevel());
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("No dimension info found!").withStyle(ChatFormatting.RED));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandStats.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandStats.java
@@ -1,10 +1,10 @@
 package dev.krona.urbex.commands;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.Statistics;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import net.minecraft.ChatFormatting;
@@ -27,7 +27,7 @@ public class CommandStats implements Command<CommandSourceStack> {
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         // The source's own level, not the player's: this has to work from the server console too,
         // which is where the generation timings are actually read from during a headless run.
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(context.getSource().getLevel());
+        IDimensionInfo dimInfo = GenerationSession.planningFor(context.getSource().getLevel());
         if (dimInfo != null) {
             Statistics statistics = dimInfo.getFeature().getStatistics();
             float averageTime = statistics.getAverageTime();

--- a/src/main/java/dev/krona/urbex/gui/PresetSelection.java
+++ b/src/main/java/dev/krona/urbex/gui/PresetSelection.java
@@ -8,7 +8,6 @@ import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.Presets;
 import dev.krona.urbex.setup.Config;
-import dev.krona.urbex.worldgen.CityFeature;
 import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.network.chat.Component;
@@ -250,13 +249,12 @@ public final class PresetSelection {
         }
         worldStyles = Config.gateMix(worldStyles, "The re-created world's saved selection");
         // Validated BEFORE publishing, not after: Config.overridesFromClient is read on a worldgen
-        // worker thread the moment a chunk generates (CityFeature.getDimensionInfo), so an unparseable
+        // worker thread the moment a chunk generates (DimensionRuntime.create), so an unparseable
         // string must never reach it - publishing it and only catching the parse failure later (in
         // reconcilePendingRestore's best-effort visual reconciliation) would leave the bad JSON sitting
         // in Config while the visual selection quietly fell back to plain.
         String overrides = validatedOverrides(overridesJson, presetId);
 
-        CityFeature.globalDimensionInfoDirtyCounter++;
         Config.resetPresetCache();
         Config.presetFromClient = presetId;
         Config.worldStyleMixFromClient = worldStyles;
@@ -271,7 +269,7 @@ public final class PresetSelection {
     /**
      * Validates a saved-data overrides string against {@link PresetRE#CODEC} before it is allowed
      * anywhere near {@link Config#overridesFromClient} - that field is read on a worldgen worker
-     * thread the instant a chunk generates ({@code CityFeature.getDimensionInfo}), so a string that
+     * thread the instant a chunk generates ({@code DimensionRuntime.create}), so a string that
      * fails to parse must never be published in the first place. Returns {@code null} - "plain
      * preset, no overrides" - for a blank input or one that fails to parse (logged either way the
      * failure differs).
@@ -334,7 +332,7 @@ public final class PresetSelection {
      * the abandon path and not the create path; see that mixin for why not {@code ScreenEvents
      * .remove}.
      * <p>
-     * The cache reset and the counter bump mirror {@link #publish()}: this changes what the next
+     * The cache reset mirrors {@link #publish()}: this changes what the next
      * world would generate with just as much as publishing does.
      */
     public void discardPublication() {
@@ -342,7 +340,6 @@ public final class PresetSelection {
                 && Config.overridesFromClient == null) {
             return;
         }
-        CityFeature.globalDimensionInfoDirtyCounter++;
         Config.resetPresetCache();
         Config.presetFromClient = null;
         Config.worldStyleMixFromClient = null;
@@ -365,7 +362,6 @@ public final class PresetSelection {
     public void publish() {
         Entry entry = selected;
 
-        CityFeature.globalDimensionInfoDirtyCounter++;
         Config.resetPresetCache();
 
         if (DISABLED_ID.equals(entry.id()) || entry.preset() == null) {

--- a/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
+++ b/src/main/java/dev/krona/urbex/setup/ClientEventHandlers.java
@@ -3,7 +3,6 @@ package dev.krona.urbex.setup;
 import dev.krona.urbex.gui.CitiesTab;
 import dev.krona.urbex.gui.PresetSelection;
 import dev.krona.urbex.gui.RecreateProfileRestore;
-import dev.krona.urbex.worldgen.CityFeature;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
@@ -38,11 +37,17 @@ public class ClientEventHandlers {
             }
         });
 
-        // Clean up client-side state when leaving a world/server
+        // Clean up client-side state when leaving a world/server.
+        //
+        // Client state only. This used to bump CityFeature's dimension-info counter as well, to
+        // drop the integrated server's cached dimension state on the way out of a single-player
+        // world - which fired on the client thread while that server was still draining in-flight
+        // generation, and could reset the asset registries underneath a worker (issue #125). The
+        // server's own state is retired by GenerationSession at SERVER_STOPPING, on the server
+        // thread, with nothing generating.
         ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
             PresetSelection.CLIENT.reset();
             Config.reset();
-            CityFeature.globalDimensionInfoDirtyCounter++;
         });
     }
 }

--- a/src/main/java/dev/krona/urbex/setup/Config.java
+++ b/src/main/java/dev/krona/urbex/setup/Config.java
@@ -394,7 +394,7 @@ public class Config {
         PresetChoice overworldChoice = cache.get(Level.OVERWORLD);
         if (overworldChoice != null) {
             Preset overworldPreset = Presets.resolve(level.registryAccess(), overworldChoice.preset());
-            // The GENERATE_NETHER probe must see the same preset CityFeature.getDimensionInfo will
+            // The GENERATE_NETHER probe must see the same preset DimensionRuntime.create will
             // actually generate with - including any client-published/saved overrides overlay - or an
             // override that flips GENERATE_NETHER (on or off) would silently not count here.
             if (overworldChoice.overridesJson().isPresent()) {

--- a/src/main/java/dev/krona/urbex/setup/MixCheck.java
+++ b/src/main/java/dev/krona/urbex/setup/MixCheck.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.setup;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.IDimensionInfo;
@@ -74,7 +75,7 @@ public final class MixCheck {
     }
 
     private static void census(ServerLevel level, int radius, int offset, boolean requireAll) {
-        IDimensionInfo provider = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo provider = GenerationSession.planningFor(level);
         if (provider == null) {
             report(FAIL + " (no Urbex preset configured for the overworld)");
             return;

--- a/src/main/java/dev/krona/urbex/setup/ServerEventHandlers.java
+++ b/src/main/java/dev/krona/urbex/setup/ServerEventHandlers.java
@@ -1,15 +1,15 @@
 package dev.krona.urbex.setup;
 
 import dev.krona.urbex.commands.ModCommands;
-import dev.krona.urbex.worldgen.CityFeature;
+import dev.krona.urbex.worldgen.GenerationSession;
 import dev.krona.urbex.worldgen.GlobalTodo;
 import dev.krona.urbex.worldgen.lost.City;
-import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 
 /**
@@ -22,24 +22,27 @@ public class ServerEventHandlers {
     public static void register() {
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> ModCommands.register(dispatcher));
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> SpawnPlacement.onPlayerFirstJoin(handler.player));
-        // Loading assets here, and not from the tick below, is what makes the eager validation in
-        // AssetRegistries.load a load-time check again. Fabric raises this event from a
+        // Where a level's generation state begins and ends. Fabric raises LOAD from a
         // @WrapOperation on the levels.put call inside MinecraftServer.createLevels
         // (fabric-lifecycle-events-v1 4.1.3, MinecraftServerMixin#onLoadWorld), and
-        // MinecraftServer.loadLevel calls createLevels() before prepareLevels() - so it fires
+        // MinecraftServer.loadLevel calls createLevels() before prepareLevels() - so this runs
         // before "Preparing spawn area" generates its first chunk, and before the overworld's own
         // setInitialSpawn (which createLevels invokes after that same put, and which SpawnPlacement
-        // hooks). It is not what guarantees loaded assets during generation, though: a level that is
-        // already loaded never fires it again, so the guarantee lives on the generation path in
-        // CityFeature.getDimensionInfo. This is the eager half - fail at load, naming the file.
+        // hooks).
         //
-        // The two are not simply complementary, and it is worth being exact: on a fresh world load
-        // this populates the registries, and then the very first getDimensionInfo of the session
-        // reconciles its dirty counter (it starts at -1), calls cleanUp(), and throws all of it away
-        // - reloading it on the same call. So every session resolves the ten registries twice. The
-        // validation still happens first, which is the point of having this at all, but the second
-        // resolve is not free and is not a fresh requirement being met.
-        ServerLevelEvents.LOAD.register((server, level) -> AssetRegistries.load(level));
+        // GenerationSession.load resolves the asset registries before it builds the level's
+        // runtime, which is what keeps the eager validation a load-time check - fail at load,
+        // naming the file. It is also now the whole of the "no chunk generates against unloaded
+        // assets" guarantee: generation reads a published runtime and does nothing without one, so
+        // there is no longer a path that generates first and loads afterwards. The generation path
+        // used to have to load the registries itself, because it was also where they were reset.
+        ServerLevelEvents.LOAD.register((server, level) -> session(server).load(level));
+        ServerLevelEvents.UNLOAD.register((server, level) -> {
+            GenerationSession current = GenerationSession.current();
+            if (current != null) {
+                current.unload(level);
+            }
+        });
         // /reload, and what it can and cannot do for a datapack author.
         //
         // It cannot reload the thirteen asset registries. They are registered through Fabric's
@@ -51,28 +54,44 @@ public class ServerEventHandlers {
         //
         // Block tags are a different matter: those do reload, and Urbex reads several of them once
         // and caches the result. CityGenerator's constructor expands urbex:lights and
-        // urbex:needspoi into BlockState sets and holds them for the lifetime of the
-        // IDimensionInfo, so without this an edited tag kept generating against the pre-reload
-        // membership, silently, until the world was reopened. Bumping the counter drops the
-        // dimension info - and with it those sets and every compiled asset - so the next chunk
-        // rebuilds from what the reload produced.
+        // urbex:needspoi into BlockState sets and holds them for the lifetime of the runtime, so
+        // without this an edited tag kept generating against the pre-reload membership, silently,
+        // until the world was reopened. Republishing every level's runtime rebuilds those sets and
+        // drops the per-level caches, so the next chunk plans from what the reload produced.
         //
-        // Same in-flight hazard as every other bump of this counter (see
-        // CityFeature.reconcileDirtyCounter): a chunk already generating can have the registries
-        // reset underneath it and be saved undecorated. /reload is an explicit operator action, and
-        // Stuff.generateStuff logs loudly if it happens, so this is the same trade the DISCONNECT
-        // bump already makes rather than a new one.
+        // What it no longer does is reset the asset registries. That is not a capability being
+        // dropped: they cannot change on a reload (see above), and clearing them from the server
+        // thread while workers were generating is precisely how a chunk got written and saved with
+        // an emptied stuff index behind it. A republished runtime replaces what the next chunk
+        // picks up and leaves chunks already in flight on the epoch they captured.
         ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, resourceManager, success) -> {
             if (success) {
-                CityFeature.globalDimensionInfoDirtyCounter++;
+                GenerationSession current = GenerationSession.current();
+                if (current != null) {
+                    current.reload();
+                }
             }
         });
         ServerTickEvents.END_LEVEL_TICK.register(ServerEventHandlers::onWorldTick);
-        ServerLifecycleEvents.SERVER_STARTING.register(server -> cleanUp());
+        ServerLifecycleEvents.SERVER_STARTING.register(server -> {
+            cleanUp();
+            GenerationSession.open(server);
+        });
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
+            GenerationSession.close(server);
             cleanUp();
             Config.reset();
         });
+    }
+
+    /**
+     * The session for {@code server}, opening one if the {@code SERVER_STARTING} registration above
+     * did not (a level loading on a server that never announced its start - which nothing in
+     * vanilla or Fabric does, but a level with no session would silently generate nothing at all).
+     */
+    private static GenerationSession session(MinecraftServer server) {
+        GenerationSession current = GenerationSession.current();
+        return current != null ? current : GenerationSession.open(server);
     }
 
     private static void onWorldTick(ServerLevel serverLevel) {
@@ -82,8 +101,8 @@ public class ServerEventHandlers {
     public static void cleanUp() {
         Config.resetPresetCache();
         // Everything that used to be cleared here now lives on DimensionCaches, and goes away with
-        // the IDimensionInfo that owns it (CityFeature.cleanUp clears that map right after
-        // calling us). Only the datapack-derived predefined maps are still global.
+        // the DimensionRuntime that owns it (GenerationSession retires those on unload and at
+        // server stop). Only the datapack-derived predefined maps are still global.
         City.cleanPredefinedCache();
         // Pending spawn corrections must not leak into the next world of this JVM session
         SpawnPlacement.reset();

--- a/src/main/java/dev/krona/urbex/setup/ServerEventHandlers.java
+++ b/src/main/java/dev/krona/urbex/setup/ServerEventHandlers.java
@@ -77,7 +77,18 @@ public class ServerEventHandlers {
             cleanUp();
             GenerationSession.open(server);
         });
-        ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
+        // STOPPED, not STOPPING, and the difference is a whole class of ruined chunk.
+        //
+        // STOPPING fires at the top of MinecraftServer.stopServer, while the chunk system is still
+        // being drained - so a chunk finishing generation after it would find its level's runtime
+        // already retired, get no city content at all, and be saved that way next to neighbours that
+        // got theirs. Vanilla terrain in the middle of a city, permanently, from a clean quit.
+        // STOPPED fires once the server has finished stopping, so nothing can still be generating.
+        //
+        // Everything retired here is per-session state that only the next server start reads, and
+        // GenerationSession.open resets the asset registries itself, so nothing depends on this
+        // having happened earlier.
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
             GenerationSession.close(server);
             cleanUp();
             Config.reset();

--- a/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
+++ b/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.setup;
 
+import dev.krona.urbex.worldgen.GenerationSession;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.varia.ChunkCoord;
@@ -75,7 +76,7 @@ public class SpawnPlacement {
     public static boolean onCreateSpawnPoint(ServerLevel serverLevel, ServerLevelData settings) {
         LevelAccessor world = serverLevel;
         {
-            IDimensionInfo dimensionInfo = Registration.cityFeature().getDimensionInfo(serverLevel);
+            IDimensionInfo dimensionInfo = GenerationSession.planningFor(serverLevel);
             if (dimensionInfo == null) {
                 return false;
             }

--- a/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
@@ -1,42 +1,23 @@
 package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.Urbex;
-import dev.krona.urbex.config.Preset;
-import dev.krona.urbex.config.Presets;
-import dev.krona.urbex.setup.Config;
-import dev.krona.urbex.setup.PresetChoice;
-import dev.krona.urbex.setup.ServerEventHandlers;
-import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
-import com.google.gson.JsonParser;
-import com.mojang.serialization.JsonOps;
 import net.minecraft.core.Holder;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 
-import javax.annotation.Nullable;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+/**
+ * The entry point into city generation. It holds no state.
+ * <p>
+ * It used to own the process-global dimension map and the dirty-counter protocol that maintained
+ * it; both belong to {@link GenerationSession} now, which publishes a {@link DimensionRuntime} per
+ * loaded level and retires it on unload (issue #125). What is left here is the dispatch.
+ */
 public class CityFeature extends Feature<NoneFeatureConfiguration> {
-
-    /**
-     * On dedicated servers the dimensionInfo cache is no problem. The server starts only once
-     * and will have the correct dimension info and for the clients it doesn't matter.
-     * However, to make sure that on a single player world this cache is cleared when the player
-     * exits the world and creates a new one we keep a static flag which is incremented whenever
-     * the player exits the world. That is then used to help clear this cache
-     */
-    private final Map<ResourceKey<Level>, IDimensionInfo> dimensionInfo = new ConcurrentHashMap<>();
-    public static volatile int globalDimensionInfoDirtyCounter = 0;
-    private volatile int dimensionInfoDirtyCounter = -1;
 
     public CityFeature() {
         super(NoneFeatureConfiguration.CODEC);
@@ -62,12 +43,20 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
         return false;
     }
 
-    /** Generates the city content for {@code chunk}. Called from the carver-stage hook. */
+    /**
+     * Generates the city content for {@code chunk}. Called from the carver-stage hook.
+     * <p>
+     * The runtime is read once, at the top, and everything below uses that one reference. A
+     * {@code /reload} or an unload landing mid-chunk republishes the level's runtime for the
+     * <em>next</em> chunk and leaves this one generating against the epoch it captured - which is
+     * the whole point of the ownership move, and the opposite of what the dirty counter did.
+     */
     public boolean generateFromPipeline(WorldGenRegion region, net.minecraft.world.level.chunk.ChunkAccess chunk) {
-        IDimensionInfo diminfo = getDimensionInfo(region);
-        if (diminfo == null) {
+        DimensionRuntime runtime = GenerationSession.runtimeFor(region);
+        if (runtime == null || !runtime.isEnabled()) {
             return false;
         }
+        IDimensionInfo diminfo = runtime.planning();
         ChunkPos center = chunk.getPos();
         Holder<Biome> biome = region.getBiome(center.getMiddleBlockPosition(60));
         if (biome.is(UrbexTags.IS_VOID)) {
@@ -81,7 +70,7 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
         // and the region arrives as an argument instead of being written onto the shared
         // IDimensionInfo. So Urbex generation runs on the worker pool in parallel with the
         // rest of worldgen again, as it did before the driver became shared.
-        CityGenerator feature = diminfo.getFeature();
+        CityGenerator feature = runtime.generator();
         try {
             feature.generate(region, chunk);
         } catch (Exception e) {
@@ -91,113 +80,5 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
             ErrorLogger.report("There was an error generating a chunk. See log for details!");
         }
         return true;
-    }
-
-    @Nullable
-    public IDimensionInfo getDimensionInfo(WorldGenLevel world) {
-        reconcileDirtyCounter();
-        // Every path that generates Urbex content comes through here first - CarverHookMixin ->
-        // generateFromPipeline -> getDimensionInfo, before CityGenerator.generate is reached - so
-        // this is where "no chunk generates against unloaded assets" is actually enforced. A
-        // lifecycle event cannot enforce it on its own: reconcileDirtyCounter() above calls
-        // cleanUp(), which calls AssetRegistries.reset(), from this very path (see cleanUp below),
-        // and no further level-load event fires for a level that is already loaded. AssetRegistries
-        // .load() latches, so from the second chunk on this costs one volatile read.
-        AssetRegistries.load(world);
-        ResourceKey<Level> type = world.getLevel().dimension();
-        IDimensionInfo known = dimensionInfo.get(type);
-        if (known != null) {
-            return known;
-        }
-        PresetChoice choice = Config.getPresetChoiceForDimension(world.getLevel(), type);
-        if (choice == null) {
-            return null;
-        }
-        Preset preset = Presets.resolve(world.registryAccess(), choice.preset());
-        if (choice.overridesJson().isPresent()) {
-            // Fail-soft, unlike the preset id resolution above: the overrides JSON is either a
-            // client-published payload PresetSelection.publish() encoded itself (trustworthy), or
-            // saved data read back from disk - a corrupted/hand-edited save file must not crash
-            // chunk generation. PresetSelection.restore() already validates before publishing, so
-            // this guard is a backstop against corrupted saved data reaching this far, not the
-            // primary defense.
-            try {
-                PresetRE re = PresetRE.CODEC.parse(JsonOps.INSTANCE,
-                        JsonParser.parseString(choice.overridesJson().get())).getOrThrow();
-                preset = Presets.applyOverrides(preset, re);
-            } catch (Exception e) {
-                Urbex.getLogger().error("Malformed Urbex preset overrides for dimension '{}'; " +
-                        "generating with the un-overridden preset '{}'.", type.identifier(), choice.preset(), e);
-            }
-        }
-        // Route 4 of the four that name a city style (see AssetRegistries.loadReachableCityStyles):
-        // the alternative style can arrive as per-world override JSON rather than from a registry
-        // entry, so the load-time sweep cannot see it - a player types an id into the ADVANCED
-        // settings box and it rides into the world through UrbexData. Checked here instead, once per
-        // dimension and before any chunk work, so an incomplete or missing style refuses the
-        // pipeline naming the dimension rather than throwing from a worker on every chunk. This is
-        // deliberately not fail-soft like the overrides parse above: a malformed payload can be
-        // ignored and the un-overridden preset used, but a style that cannot resolve has no such
-        // fallback - City.getCityStyle would simply hand null on to generation.
-        AssetRegistries.requireCityStyle(world, preset.CITY_STYLE_ALTERNATIVE, type.identifier());
-        // Built outside the map. Two threads may both build one for the same dimension the
-        // first time a chunk is generated - the loser's is simply dropped, caches and all.
-        IDimensionInfo diminfo = new DefaultDimensionInfo(world, preset, choice.worldStyles());
-        IDimensionInfo raced = dimensionInfo.putIfAbsent(type, diminfo);
-        return raced != null ? raced : diminfo;
-    }
-
-    /**
-     * Drops the caches once per bump of {@link #globalDimensionInfoDirtyCounter}, and makes every
-     * other caller wait while that happens.
-     * <p>
-     * This used to be a bare {@code if (global != mine) cleanUp();} on two volatile ints - a
-     * check-then-act, run from the parallel worldgen worker pool, so two threads reading the counter
-     * before either had written it back both called {@link #cleanUp()}. The first call of a session
-     * always reconciles ({@code dimensionInfoDirtyCounter} starts at -1), so that was reachable on
-     * any world's first chunks: the second reset landed while the first thread was already
-     * generating against the registries it cleared. MultiChunk's city-style counter names the same
-     * window, because a style resolved either side of a reset is two instances of one id.
-     * <p>
-     * The lock only bites when the counters differ; once they agree, the volatile read on the first
-     * line returns and nothing synchronizes.
-     * <p>
-     * <b>What this does not cover, and what it costs.</b> A bump that arrives while generation is
-     * already in flight still resets the registries underneath it, and the consequence is not
-     * merely MultiChunk's split city-style vote - that is the mild version. {@link
-     * AssetRegistries#reset()} sets the stuff-by-tag index to empty, and unlike every other registry
-     * that index has no lazy rebuild: {@code Stuff.generateStuff} reads null for every tag, places
-     * nothing, and the chunk is written and <em>saved</em> undecorated. That is the shipped defect
-     * this whole task removed, reappearing one chunk at a time. It is reachable rather than
-     * theoretical - {@code ClientEventHandlers.java:42-46} bumps the counter from
-     * {@code ClientPlayConnectionEvents.DISCONNECT} on the client thread, which in single-player
-     * fires while the integrated server is still draining in-flight generation. Nothing here
-     * prevents it; {@code Stuff.generateStuff} logs loudly when it happens so it can no longer pass
-     * quietly, and closing it properly means not tearing the registries down from a path that
-     * generation shares.
-     */
-    private void reconcileDirtyCounter() {
-        if (globalDimensionInfoDirtyCounter == dimensionInfoDirtyCounter) {
-            return;
-        }
-        synchronized (this) {
-            if (globalDimensionInfoDirtyCounter != dimensionInfoDirtyCounter) {
-                cleanUp();
-            }
-        }
-    }
-
-    /**
-     * Private and synchronized on purpose. {@link #reconcileDirtyCounter()} is the only caller and
-     * already holds this monitor, and the design above depends on that staying true: a caller that
-     * reached this without the monitor would be back to two threads resetting the registries at
-     * once. Java monitors are reentrant, so the redundant acquisition costs nothing on the existing
-     * path and is what keeps a future second caller from silently reopening the window.
-     */
-    private synchronized void cleanUp() {
-        ServerEventHandlers.cleanUp();
-        AssetRegistries.reset();
-        dimensionInfo.clear();
-        dimensionInfoDirtyCounter = globalDimensionInfoDirtyCounter;
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
@@ -2,13 +2,19 @@ package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.Urbex;
 import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The entry point into city generation. It holds no state.
@@ -53,7 +59,12 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
      */
     public boolean generateFromPipeline(WorldGenRegion region, net.minecraft.world.level.chunk.ChunkAccess chunk) {
         DimensionRuntime runtime = GenerationSession.runtimeFor(region);
-        if (runtime == null || !runtime.isEnabled()) {
+        if (runtime == null) {
+            reportMissingRuntime(region.getLevel(), chunk.getPos());
+            return false;
+        }
+        if (!runtime.isEnabled()) {
+            // Urbex does not generate in this dimension. A published decision, not a missing one.
             return false;
         }
         IDimensionInfo diminfo = runtime.planning();
@@ -81,4 +92,35 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
         }
         return true;
     }
+
+    /**
+     * Reported once per dimension per JVM: this cannot be allowed to be quiet.
+     * <p>
+     * A chunk reaching here with no published runtime generates as plain vanilla terrain, and
+     * <em>saves that way</em>, in the middle of a city its neighbours have carved streets into. That
+     * looks exactly like corrupted terrain - a floating cliff over a road - and nothing else in the
+     * mod would say a word about it. It is also a shape the old code could not produce, because
+     * {@code getDimensionInfo} built the missing state on the spot from the worker thread; removing
+     * that lazy build (issue #125) is what makes this state reachable at all, so the diagnostic
+     * belongs with it.
+     * <p>
+     * Every path that gets here is a lifecycle bug rather than a configuration one: a level
+     * generating with no session open, or one whose runtime was retired while its chunks were still
+     * in flight. The latch is a diagnostic, deliberately not the state this issue removed - it
+     * decides nothing, and a wrong answer from it costs a duplicate or a missing log line.
+     */
+    private static void reportMissingRuntime(ServerLevel level, ChunkPos pos) {
+        if (!REPORTED_MISSING_RUNTIME.add(level.dimension())) {
+            return;
+        }
+        Urbex.getLogger().error(
+                "Generating chunk {},{} in '{}' with no Urbex runtime published for that level: this "
+                        + "chunk and any others in the same state get no city content at all and are "
+                        + "saved that way, next to neighbours that did. Either the level loaded without "
+                        + "ServerLevelEvents.LOAD firing, or its runtime was retired while chunks were "
+                        + "still generating. Reported once per dimension.",
+                pos.x(), pos.z(), level.dimension().identifier());
+    }
+
+    private static final Set<ResourceKey<Level>> REPORTED_MISSING_RUNTIME = ConcurrentHashMap.newKeySet();
 }

--- a/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
@@ -1,6 +1,5 @@
 package dev.krona.urbex.worldgen;
 
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.lost.BuildingInfo;
 import dev.krona.urbex.worldgen.lost.PrimaryBridgePlanner;
@@ -178,7 +177,7 @@ public final class DigestRunner {
      * configured for this dimension - the driver-writes check already fails that case loudly.
      */
     private static int countBridgeChunks(ServerLevel level, List<ChunkPos> chunkPositions) {
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             return 0;
         }
@@ -199,7 +198,7 @@ public final class DigestRunner {
      * for this dimension - the driver-writes check already fails that case loudly.
      */
     private static int countSlopeChunks(ServerLevel level, List<ChunkPos> chunkPositions) {
-        IDimensionInfo dimInfo = Registration.cityFeature().getDimensionInfo(level);
+        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
@@ -1,0 +1,107 @@
+package dev.krona.urbex.worldgen;
+
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.config.Presets;
+import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.setup.PresetChoice;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
+import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+
+import javax.annotation.Nullable;
+
+/**
+ * Everything one loaded level generates with, built when that level loads and retired when it
+ * unloads.
+ *
+ * <p>This replaces {@code CityFeature}'s process-global {@code Map<ResourceKey<Level>,
+ * IDimensionInfo>} and the dirty-counter protocol that maintained it. That map was keyed by
+ * dimension id alone, so a second world in the same JVM inherited the first world's entry until
+ * something remembered to bump a counter; and the counter's reset ran from the generation path
+ * itself, which is how a worker could have the asset registries cleared underneath it and save an
+ * undecorated chunk (issue #125).</p>
+ *
+ * <p>{@code planning} is {@code null} for a level Urbex does not generate in. That is a cached
+ * answer, not an absent one: the alternative is re-deriving "this dimension has no preset" from the
+ * config on every chunk of every vanilla dimension.</p>
+ *
+ * <p>The record is the phase-1 shape from the milestone plan, deliberately not the final one:
+ * {@code planning} holds today's {@link IDimensionInfo} until #129 replaces it with an explicit
+ * planning context, and #127's level-owned task queue joins it. {@link #caches()} and
+ * {@link #generator()} read like the components they will become while still delegating to the one
+ * object that owns them today - two record components holding the same objects would be two owners
+ * of one thing, which is the mistake this whole epic is about.</p>
+ */
+public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo planning) {
+
+    /** A runtime for a level Urbex does not generate in. */
+    public static DimensionRuntime disabled(ServerLevel level) {
+        return new DimensionRuntime(level, null);
+    }
+
+    public boolean isEnabled() {
+        return planning != null;
+    }
+
+    /** The per-level caches. Never call on a disabled runtime. */
+    public DimensionCaches caches() {
+        return planning.caches();
+    }
+
+    /** The generator this level's chunks are driven by. Never call on a disabled runtime. */
+    public CityGenerator generator() {
+        return planning.getFeature();
+    }
+
+    /**
+     * Builds the runtime for {@code level}.
+     *
+     * <p>Everything here used to happen lazily on the generation path, the first time a chunk of the
+     * dimension was built, behind a {@code putIfAbsent} race that two worker threads could both
+     * enter. It happens once now, on the thread that loads the level, before that level can generate
+     * anything - which is also what makes the {@code CITY_STYLE_ALTERNATIVE} check below a load-time
+     * refusal rather than an exception from a worker.</p>
+     *
+     * <p>Callers must have loaded the asset registries first; {@link GenerationSession#load} is the
+     * one caller and does exactly that.</p>
+     */
+    static DimensionRuntime create(ServerLevel level) {
+        ResourceKey<Level> type = level.dimension();
+        PresetChoice choice = Config.getPresetChoiceForDimension(level, type);
+        if (choice == null) {
+            return disabled(level);
+        }
+        Preset preset = Presets.resolve(level.registryAccess(), choice.preset());
+        if (choice.overridesJson().isPresent()) {
+            // Fail-soft, unlike the preset id resolution above: the overrides JSON is either a
+            // client-published payload PresetSelection.publish() encoded itself (trustworthy), or
+            // saved data read back from disk - a corrupted/hand-edited save file must not refuse the
+            // level. PresetSelection.restore() already validates before publishing, so this guard is
+            // a backstop against corrupted saved data reaching this far, not the primary defense.
+            try {
+                PresetRE re = PresetRE.CODEC.parse(JsonOps.INSTANCE,
+                        JsonParser.parseString(choice.overridesJson().get())).getOrThrow();
+                preset = Presets.applyOverrides(preset, re);
+            } catch (Exception e) {
+                Urbex.getLogger().error("Malformed Urbex preset overrides for dimension '{}'; " +
+                        "generating with the un-overridden preset '{}'.", type.identifier(), choice.preset(), e);
+            }
+        }
+        // Route 4 of the four that name a city style (see AssetRegistries.loadReachableCityStyles):
+        // the alternative style can arrive as per-world override JSON rather than from a registry
+        // entry, so the load-time sweep cannot see it - a player types an id into the ADVANCED
+        // settings box and it rides into the world through UrbexData. Checked here instead, once per
+        // level load and before any chunk work, so an incomplete or missing style refuses the level
+        // naming the dimension rather than throwing from a worker on every chunk. This is
+        // deliberately not fail-soft like the overrides parse above: a malformed payload can be
+        // ignored and the un-overridden preset used, but a style that cannot resolve has no such
+        // fallback - City.getCityStyle would simply hand null on to generation.
+        AssetRegistries.requireCityStyle(level, preset.CITY_STYLE_ALTERNATIVE, type.identifier());
+        return new DimensionRuntime(level, new DefaultDimensionInfo(level, preset, choice.worldStyles()));
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
+++ b/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
@@ -1,0 +1,201 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ServerLevelAccessor;
+
+import javax.annotation.Nullable;
+
+/**
+ * One running server's generation state: the levels it generates in, and the runtime each of them
+ * generates with.
+ *
+ * <p>What this replaces is not a data structure but an ownership vacuum. {@code CityFeature} kept a
+ * {@code Map<ResourceKey<Level>, IDimensionInfo>} on the registered feature instance - one object
+ * for the whole process - and reconciled it against a {@code static volatile int} that the client
+ * bumped on disconnect, the GUI bumped on world creation, and {@code /reload} bumped on the server
+ * thread. Reconciliation ran from the generation path, so the reset it triggered could clear the
+ * asset registries while a worker was midway through a chunk; the chunk was then written, saved and
+ * never revisited, missing everything the emptied stuff index would have placed (issue #125).</p>
+ *
+ * <p>The session is opened at server start and closed at server stop, and each level's runtime is
+ * published when that level loads and retired when it unloads. Two servers started in sequence in
+ * one JVM get two sessions, so the second cannot see the first's runtimes whether or not anything
+ * remembered to invalidate them.</p>
+ *
+ * <h2>The asset-load invariant</h2>
+ *
+ * <p><strong>No chunk generates against unloaded assets.</strong> Until this change the only thing
+ * enforcing that was the generation path itself calling {@code AssetRegistries.load}, because that
+ * same path was where the registries got reset. Enforcement now has two halves, and neither is a
+ * best-effort:</p>
+ * <ul>
+ *   <li>{@link #load} loads the asset registries <em>before</em> it builds the level's runtime, from
+ *       {@code ServerLevelEvents.LOAD}. Fabric raises that event from the {@code levels.put} inside
+ *       {@code MinecraftServer.createLevels}, and {@code loadLevel} calls {@code createLevels()}
+ *       before {@code prepareLevels()} - so it is ordered before "Preparing spawn area" generates
+ *       its first chunk, which is the case a plain lifecycle hook previously failed.</li>
+ *   <li>Generation reads a <em>published</em> runtime and does nothing at all without one. A level
+ *       that never loaded has no runtime, and a runtime cannot exist without its assets having been
+ *       loaded first. There is no longer a path that generates first and loads afterwards.</li>
+ * </ul>
+ * <p>Nothing resets the registries from a worker thread any more: the only resets left are at
+ * session open and session close, both on the server thread, with no level loaded.</p>
+ */
+public final class GenerationSession {
+
+    /**
+     * The session the current server is running. Static because the generation path is entered from
+     * a mixin holding nothing but a {@code WorldGenRegion} - but unlike the map it replaces, this is
+     * one slot with one writer (server start/stop) rather than shared mutable state that generation
+     * itself maintains.
+     */
+    private static volatile GenerationSession current;
+
+    /**
+     * The server this session belongs to. Held for identity only - it is compared by reference in
+     * {@link #close} and never dereferenced - which is why the two methods below take it as an
+     * {@code Object}: a {@code MinecraftServer} cannot be constructed in a test, and the identity
+     * rule is one of the things that has to be tested.
+     */
+    @Nullable
+    private final Object owner;
+    private final RuntimeRepository<ServerLevel, DimensionRuntime> dimensions = new RuntimeRepository<>();
+
+    private GenerationSession(@Nullable Object owner) {
+        this.owner = owner;
+    }
+
+    /** Opens the session for a starting server, closing whatever came before it. */
+    public static GenerationSession open(@Nullable MinecraftServer server) {
+        return openFor(server);
+    }
+
+    /** Closes the session belonging to {@code server}, if it is the current one. */
+    public static void close(@Nullable MinecraftServer server) {
+        closeFor(server);
+    }
+
+    /**
+     * @see #open(MinecraftServer)
+     *
+     * <p>The asset registries are reset here rather than trusted to be empty. {@code load} latches,
+     * so a previous world's assets left loaded would silently become the new world's - the failure
+     * would be a world generating from another world's datapacks, with nothing logged.</p>
+     */
+    static synchronized GenerationSession openFor(@Nullable Object owner) {
+        GenerationSession previous = current;
+        if (previous != null) {
+            previous.dimensions.close();
+        }
+        AssetRegistries.reset();
+        GenerationSession session = new GenerationSession(owner);
+        current = session;
+        return session;
+    }
+
+    /**
+     * @see #close(MinecraftServer)
+     *
+     * <p>Identity-checked so a server that stopped after another had already started cannot close
+     * the running server's state - the same cross-lifetime confusion that keying runtimes by
+     * dimension id alone produced.</p>
+     */
+    static synchronized void closeFor(@Nullable Object owner) {
+        GenerationSession session = current;
+        if (session == null || session.owner != owner) {
+            return;
+        }
+        session.dimensions.close();
+        AssetRegistries.reset();
+        current = null;
+    }
+
+    @Nullable
+    public static GenerationSession current() {
+        return current;
+    }
+
+    /**
+     * The runtime for {@code level}, or {@code null} if that level has none - no session, an
+     * unloaded level, or a level from a server that has already stopped.
+     */
+    @Nullable
+    public static DimensionRuntime runtimeFor(ServerLevelAccessor level) {
+        GenerationSession session = current;
+        if (session == null) {
+            return null;
+        }
+        return session.dimensions.find(level.getLevel());
+    }
+
+    /**
+     * What {@code level} plans its chunks with, or {@code null} if Urbex does not generate there.
+     *
+     * <p>The direct replacement for {@code CityFeature.getDimensionInfo}, with the same nullable
+     * contract and none of its side effects: it builds nothing, loads nothing and resets nothing.</p>
+     */
+    @Nullable
+    public static IDimensionInfo planningFor(ServerLevelAccessor level) {
+        DimensionRuntime runtime = runtimeFor(level);
+        return runtime == null ? null : runtime.planning();
+    }
+
+    /**
+     * Builds and publishes the runtime for a level that has just loaded.
+     *
+     * <p>The asset load on the first line is the invariant this class documents. Everything after it
+     * reads the level; nothing before it does.</p>
+     */
+    public DimensionRuntime load(ServerLevel level) {
+        AssetRegistries.load(level);
+        DimensionRuntime runtime = DimensionRuntime.create(level);
+        // Logged per level, at debug, because the ordering this line sits in is the invariant: in a
+        // real server log every one of these lands before "Preparing spawn area", which is what a
+        // unit test cannot show. (Verified on the digest run's dedicated server: overworld, nether
+        // and end all publish before that line, and the overworld's before "Selecting global world
+        // spawn", the other pre-tick generator.)
+        Urbex.getLogger().debug("Published the Urbex runtime for '{}' ({})", level.dimension().identifier(),
+                runtime.isEnabled() ? "generating" : "no preset for this dimension");
+        return dimensions.publish(level, runtime);
+    }
+
+    /** Retires a level's runtime. Chunks already generating keep the runtime they captured. */
+    public void unload(ServerLevel level) {
+        dimensions.retire(level);
+    }
+
+    /**
+     * Rebuilds every loaded level's runtime, for a {@code /reload}.
+     *
+     * <p>Rebuilding is what {@code /reload} can honestly do. The thirteen asset registries are
+     * Fabric dynamic registries, loaded once with the world and frozen (issue #61), so an edited
+     * building or palette JSON needs the world reopened whatever happens here - the old counter bump
+     * cleared and re-resolved them anyway, which changed nothing an author could see and is exactly
+     * how a running worker ended up reading an emptied stuff index. Block tags <em>do</em> reload,
+     * and {@code CityGenerator} expands several of them into {@code BlockState} sets in its
+     * constructor, so a fresh runtime per level is what makes an edited tag take effect.</p>
+     *
+     * <p>Each replacement is published whole; a chunk already generating finishes against the
+     * runtime it captured.</p>
+     */
+    public void reload() {
+        dimensions.republish(level -> DimensionRuntime.create(level));
+    }
+
+    /** Who this session belongs to, for a caller that has to close it without holding that server. */
+    @Nullable
+    Object owner() {
+        return owner;
+    }
+
+    boolean isClosed() {
+        return dimensions.isClosed();
+    }
+
+    int loadedLevelCount() {
+        return dimensions.size();
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/RuntimeRepository.java
+++ b/src/main/java/dev/krona/urbex/worldgen/RuntimeRepository.java
@@ -1,0 +1,90 @@
+package dev.krona.urbex.worldgen;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * The publish/retire rules a set of scoped runtimes obeys, with the scope's own types kept out.
+ *
+ * <p>Generic in both the key and the value on purpose, and not because a second instantiation is
+ * expected: {@code ServerLevel} and {@code MinecraftServer} are final-ish vanilla classes that no
+ * test can stand in for, so the lifetime rules below - publish once, retire on unload, swap
+ * atomically, refuse everything after close - would otherwise be reachable only from a running
+ * server. Here they are ordinary unit-testable code, and {@link GenerationSession} is the thin
+ * level-typed edge that uses them.</p>
+ *
+ * <p>The rule that matters most is what a <em>reader</em> sees. {@link #find} hands back a value,
+ * and whoever holds it keeps it: a {@link #republish} or a {@link #retire} that lands afterwards
+ * replaces what the <em>next</em> reader gets and never mutates or empties the value already handed
+ * out. That is what lets a chunk that is already generating finish against the epoch it started
+ * with, instead of having its assets cleared underneath it (issue #125).</p>
+ */
+final class RuntimeRepository<K, V> {
+
+    private final Map<K, V> published = new ConcurrentHashMap<>();
+    private volatile boolean closed;
+
+    /**
+     * Publishes {@code value} for {@code key}, replacing any previous value in one write.
+     *
+     * @return the value now published for the key
+     * @throws IllegalStateException if this repository has been closed - a runtime published into a
+     *                               retired server or level would never be retired again
+     */
+    V publish(K key, V value) {
+        if (closed) {
+            throw new IllegalStateException("Cannot publish into a closed runtime repository");
+        }
+        published.put(key, value);
+        return value;
+    }
+
+    @Nullable
+    V find(K key) {
+        return published.get(key);
+    }
+
+    /** Retires one key's runtime. Whatever already holds it keeps working; nothing new finds it. */
+    @Nullable
+    V retire(K key) {
+        return published.remove(key);
+    }
+
+    /**
+     * Rebuilds every published runtime and swaps each in, one key at a time.
+     *
+     * <p>One key at a time is deliberate, and it is not a weaker guarantee than a whole-map swap:
+     * every reader looks one key up, so the only atomicity a reader can observe is per key, and
+     * {@code ConcurrentHashMap.put} gives that. Building outside the map matters more - a reader
+     * must never see a half-built runtime, so each one is finished before it is published.</p>
+     */
+    void republish(Function<K, V> rebuild) {
+        if (closed) {
+            throw new IllegalStateException("Cannot republish into a closed runtime repository");
+        }
+        for (K key : List.copyOf(published.keySet())) {
+            V rebuilt = rebuild.apply(key);
+            // Not putIfAbsent/replace: the key may have been retired while this ran (a level
+            // unloading during a reload), and a rebuilt runtime for a retired level must not
+            // resurrect it.
+            published.computeIfPresent(key, (k, old) -> rebuilt);
+        }
+    }
+
+    /** Retires everything and refuses further publication. Idempotent. */
+    void close() {
+        closed = true;
+        published.clear();
+    }
+
+    boolean isClosed() {
+        return closed;
+    }
+
+    int size() {
+        return published.size();
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/StructureSuppressor.java
+++ b/src/main/java/dev/krona/urbex/worldgen/StructureSuppressor.java
@@ -27,13 +27,9 @@ public class StructureSuppressor {
         if (!Config.STRUCTURES_YIELD_TO_CITIES.get()) {
             return false;
         }
-        CityFeature feature = Registration.cityFeature();
-        if (feature == null) {
-            return false;
-        }
-        IDimensionInfo diminfo = feature.getDimensionInfo(level);
+        IDimensionInfo diminfo = GenerationSession.planningFor(level);
         if (diminfo == null) {
-            return false;   // No Lost Cities profile for this dimension
+            return false;   // No Urbex profile for this dimension, or the level is not loaded
         }
 
         // No lock and no setWorld: the city caches are concurrent now, and IDimensionInfo's level

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
@@ -57,11 +57,14 @@ public class Stuff {
         // observed out of step (emptied index, stale loaded == true), and the guard would wave
         // through exactly the silent chunk it exists to catch. See AssetRegistries.StuffIndex.
         //
-        // Reachable, not hypothetical: AssetRegistries.reset() is called from CityFeature.cleanUp,
-        // which reconcileDirtyCounter invokes when globalDimensionInfoDirtyCounter is bumped, and
-        // ClientEventHandlers.java:42-46 bumps it from ClientPlayConnectionEvents.DISCONNECT on the
-        // client thread - which in single-player fires while the integrated server is still
-        // draining in-flight generation.
+        // No longer reachable by any path this mod owns, and kept anyway. It used to be plainly
+        // reachable: AssetRegistries.reset() ran from CityFeature.cleanUp, which the generation
+        // path invoked whenever a global dirty counter had been bumped, and
+        // ClientPlayConnectionEvents.DISCONNECT bumped it from the client thread while a
+        // single-player integrated server was still draining in-flight generation. reset() is now
+        // called only when a session opens or closes, on the server thread with no level loaded
+        // (GenerationSession, issue #125). This guard is what would say so if that ever stopped
+        // being true - the failure it detects is otherwise completely silent.
         //
         // Logged rather than thrown, for two reasons. generateStuff is the last statement of
         // CityGenerator.doCityChunk, which generate() calls at CityGenerator.java:290, well before

--- a/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
@@ -99,30 +99,20 @@ public class MultiChunk {
         // would split one style's votes in two, and the getId() sort would stop being a total order
         // (two entries comparing equal, ordered by whatever the HashMap handed over).
         //
-        // reset() is not confined to server start/stop, and that is worth being precise about:
-        // CityFeature.cleanUp() calls it, and cleanUp() is invoked lazily from
-        // CityFeature.getDimensionInfo() whenever globalDimensionInfoDirtyCounter differs from that
-        // feature's own. It therefore does fire once per session, since dimensionInfoDirtyCounter
-        // starts at -1 - not necessarily from a generation call, since getDimensionInfo also has
-        // callers in DigestRunner, SpawnPlacement, StructureSuppressor and the commands.
+        // reset() is confined to server start and server stop now, both on the server thread with
+        // no level loaded (GenerationSession.open/close, issue #125). It used to be reachable from
+        // the generation path itself - CityFeature.cleanUp(), invoked lazily from getDimensionInfo
+        // whenever a global dirty counter differed from the feature's own, and that counter was
+        // bumped from ClientPlayConnectionEvents.DISCONNECT on the client thread, which in
+        // single-player fires while the integrated server is still draining in-flight generation.
+        // So a chunk resolved either side of a reset really could hold two instances of one id, and
+        // the split vote below was the mild consequence: the same reset emptied AssetRegistries'
+        // stuff-by-tag index, which alone among the registries has no lazy rebuild, and those
+        // chunks were written and saved with no decoration at all.
         //
-        // What bounds this is narrow, and still does not amount to a guarantee. The first reconcile
-        // is now a single call: CityFeature.reconcileDirtyCounter holds the feature's monitor across
-        // the counter comparison and cleanUp(), so the second thread through waits and then finds
-        // the counters equal instead of resetting the registries underneath the first (Task 5c; the
-        // check-then-act this paragraph used to describe is gone). What remains is a bump arriving
-        // while generation is in flight: globalDimensionInfoDirtyCounter is written only from
-        // client-side paths, but ClientEventHandlers.java:42-46 writes it from
-        // ClientPlayConnectionEvents.DISCONNECT, which in single-player fires while the integrated
-        // server is still draining generation - so "none of them run while a server generates" is an
-        // argument about callers that does not actually hold at shutdown.
-        //
-        // And the split vote below is the mild consequence, not the worst one. The same reset empties
-        // AssetRegistries' stuff-by-tag index, which - alone among the registries - has no lazy
-        // rebuild, so the affected chunks are written and saved with no decoration at all. See
-        // CityFeature.reconcileDirtyCounter and the guard in Stuff.generateStuff, which at least
-        // makes it say so. Closing this loop's own exposure means keying on ids rather than
-        // instances - not a comment.
+        // Keying on ids rather than instances would close this loop's own exposure regardless of
+        // who may reset what, and is still worth doing - it is just no longer load-bearing. The
+        // guard in Stuff.generateStuff is the remaining detector for the wider failure.
         Counter<CityStyle> cityStyleCounter = new Counter<>();
         for (int x = 0 ; x < areasize ; x++) {
             for (int z = 0 ; z < areasize ; z++) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetRegistries.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetRegistries.java
@@ -70,9 +70,10 @@ public class AssetRegistries {
      */
     private static volatile StuffIndex stuffIndex = new StuffIndex(Map.of(), false);
 
-    // Guards load() and reset() against each other and against concurrent loads. load() is no
-    // longer confined to the server thread: CityFeature.getDimensionInfo calls it, and generation
-    // runs on the parallel worldgen worker pool (see the "No lock" note in CityFeature).
+    // Guards load() and reset() against each other and against concurrent loads. Both callers are
+    // on the server thread now (GenerationSession opens a session and loads each level's assets;
+    // see issue #125), but the lock stays: it is what makes "load exactly once, and see the whole
+    // result" a property of this class rather than of its callers' threading.
     private static final Object LOAD_LOCK = new Object();
 
     // Volatile, and written after the map it guards is filled, so the fast path out of
@@ -172,14 +173,12 @@ public class AssetRegistries {
      * Only {@code VARIANTS} before {@code PALETTES} is tidiness: compiling a palette entry that names
      * a variant reaches into that registry, but through {@code get}, which resolves on demand.
      * <p>
-     * Called from two places, for two different reasons. {@code ServerEventHandlers} calls it from
-     * {@code ServerLevelEvents.LOAD} so the validation above happens while the world is loading and
-     * a broken pack refuses the world instead of failing later; {@code CityFeature.getDimensionInfo}
-     * calls it on the generation path so that no chunk can ever generate against an unloaded
-     * registry, whenever generation starts and whatever has reset the registries since. The second
-     * caller means this runs on worldgen worker threads, hence the lock: exactly one thread does the
-     * work and the rest wait for it, rather than several racing through {@code loadAll} and building
-     * the tag index from a half-filled {@code STUFF}.
+     * Called by {@code GenerationSession.load}, from {@code ServerLevelEvents.LOAD}, before it
+     * builds that level's runtime - so the validation above happens while the world is loading and a
+     * broken pack refuses the world instead of failing later. It used to have a second caller on the
+     * generation path, so that no chunk could generate against an unloaded registry whatever had
+     * reset them since; nothing resets them from a worker any more (issue #125), and a chunk cannot
+     * generate without a runtime that this call precedes.
      */
     public static void load(CommonLevelAccessor level) {
         if (stuffIndex.loaded()) {
@@ -225,9 +224,9 @@ public class AssetRegistries {
      *     field, but arriving as override JSON rather than from a registry entry, so nothing here
      *     can see it. It is user-reachable: {@code CITY_STYLE_ALTERNATIVE} is a free-text box in the
      *     customization GUI ({@code Settings.java:466}), published or restored through
-     *     {@code UrbexData}, and applied by {@code CityFeature.getDimensionInfo}. That one is
-     *     checked where it is built, by the {@link #requireCityStyle} call in {@code CityFeature}
-     *     right after {@code Presets.applyOverrides} - once per dimension, before any chunk work.</li>
+     *     {@code UrbexData}, and applied by {@code DimensionRuntime.create}. That one is checked
+     *     where it is built, by the {@link #requireCityStyle} call in {@code DimensionRuntime} right
+     *     after {@code Presets.applyOverrides} - once per level load, before any chunk work.</li>
      * </ol>
      * {@code BuildingInfo}'s lookup adds no fifth route: the name it passes is the winner of a
      * {@code Counter} over ids of styles the surrounding chunks already resolved through routes 1-4.
@@ -271,7 +270,7 @@ public class AssetRegistries {
      * required field undeclared fails here rather than from a worldgen worker.
      * <p>
      * The only place {@code CITYSTYLES} is looked up outside generation, and the entry point route 4
-     * uses: {@code CityFeature.getDimensionInfo} calls it for the preset it has just built, which is
+     * uses: {@code DimensionRuntime.create} calls it for the preset it has just built, which is
      * the only form of the alternative-style setting no registry sweep can reach. Blank is not a
      * name - {@code Preset.CITY_STYLE_ALTERNATIVE} starts as {@code ""} and most presets never set
      * it - so it resolves nothing rather than failing.

--- a/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
+++ b/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
@@ -263,9 +263,9 @@ class PresetSelectionTest {
 
     /**
      * Regression: an unparseable overridesJson must never reach {@code Config.overridesFromClient} -
-     * that field is read on a worldgen worker thread the instant a chunk generates
-     * ({@code CityFeature.getDimensionInfo}'s unguarded {@code PresetRE.CODEC.parse(...).getOrThrow()}),
-     * so a corrupted/hand-edited save's garbage JSON must be rejected before publish, not after.
+     * that field is read when a level loads and its runtime is built
+     * ({@code DimensionRuntime.create}'s {@code PresetRE.CODEC.parse(...).getOrThrow()}), so a
+     * corrupted/hand-edited save's garbage JSON must be rejected before publish, not after.
      */
     @Test
     void restoreWithMalformedOverridesJsonPublishesThePlainPresetInstead() {

--- a/src/test/java/dev/krona/urbex/worldgen/AssetsLoadedBeforeGenerationTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/AssetsLoadedBeforeGenerationTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * The invariant Task 5c exists to hold: <strong>no chunk generates against unloaded assets</strong>.
+ * The invariant this file exists to hold: <strong>no chunk generates against unloaded assets</strong>.
  * <p>
  * For the life of the project nothing asserted it, and nothing had to: {@code AssetRegistries.load}
  * was called only from {@code ServerTickEvents.END_LEVEL_TICK}, while {@code prepareLevels()} -
@@ -45,13 +45,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Those chunks were written with no decoration and persisted that way. The failure is entirely
  * silent: {@code Stuff.generateStuff} looks a tag up, gets nothing back, and places nothing.
  * <p>
- * {@link #generationPathLoadsTheStuffIndexBeforeItTouchesTheLevel()} is the guard. It drives
- * {@link CityFeature#getDimensionInfo}, which every generation path reaches first
- * ({@code CarverHookMixin} -> {@code generateFromPipeline} -> {@code getDimensionInfo}, before
- * {@code CityGenerator.generate} is called), through a level that throws the moment anything but
- * {@code registryAccess()} is asked of it. If the load ever moves back off that path, the stuff
- * index is still empty when the level is reached and the test fails.
- * <p>
+ * Its owner has changed (issue #125) and so has the shape of the argument, which is the reason this
+ * file was rewritten rather than deleted. The guarantee used to live on the generation path itself -
+ * {@code CityFeature.getDimensionInfo} called {@code AssetRegistries.load} before any chunk work -
+ * because that same path was where the registries were <em>reset</em>. Nothing resets them from a
+ * worker any more, and enforcement is now two statements that together leave no gap:
+ * <ol>
+ * <li>{@link #theLevelLoadHandlerLoadsAssetsBeforeItReachesTheLevel()} - the level-load handler
+ *     loads the registries before it touches the level it was handed, so a level that has loaded has
+ *     loaded assets. A plain lifecycle event was not enough on its own before; it is now, because of
+ *     the second half.</li>
+ * <li>{@link #generationRefusesALevelWithNoPublishedRuntime()} - generation reads a published
+ *     runtime and does nothing without one. There is no path left that generates first and loads
+ *     afterwards, which is what the generation-path load was compensating for.</li>
+ * </ol>
  * A test that asserted "a cobweb lands at (x, y, z)" would not do this job: it would pass on any
  * arrangement that eventually loads the registries, including one that loads them a tick too late.
  */
@@ -72,64 +79,86 @@ class AssetsLoadedBeforeGenerationTest {
 
     @BeforeEach
     @AfterEach
-    void clearRegistries() {
+    void clearRegistriesAndSession() {
+        GenerationSession session = GenerationSession.current();
+        if (session != null) {
+            GenerationSession.closeFor(session.owner());
+        }
         AssetRegistries.reset();
     }
 
+    /**
+     * The eager half, and the half a deletion would take away silently: the registries are resolved
+     * while the world is loading, so a broken pack refuses the world naming the file instead of
+     * throwing from a worldgen worker mid-generation.
+     * <p>
+     * The ordering within the handler is what is actually pinned here, and the null level is what
+     * pins it - it plays the part the throwing proxy plays below. {@code GenerationSession.load}
+     * loads the assets and then builds the level's runtime, which reads the level; handed nothing,
+     * that second step fails. So the exception says the handler went on to reach the level, and the
+     * latched registries say the load happened before it did. Move the load after the runtime build
+     * and the assertion below fails.
+     * <p>
+     * {@code AssetRegistries.load} latching on a null level is exactly the no-op latch
+     * {@code loadPredefinedStuff} deliberately refuses (issue #67), and none is needed here: nothing
+     * in production ever calls it with a null level. If it ever gains that guard, this test starts
+     * failing while the wiring it pins is intact - the fix then is to give this test a level, not to
+     * delete it.
+     */
     @Test
-    void generationPathLoadsTheStuffIndexBeforeItTouchesTheLevel() {
+    void theLevelLoadHandlerLoadsAssetsBeforeItReachesTheLevel() {
+        assertFalse(AssetRegistries.isLoaded(), "precondition: @BeforeEach reset the registries");
+
+        ServerEventHandlers.register();
+        assertThrows(NullPointerException.class,
+                () -> ServerLevelEvents.LOAD.invoker().onLevelLoad(null, null),
+                "the handler must go on to build the level's runtime, which reads the level");
+
+        assertTrue(AssetRegistries.isLoaded(),
+                "ServerLevelEvents.LOAD must load the asset registries before it reads the level - "
+                        + "it is what keeps the eager validation a load-time check, and what makes "
+                        + "'a loaded level has loaded assets' true for every level");
+    }
+
+    /**
+     * The other half. Generation is gated on a published runtime, and only the level-load handler
+     * above publishes one - so the ordering it guarantees is the only way into generation.
+     * <p>
+     * Asserted through {@link GenerationSession#planningFor}, which is what
+     * {@code CityFeature.generateFromPipeline} calls first and what every other entry point
+     * (commands, spawn placement, structure suppression) shares. Its predecessor,
+     * {@code CityFeature.getDimensionInfo}, would instead have <em>built</em> the missing state on
+     * the spot, from a worldgen worker, which is why it had to load the registries itself.
+     */
+    @Test
+    void generationRefusesALevelWithNoPublishedRuntime() {
+        assertNull(GenerationSession.current(), "precondition: @BeforeEach closed the session");
+
+        assertNull(GenerationSession.runtimeFor(levelThatOnlyAnswersRegistryAccess()),
+                "with no session there is nothing to generate against - and the level is not even "
+                        + "read, let alone used to build state on the spot as getDimensionInfo did");
+
+        GenerationSession session = GenerationSession.open(null);
+        assertEquals(0, session.loadedLevelCount(),
+                "a fresh session generates nowhere until a level load publishes a runtime");
+    }
+
+    /**
+     * The loader populates the index it is asked for. Split out from the ordering test above, which
+     * a null level cannot cover: this one hands the loader a level that answers exactly the one call
+     * it needs and throws for everything else, so it also pins that the load reads nothing more.
+     */
+    @Test
+    void theLoaderPopulatesTheStuffIndexFromNothingButRegistryAccess() {
         assertNull(AssetRegistries.stuffIndex().byTag().get("rubble"),
                 "precondition: nothing is filed under the tag before anything loads");
 
-        WorldGenLevel level = levelThatOnlyAnswersRegistryAccess();
-        CityFeature feature = new CityFeature();
-
-        // getDimensionInfo cannot complete against this level - getLevel() throws. What matters is
-        // how far it got first: the assets have to be loaded before that point, not after it.
-        assertThrows(ReachedTheLevel.class, () -> feature.getDimensionInfo(level));
+        AssetRegistries.load(levelThatOnlyAnswersRegistryAccess());
 
         List<StuffObject> rubble = AssetRegistries.stuffIndex().byTag().get("rubble");
         assertNotNull(rubble, "the stuff tag index must be populated before generation reads the "
                 + "level - an empty index places no decoration and says nothing about it");
         assertEquals(List.of("urbex:cobweb"), rubble.stream().map(StuffObject::getName).toList());
-    }
-
-    /**
-     * The other half of the argument, and the half a deletion would take away silently.
-     * <p>
-     * The test above pins the generation-path load, which is what guarantees a chunk never generates
-     * against unloaded assets. It says nothing about the <em>eager</em> load, and without that one
-     * Task 4a's rule reverts from "a bad asset fails the world load, naming the file" to "a bad
-     * asset throws from a worldgen worker mid-generation" - with every test still green, because
-     * generation would go on loading the registries itself. So the registration is pinned here
-     * directly: register the server events, fire {@code ServerLevelEvents.LOAD}, and require that
-     * something on it loaded the registries.
-     * <p>
-     * A null level is enough to tell the two apart. {@code RegistryAssetRegistry.loadAll} returns
-     * immediately for one, so nothing is actually resolved, but {@code load} still latches - and if
-     * the registration line is gone, the invoker has no callbacks, nothing runs, and the latch stays
-     * false. The registration is left on the static event afterwards; nothing else in the suite
-     * invokes it.
-     * <p>
-     * <b>Why that latch is the signal, and what would break it.</b> {@code load} latching on a null
-     * level is exactly the no-op latch {@code loadPredefinedStuff} deliberately refuses (issue #67 -
-     * see the null guard in {@code AssetRegistries.loadPredefinedStuff}), because for predefined
-     * cities a real level arriving later still has to be able to load. {@code load} has no such
-     * guard, and none is needed in production: nothing ever calls it with a null level, since both
-     * call sites hand it a level they already hold. But if {@code load} ever gains that guard, this
-     * test starts failing while the registration it is pinning is perfectly intact. If that happens,
-     * the fix is to give this test a level rather than to delete it.
-     */
-    @Test
-    void theEagerLoadIsWiredToTheLevelLoadEvent() {
-        assertFalse(AssetRegistries.isLoaded(), "precondition: @BeforeEach reset the registries");
-
-        ServerEventHandlers.register();
-        ServerLevelEvents.LOAD.invoker().onLevelLoad(null, null);
-
-        assertTrue(AssetRegistries.isLoaded(),
-                "ServerLevelEvents.LOAD must load the asset registries - it is what keeps the "
-                        + "eager validation a load-time check instead of a mid-generation one");
     }
 
     @Test
@@ -156,8 +185,9 @@ class AssetsLoadedBeforeGenerationTest {
 
     /**
      * A level that hands over a registry access carrying one tagged stuff entry, and throws for
-     * every other call. {@code AssetRegistries.load} needs nothing else; {@code getDimensionInfo}
-     * needs {@code getLevel()}, which is exactly the line this test wants the load to precede.
+     * every other call - {@code getLevel()} included, which is what makes "the lookup did not even
+     * read the level" an assertion rather than a claim. {@code AssetRegistries.load} needs nothing
+     * else.
      */
     private static WorldGenLevel levelThatOnlyAnswersRegistryAccess() {
         RegistryAccess access = registriesWithOneRubbleStuff();

--- a/src/test/java/dev/krona/urbex/worldgen/GenerationSessionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/GenerationSessionTest.java
@@ -1,0 +1,110 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The server half of the lifetime rules (issue #125): one session per running server, and nothing
+ * of one server's reachable from the next.
+ * <p>
+ * The per-level rules - load, unload, reload, epoch retention - are in
+ * {@link RuntimeRepositoryTest}. Both suites drive the identities as plain objects because neither
+ * {@code MinecraftServer} nor {@code ServerLevel} can be constructed, subclassed usefully or
+ * proxied; the session takes its owner as an {@code Object} for exactly that reason, and never
+ * dereferences it.
+ */
+class GenerationSessionTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        // AssetRegistries.reset(), which opening and closing a session both do, walks the
+        // registry-backed asset registries.
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @AfterEach
+    void closeWhateverIsOpen() {
+        GenerationSession session = GenerationSession.current();
+        if (session != null) {
+            GenerationSession.closeFor(session.owner());
+        }
+        AssetRegistries.reset();
+    }
+
+    @Test
+    void openingASessionInstallsIt() {
+        GenerationSession session = GenerationSession.openFor(new Object());
+
+        assertSame(session, GenerationSession.current());
+        assertFalse(session.isClosed());
+        assertEquals(0, session.loadedLevelCount(), "a fresh session has published no level runtimes");
+    }
+
+    /**
+     * Two servers in one JVM, in sequence. The second gets a different session with nothing
+     * published, and the first is closed rather than left holding a stopped server's levels - the
+     * failure mode of the map this replaced, which kept the previous world's dimension info until a
+     * counter bump from somewhere else invalidated it.
+     */
+    @Test
+    void aSecondServerInTheSameJvmGetsAFreshSession() {
+        Object firstServer = new Object();
+        Object secondServer = new Object();
+        GenerationSession first = GenerationSession.openFor(firstServer);
+
+        GenerationSession second = GenerationSession.openFor(secondServer);
+
+        assertNotSame(first, second);
+        assertSame(second, GenerationSession.current());
+        assertTrue(first.isClosed(), "the previous server's runtimes are retired, not inherited");
+        assertEquals(0, second.loadedLevelCount());
+    }
+
+    @Test
+    void closingTheCurrentSessionLeavesNothingToGenerateAgainst() {
+        Object server = new Object();
+        GenerationSession session = GenerationSession.openFor(server);
+
+        GenerationSession.closeFor(server);
+
+        assertNull(GenerationSession.current());
+        assertTrue(session.isClosed());
+    }
+
+    /**
+     * The same-JVM restart hazard from the other side. A server that stops after a second one has
+     * already started must not close the running server's session; without the identity check, the
+     * new world would silently generate nothing at all.
+     */
+    @Test
+    void aStoppingServerCannotCloseASessionThatIsNotItsOwn() {
+        Object firstServer = new Object();
+        Object secondServer = new Object();
+        GenerationSession.openFor(firstServer);
+        GenerationSession second = GenerationSession.openFor(secondServer);
+
+        GenerationSession.closeFor(firstServer);
+
+        assertSame(second, GenerationSession.current());
+        assertFalse(second.isClosed());
+    }
+
+    @Test
+    void closingWhenNothingIsOpenIsHarmless() {
+        GenerationSession.closeFor(new Object());
+
+        assertNull(GenerationSession.current());
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/RuntimeRepositoryTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/RuntimeRepositoryTest.java
@@ -1,0 +1,170 @@
+package dev.krona.urbex.worldgen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The lifetime rules {@link GenerationSession} keeps its level runtimes by (issue #125): load,
+ * unload, replacement on reload, and the fact that a server's runtimes die with that server.
+ * <p>
+ * Driven through plain strings rather than {@code ServerLevel}s. That is why the repository is a
+ * separate, generic class: a {@code ServerLevel} cannot be constructed, subclassed usefully or
+ * proxied, so rules expressed directly against one are only reachable from a running dedicated
+ * server - and these are exactly the rules that were previously wrong in ways no test caught.
+ */
+class RuntimeRepositoryTest {
+
+    @Test
+    void aPublishedRuntimeIsWhatTheNextLookupFinds() {
+        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
+
+        assertNull(repository.find("overworld"), "nothing generates in a level that never loaded");
+        repository.publish("overworld", "runtime-1");
+
+        assertEquals("runtime-1", repository.find("overworld"));
+        assertEquals(1, repository.size());
+    }
+
+    @Test
+    void unloadingALevelRetiresItsRuntime() {
+        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
+        repository.publish("overworld", "runtime-1");
+
+        assertEquals("runtime-1", repository.retire("overworld"));
+
+        assertNull(repository.find("overworld"));
+        assertEquals(0, repository.size());
+    }
+
+    /**
+     * The property the whole ownership move exists for. A chunk that is already generating holds
+     * the runtime it started with; a reload swaps what the <em>next</em> chunk picks up and cannot
+     * reach into the epoch already in flight. The dirty counter did the opposite - it cleared shared
+     * state in place, from whichever thread happened to notice.
+     */
+    @Test
+    void aReloadReplacesWhatTheNextLookupFindsAndLeavesTheOneInFlightAlone() {
+        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
+        repository.publish("overworld", "runtime-1");
+        String inFlight = repository.find("overworld");
+
+        repository.republish(key -> "runtime-2");
+
+        assertEquals("runtime-1", inFlight, "work already holding an epoch keeps it");
+        assertEquals("runtime-2", repository.find("overworld"));
+    }
+
+    /** A level unloading during a reload must not be brought back by the rebuild that overtook it. */
+    @Test
+    void aReloadDoesNotResurrectALevelRetiredWhileItRan() {
+        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
+        repository.publish("overworld", "runtime-1");
+
+        repository.republish(key -> {
+            repository.retire(key);
+            return "runtime-2";
+        });
+
+        assertNull(repository.find("overworld"));
+        assertEquals(0, repository.size());
+    }
+
+    /**
+     * Two servers started in sequence in one JVM. The second gets its own repository, so it cannot
+     * inherit the first's runtimes - which is what a process-global map keyed by dimension id did
+     * until something remembered to bump a counter.
+     */
+    @Test
+    void aClosedRepositoryKeepsNothingAndAcceptsNothing() {
+        RuntimeRepository<String, String> first = new RuntimeRepository<>();
+        first.publish("overworld", "runtime-1");
+
+        first.close();
+
+        assertTrue(first.isClosed());
+        assertNull(first.find("overworld"));
+        assertThrows(IllegalStateException.class, () -> first.publish("overworld", "runtime-2"),
+                "a runtime published into a stopped server would never be retired again");
+        assertThrows(IllegalStateException.class, () -> first.republish(key -> "runtime-2"));
+
+        RuntimeRepository<String, String> second = new RuntimeRepository<>();
+        assertNull(second.find("overworld"), "the next server starts with nothing published");
+    }
+
+    @Test
+    void closingTwiceIsHarmless() {
+        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
+        repository.close();
+        repository.close();
+        assertTrue(repository.isClosed());
+    }
+
+    /**
+     * A reload landing while chunks are generating. Every lookup must answer with some complete
+     * runtime - never null, never a half-built one - which is the difference between republishing
+     * and the clear-then-refill the counter protocol performed.
+     */
+    @Test
+    void aReloadOverlappingGenerationNeverExposesClearedState() throws Exception {
+        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
+        repository.publish("overworld", "runtime-0");
+        AtomicInteger epoch = new AtomicInteger();
+        CountDownLatch readerStarted = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<List<String>> readers = executor.submit(() -> {
+                readerStarted.countDown();
+                List<String> seen = new java.util.ArrayList<>();
+                for (int i = 0; i < 10_000; i++) {
+                    seen.add(repository.find("overworld"));
+                }
+                return seen;
+            });
+            Future<?> reloads = executor.submit(() -> {
+                readerStarted.await();
+                for (int i = 0; i < 500; i++) {
+                    repository.republish(key -> "runtime-" + epoch.incrementAndGet());
+                }
+                return null;
+            });
+
+            reloads.get();
+            for (String seen : readers.get()) {
+                assertNotNull(seen, "a lookup during a reload must never find the level unpublished");
+                assertTrue(seen.startsWith("runtime-"), "and never a value that is not a runtime");
+            }
+        }
+    }
+
+    @Test
+    void republishSeesTheKeysThatWerePublished() {
+        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
+        repository.publish("overworld", "runtime-1");
+        repository.publish("nether", "runtime-1");
+
+        repository.republish(key -> key + "-rebuilt");
+
+        assertEquals("overworld-rebuilt", repository.find("overworld"));
+        assertEquals("nether-rebuilt", repository.find("nether"));
+    }
+
+    @Test
+    void retiringSomethingNeverPublishedIsHarmless() {
+        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
+        assertNull(repository.retire("overworld"));
+        assertSame(0, repository.size());
+    }
+}


### PR DESCRIPTION
Closes #125. Second step of the phase-1 ordering in epic #134. Stacked on #135.

## What was wrong

`CityFeature` owned the dimension state for the whole process — one `Map<ResourceKey<Level>,
IDimensionInfo>` on the registered feature instance — and kept it honest with a
`static volatile int` that the client bumped on disconnect, the world-creation screen bumped on
publish, and `/reload` bumped on the server thread.

Reconciliation ran **from the generation path**. So a bump arriving while chunks were in flight
reset the asset registries underneath a worker, and because the stuff-by-tag index alone has no
lazy rebuild, those chunks were written, saved and never revisited with no decoration in them at
all. The disconnect bump fired on the client thread while a single-player integrated server was
still draining generation, which made that reachable rather than theoretical.

## What changed

A `GenerationSession` per running server owns a `DimensionRuntime` per loaded level, published at
`ServerLevelEvents.LOAD` and retired at `UNLOAD`.

- **Nothing resets the registries from a worker any more.** The only resets left are session open
  and session close, both on the server thread with no level loaded.
- **The disconnect hook clears client state only.**
- **`/reload` republishes each level's runtime** instead of clearing the registries. Block tags do
  reload and `CityGenerator` caches several of them, so a fresh runtime is what makes an edited tag
  take effect; the thirteen asset registries are frozen at world load and cannot change whatever is
  done to them (#61), so clearing them bought nothing. A chunk already generating finishes against
  the epoch it captured.
- **Two servers in one JVM cannot share state.** Each start opens a new session, the previous one
  is closed rather than inherited, and a stopping server can only close its own.
- `CityFeature` is now stateless dispatch; `CityFeature.getDimensionInfo` is replaced by
  `GenerationSession.planningFor`, which builds nothing, loads nothing and resets nothing.

## The asset-load invariant, re-owned rather than dropped

**No chunk generates against unloaded assets.** Enforcement is now two statements with no gap
between them:

1. `GenerationSession.load` resolves the asset registries **before** it builds the level's runtime.
2. Generation reads a *published* runtime and does nothing without one — so there is no longer a
   path that generates first and loads afterwards, which is what the generation-path load was
   compensating for.

`AssetsLoadedBeforeGenerationTest` is rewritten against that owner rather than deleted, and still
fails if the load moves after the runtime build.

Verified on the digest run's dedicated server that the ordering holds in practice — the overworld,
nether and end runtimes all publish before `Preparing spawn area`, and the overworld's before
`Selecting global world spawn`, the other pre-tick generator:

```
[Server thread/INFO] (urbex) publishing runtime for minecraft:overworld
[Server thread/INFO] (Minecraft) Selecting global world spawn...
[Server thread/INFO] (urbex) publishing runtime for minecraft:the_nether
[Server thread/INFO] (urbex) publishing runtime for minecraft:the_end
[Server thread/INFO] (Minecraft) Preparing spawn area: 100%
```

## Why `RuntimeRepository` is generic

`ServerLevel` and `MinecraftServer` cannot be constructed, subclassed usefully or proxied, so
lifetime rules written directly against them are only reachable from a running server — and these
are precisely the rules that were wrong in ways nothing caught. The publish/retire/republish/close
semantics live in one small generic class that `RuntimeRepositoryTest` drives with plain values;
`GenerationSession` is the level-typed edge.

## Scope boundary with #129

`DimensionRuntime.planning` holds today's `IDimensionInfo`, as the epic's phase-1 shape requires.
`caches()` and `generator()` read like the record components they will become but delegate, rather
than duplicating ownership of the same objects. #127's level-owned task queue joins the record in
the next PR of this stack.

`ServerAccess` is gone from the lifecycle paths. It remains in palette variant resolution (#60),
block/tag resolution in `Tools`/`WorldTools` (#128) and error reporting (#131), each assigned
elsewhere in the milestone.

## Two windows this change opened, and closed again

Removing the lazy `getDimensionInfo` build means a chunk reaching `generateFromPipeline` with no
published runtime can no longer build the missing state on the spot — it returns false and gets no
city content at all, and is saved that way next to neighbours that got theirs. That is
indistinguishable from corrupted terrain (a vanilla cliff over a carved street) and it was silent.
It is now an error naming the chunk and the dimension, once per dimension.

The session was also being closed from `SERVER_STOPPING`, which fires at the top of `stopServer`
while the chunk system is still draining, so a chunk finishing after it would find its level's
runtime already retired. Moved to `SERVER_STOPPED`, which fires once the server has stopped and
nothing can still be generating. Everything retired there is per-session state that only the next
server start reads, and `open()` resets the asset registries itself.

## Verification

- `./gradlew test` — pass, including new `GenerationSessionTest` and `RuntimeRepositoryTest`
  (load, unload, same-JVM restart, reload replacement, epoch retention, and a concurrent
  reload-during-lookup that must never observe cleared state)
- `./gradlew runDigestCheck` — `688914e862e938fb`, unchanged
- `./gradlew runDigestCheckFeatures` — `7b5348f28e0a6d23`, unchanged
