### PR TITLE
fix: resolve palette variants against the palette's own registries (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **A palette's `variant` resolves against its own dimension's registries.** `Palette.compile`
+  looked a variant up through `ServerAccess.getServer().getLevel(Level.OVERWORLD)` — the
+  process-wide server reference, and then unconditionally that server's overworld — ignoring the
+  registries the palette had just been read from. A palette compiled for any other dimension took
+  the overworld's variants, and one compiled on a worldgen worker before the static server
+  reference was populated threw a `NullPointerException` out of asset compilation (issue #60). The
+  registry access now travels with the chain being compiled, which is what
+  `RegistryAssetRegistry` had in hand at every one of its three compile sites all along. A palette
+  compiled with no registry access and a `variant` entry to resolve now says exactly that, naming
+  the variant. *No worldgen change*: both digest goldens are unchanged.
+
 - **Deferred level work belongs to the level, and says whether it actually ran.** `GlobalTodo` was a
   `static` map keyed by dimension id, and every one of its problems followed from that (issue #127,
   part b). Nothing ever removed a dimension's bucket, so work queued in one single-player world was

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetRegistries.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetRegistries.java
@@ -24,18 +24,18 @@ import java.util.function.Predicate;
 
 public class AssetRegistries {
 
-    public static final RegistryAssetRegistry<Variant, VariantRE> VARIANTS = new RegistryAssetRegistry<>(CustomRegistries.VARIANTS_REGISTRY_KEY, Variant::new);
-    public static final RegistryAssetRegistry<Condition, ConditionRE> CONDITIONS = new RegistryAssetRegistry<>(CustomRegistries.CONDITIONS_REGISTRY_KEY, Condition::new);
-    public static final RegistryAssetRegistry<WorldStyle, WorldStyleRE> WORLDSTYLES = new RegistryAssetRegistry<>(CustomRegistries.WORLDSTYLES_REGISTRY_KEY, WorldStyle::new);
-    public static final RegistryAssetRegistry<CityStyle, CityStyleRE> CITYSTYLES = new RegistryAssetRegistry<>(CustomRegistries.CITYSTYLES_REGISTRY_KEY, CityStyle::new);
+    public static final RegistryAssetRegistry<Variant, VariantRE> VARIANTS = new RegistryAssetRegistry<>(CustomRegistries.VARIANTS_REGISTRY_KEY, (access, chain) -> new Variant(chain));
+    public static final RegistryAssetRegistry<Condition, ConditionRE> CONDITIONS = new RegistryAssetRegistry<>(CustomRegistries.CONDITIONS_REGISTRY_KEY, (access, chain) -> new Condition(chain));
+    public static final RegistryAssetRegistry<WorldStyle, WorldStyleRE> WORLDSTYLES = new RegistryAssetRegistry<>(CustomRegistries.WORLDSTYLES_REGISTRY_KEY, (access, chain) -> new WorldStyle(chain));
+    public static final RegistryAssetRegistry<CityStyle, CityStyleRE> CITYSTYLES = new RegistryAssetRegistry<>(CustomRegistries.CITYSTYLES_REGISTRY_KEY, (access, chain) -> new CityStyle(chain));
     public static final RegistryAssetRegistry<BuildingPart, BuildingPartRE> PARTS = new RegistryAssetRegistry<>(CustomRegistries.PART_REGISTRY_KEY, BuildingPart::new);
     public static final RegistryAssetRegistry<Building, BuildingRE> BUILDINGS = new RegistryAssetRegistry<>(CustomRegistries.BUILDING_REGISTRY_KEY, Building::new);
-    public static final RegistryAssetRegistry<MultiBuilding, MultiBuildingRE> MULTI_BUILDINGS = new RegistryAssetRegistry<>(CustomRegistries.MULTIBUILDINGS_REGISTRY_KEY, MultiBuilding::new);
-    public static final RegistryAssetRegistry<Style, StyleRE> STYLES = new RegistryAssetRegistry<>(CustomRegistries.STYLE_REGISTRY_KEY, Style::new);
+    public static final RegistryAssetRegistry<MultiBuilding, MultiBuildingRE> MULTI_BUILDINGS = new RegistryAssetRegistry<>(CustomRegistries.MULTIBUILDINGS_REGISTRY_KEY, (access, chain) -> new MultiBuilding(chain));
+    public static final RegistryAssetRegistry<Style, StyleRE> STYLES = new RegistryAssetRegistry<>(CustomRegistries.STYLE_REGISTRY_KEY, (access, chain) -> new Style(chain));
     public static final RegistryAssetRegistry<Palette, PaletteRE> PALETTES = new RegistryAssetRegistry<>(CustomRegistries.PALETTE_REGISTRY_KEY, Palette::new);
-    public static final RegistryAssetRegistry<ScatteredBuilding, ScatteredRE> SCATTERED = new RegistryAssetRegistry<>(CustomRegistries.SCATTERED_REGISTRY_KEY, ScatteredBuilding::new);
-    public static final RegistryAssetRegistry<PredefinedCity, PredefinedCityRE> PREDEFINED_CITIES = new RegistryAssetRegistry<>(CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY, PredefinedCity::new);
-    public static final RegistryAssetRegistry<StuffObject, StuffSettingsRE> STUFF = new RegistryAssetRegistry<>(CustomRegistries.STUFF_REGISTRY_KEY, StuffObject::new);
+    public static final RegistryAssetRegistry<ScatteredBuilding, ScatteredRE> SCATTERED = new RegistryAssetRegistry<>(CustomRegistries.SCATTERED_REGISTRY_KEY, (access, chain) -> new ScatteredBuilding(chain));
+    public static final RegistryAssetRegistry<PredefinedCity, PredefinedCityRE> PREDEFINED_CITIES = new RegistryAssetRegistry<>(CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY, (access, chain) -> new PredefinedCity(chain));
+    public static final RegistryAssetRegistry<StuffObject, StuffSettingsRE> STUFF = new RegistryAssetRegistry<>(CustomRegistries.STUFF_REGISTRY_KEY, (access, chain) -> new StuffObject(chain));
 
     /**
      * The stuff-by-tag index and whether it was actually loaded, as one value.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
@@ -4,6 +4,7 @@ import dev.krona.urbex.worldgen.lost.regassets.BuildingRE;
 import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.CommonLevelAccessor;
 import org.apache.commons.lang3.tuple.Pair;
@@ -13,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.util.RandomSource;
 import java.util.function.Predicate;
+
 
 public class Building {
 
@@ -52,7 +54,7 @@ public class Building {
      * ancestor that set something else. The defaults the fields start at are this class's own
      * documented fallbacks - {@code -1} for "take the level's limit" - not markers for "undeclared".
      */
-    public Building(List<BuildingRE> chainRootFirst) {
+    public Building(@Nullable RegistryAccess access, List<BuildingRE> chainRootFirst) {
         name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
         List<PartRef> partRefs = new ArrayList<>();
         boolean anyParts = false;
@@ -113,7 +115,7 @@ public class Building {
         Resolved.require(anyParts ? partRefs : null, name, "parts");
 
         if (!inlinePalettes.isEmpty()) {
-            localPalette = Palette.inline(name, inlinePalettes); // @todo get the full palette instead
+            localPalette = Palette.inline(access, name, inlinePalettes); // @todo get the full palette instead
         } else if (refPalette != null) {
             refPaletteName = refPalette;
         }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPart.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPart.java
@@ -5,6 +5,7 @@ import dev.krona.urbex.worldgen.lost.regassets.BuildingPartRE;
 import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartMeta;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.CommonLevelAccessor;
 
@@ -16,6 +17,8 @@ import java.util.Map;
 /**
  * A structure part
  */
+import javax.annotation.Nullable;
+
 public class BuildingPart implements IBuildingPart {
 
     // Meta values that you can use in assets
@@ -58,7 +61,7 @@ public class BuildingPart implements IBuildingPart {
      * {@code slices} replaces the inherited ones wholesale; declaring a size that contradicts the
      * slices actually in force is a load error rather than a silent truncation.
      */
-    public BuildingPart(List<BuildingPartRE> chainRootFirst) {
+    public BuildingPart(@Nullable RegistryAccess access, List<BuildingPartRE> chainRootFirst) {
         BuildingPartRE leaf = chainRootFirst.get(chainRootFirst.size() - 1);
         name = leaf.getRegistryName();
 
@@ -108,7 +111,7 @@ public class BuildingPart implements IBuildingPart {
         slices = declaredSlices;
 
         if (!inlinePalettes.isEmpty()) {
-            localPalette = Palette.inline(name, inlinePalettes); // @todo get the full palette instead
+            localPalette = Palette.inline(access, name, inlinePalettes); // @todo get the full palette instead
         } else if (refPalette != null) {
             refPaletteName = refPalette;
         }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
@@ -5,15 +5,13 @@ import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.Identifier;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import dev.krona.urbex.varia.ServerAccess;
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -40,9 +38,15 @@ public class Palette {
      * list would silently drop everything the child did not restate. Only the surviving entries are
      * then compiled, so an overridden entry takes its {@code damaged} mapping with it.
      */
-    public Palette(List<PaletteRE> chainRootFirst) {
+    /**
+     * @param access the registries this palette's chain was read from, used to resolve a
+     *               {@code variant} entry against {@code AssetRegistries.VARIANTS}. May be null only
+     *               for a palette that provably names no variant; one that does then fails naming
+     *               itself and the variant rather than reaching for a static server (issue #60).
+     */
+    public Palette(@Nullable RegistryAccess access, List<PaletteRE> chainRootFirst) {
         name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
-        compile(mergeByCharacter(chainRootFirst, name));
+        compile(access, mergeByCharacter(chainRootFirst, name));
     }
 
     public Palette(String name) {
@@ -62,7 +66,8 @@ public class Palette {
      *                       for the synthetic palette name
      * @param chainRootFirst the inline blocks along the owner's chain, root first
      */
-    public static Palette inline(Identifier owner, List<PaletteRE> chainRootFirst) {
+    public static Palette inline(@Nullable RegistryAccess access, Identifier owner,
+                                 List<PaletteRE> chainRootFirst) {
         for (PaletteRE re : chainRootFirst) {
             // The codec accepts 'extends' wherever a PaletteRE is embedded, but an inline block is
             // not a registry entry, so nothing can resolve it. Rejecting is the honest option:
@@ -76,7 +81,7 @@ public class Palette {
             }
         }
         Palette palette = new Palette("__local__" + owner.getPath());
-        palette.compile(mergeByCharacter(chainRootFirst, owner));
+        palette.compile(access, mergeByCharacter(chainRootFirst, owner));
         return palette;
     }
 
@@ -129,7 +134,7 @@ public class Palette {
         return palette;
     }
 
-    private void compile(Collection<PaletteEntry> entries) {
+    private void compile(@Nullable RegistryAccess access, Collection<PaletteEntry> entries) {
         for (PaletteEntry entry : entries) {
             Character c = entry.getChr().charAt(0);
             BlockState dmg = null;
@@ -149,9 +154,11 @@ public class Palette {
                 }
             } else if (entry.getVariant() != null) {
                 String variantName = entry.getVariant();
-                MinecraftServer server = ServerAccess.getServer();
-                ServerLevel level = server.getLevel(Level.OVERWORLD);
-                Variant variant = AssetRegistries.VARIANTS.getOrThrow(level, variantName);
+                // The registries this palette came from, not the overworld's. Asking
+                // ServerAccess.getServer().getLevel(OVERWORLD) resolved every dimension's variants
+                // against the overworld, and threw from a worldgen worker when the static server
+                // reference was not populated yet (issue #60).
+                Variant variant = AssetRegistries.VARIANTS.getOrThrow(access, variantName);
                 List<Pair<Integer, BlockState>> blocks = variant.getBlocks();
                 if (dmg != null) {
                     for (Pair<Integer, BlockState> pair : blocks) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryAssetRegistry.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryAssetRegistry.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 public class RegistryAssetRegistry<T, R> {
 
@@ -26,9 +26,20 @@ public class RegistryAssetRegistry<T, R> {
     // throwaway copy of an immutable asset.
     private final Map<Identifier, T> assets = new ConcurrentHashMap<>();
     private final ResourceKey<Registry<R>> registryKey;
-    private final Function<List<R>, T> assetConstructor;
+    /**
+     * Compiles a resolved {@code extends} chain into the runtime asset.
+     * <p>
+     * It is handed the {@link RegistryAccess} the chain was read from, because compiling an asset
+     * can require resolving a reference into another of these registries - a palette entry naming a
+     * {@code variant} is the case that exists. That used to be done by asking
+     * {@code ServerAccess.getServer().getLevel(OVERWORLD)}, which pinned every dimension's variants
+     * to the overworld's registries and threw from a worldgen worker if the static server reference
+     * was not populated yet (issue #60). The access the caller already holds is the correct one.
+     */
+    private final BiFunction<RegistryAccess, List<R>, T> assetConstructor;
 
-    public RegistryAssetRegistry(ResourceKey<Registry<R>> registryKey, Function<List<R>, T> assetConstructor) {
+    public RegistryAssetRegistry(ResourceKey<Registry<R>> registryKey,
+                                 BiFunction<RegistryAccess, List<R>, T> assetConstructor) {
         this.registryKey = registryKey;
         this.assetConstructor = assetConstructor;
     }
@@ -72,7 +83,8 @@ public class RegistryAssetRegistry<T, R> {
         T t = assets.get(name);
         if (t == null) {
             try {
-                Registry<R> registry = level.registryAccess().lookupOrThrow(registryKey);
+                RegistryAccess access = level.registryAccess();
+                Registry<R> registry = access.lookupOrThrow(registryKey);
                 List<R> chain = ExtendsChain.resolve(name,
                         key -> {
                             R entry = registry.getValue(ResourceKey.create(registryKey, key));
@@ -82,7 +94,7 @@ public class RegistryAssetRegistry<T, R> {
                             return entry;
                         },
                         entry -> entry instanceof Extendable ext ? ext.getExtends() : Optional.empty());
-                t = assetConstructor.apply(chain);
+                t = assetConstructor.apply(access, chain);
             } catch (Exception e) {
                 throw new RuntimeException("Error getting resource " + name + "!", e);
             }
@@ -107,6 +119,28 @@ public class RegistryAssetRegistry<T, R> {
         return get(access, DataTools.fromName(name));
     }
 
+    /**
+     * @throws RuntimeException naming the registry and the id, including when {@code access} is
+     *                          null - an asset compiled without registry access cannot resolve a
+     *                          cross-reference, and saying so beats a {@code NullPointerException}
+     *                          from somewhere further in.
+     */
+    @Nonnull
+    public T getOrThrow(RegistryAccess access, String name) {
+        if (name == null) {
+            throw new RuntimeException("Invalid name given to " + registryKey.registry() + " getOrThrow!");
+        }
+        if (access == null) {
+            throw new RuntimeException("Cannot resolve '" + name + "' in " + registryKey.registry()
+                    + "! This asset was compiled without registry access.");
+        }
+        T result = get(access, DataTools.fromName(name));
+        if (result == null) {
+            throw new RuntimeException("Can't find '" + name + "' in " + registryKey.registry() + "!");
+        }
+        return result;
+    }
+
     @Nullable
     public T get(RegistryAccess access, Identifier name) {
         if (access == null || name == null) {
@@ -125,7 +159,7 @@ public class RegistryAssetRegistry<T, R> {
                             return entry;
                         },
                         entry -> entry instanceof Extendable ext ? ext.getExtends() : Optional.empty());
-                t = assetConstructor.apply(chain);
+                t = assetConstructor.apply(access, chain);
             } catch (Exception e) {
                 throw new RuntimeException("Error getting resource " + name + "!", e);
             }
@@ -141,7 +175,8 @@ public class RegistryAssetRegistry<T, R> {
         if (level == null) {
             return;
         }
-        Registry<R> registry = level.registryAccess().lookupOrThrow(registryKey);
+        RegistryAccess access = level.registryAccess();
+        Registry<R> registry = access.lookupOrThrow(registryKey);
         for (R r : registry) {
             Identifier name = registry.getKey(r);
             if (!assets.containsKey(name)) {
@@ -154,7 +189,7 @@ public class RegistryAssetRegistry<T, R> {
                             return entry;
                         },
                         entry -> entry instanceof Extendable ext ? ext.getExtends() : Optional.empty());
-                T t = assetConstructor.apply(chain);
+                T t = assetConstructor.apply(access, chain);
                 assets.putIfAbsent(name, t);
             }
         }

--- a/src/test/java/dev/krona/urbex/data/DatapackGuideExamplesTest.java
+++ b/src/test/java/dev/krona/urbex/data/DatapackGuideExamplesTest.java
@@ -188,21 +188,21 @@ class DatapackGuideExamplesTest {
         expect(guide, missing, () -> Resolved.require(null, downtown, "streetblocks.parts.stair"));
 
         // A part with no geometry, and a part whose redeclared size contradicts inherited slices.
-        expect(guide, missing, () -> new BuildingPart(List.of(namedPart(tower, null, null, null))));
-        expect(guide, missing, () -> new BuildingPart(List.of(
+        expect(guide, missing, () -> new BuildingPart(null, List.of(namedPart(tower, null, null, null))));
+        expect(guide, missing, () -> new BuildingPart(null, List.of(
                 namedPart(Identifier.fromNamespaceAndPath("urbexmt", "tower_base"), 16, 16,
                         List.of(List.of("x".repeat(256)))),
                 namedPart(tower, 8, null, null))));
 
         // 'extends' inside an inline palette block.
-        expect(guide, missing, () -> Palette.inline(tower, List.of(new PaletteRE(
+        expect(guide, missing, () -> Palette.inline(null, tower, List.of(new PaletteRE(
                 Optional.of(Identifier.fromNamespaceAndPath("urbex", "common")), Optional.empty()))));
 
         // A palette entry that resolves to nothing at all.
         PaletteEntry empty = new PaletteEntry("#", Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        expect(guide, missing, () -> new Palette(List.of(
+        expect(guide, missing, () -> new Palette(null, List.of(
                 new PaletteRE(Optional.empty(), Optional.of(List.of(empty)))
                         .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "x")))));
 

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BelowPartConditionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BelowPartConditionTest.java
@@ -94,7 +94,7 @@ public class BelowPartConditionTest {
     private static Building buildingWithParts2Condition(Set<String> belowPart, Set<String> inpart) {
         PartRef floor = partRef(FLOOR, null, null);
         PartRef second = partRef("urbex:second_part", belowPart, inpart);
-        return new Building(List.of(new BuildingRE(
+        return new Building(null, List.of(new BuildingRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.of('#'), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPartExtendsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPartExtendsTest.java
@@ -46,7 +46,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("radiotower_rusted", inherits("urbex:radiotower")
                 .refpalette("urbexmt:radiotower_rusted"));
 
-        BuildingPart resolved = new BuildingPart(List.of(parent, child));
+        BuildingPart resolved = new BuildingPart(null, List.of(parent, child));
 
         assertEquals(2, resolved.getXSize());
         assertEquals(2, resolved.getZSize());
@@ -63,7 +63,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_short", inherits("urbex:tower")
                 .slices(List.of(List.of("ij", "kl"))));
 
-        BuildingPart resolved = new BuildingPart(List.of(parent, child));
+        BuildingPart resolved = new BuildingPart(null, List.of(parent, child));
 
         assertEquals(1, resolved.getSliceCount());
         assertArrayEquals(new String[]{"ijkl"}, resolved.getSlices());
@@ -77,7 +77,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_wide", inherits("urbex:tower").xsize(3));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(List.of(parent, child)));
+                () -> new BuildingPart(null, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_wide"),
                 () -> "the error must name the part: " + error.getMessage());
@@ -93,7 +93,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_deep", inherits("urbex:tower").zsize(5));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(List.of(parent, child)));
+                () -> new BuildingPart(null, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_deep"),
                 () -> "the error must name the part: " + error.getMessage());
@@ -106,7 +106,7 @@ class BuildingPartExtendsTest {
                 .refpalette("urbex:rusted"));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(List.of(parent, child)));
+                () -> new BuildingPart(null, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_rusted"),
                 () -> "the error must name the part that failed to resolve: " + error.getMessage());
@@ -119,7 +119,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE parent = part("sliced_only", new Builder().slices(TOWER));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(List.of(parent)));
+                () -> new BuildingPart(null, List.of(parent)));
 
         assertTrue(error.getMessage().contains("urbex:sliced_only"), error::getMessage);
     }
@@ -130,11 +130,11 @@ class BuildingPartExtendsTest {
         BuildingPartRE replacing = part("tower_a", inherits("urbex:tower").meta(true, meta("nowater")));
         BuildingPartRE appending = part("tower_b", inherits("urbex:tower").meta(false, meta("nowater")));
 
-        BuildingPart replaced = new BuildingPart(List.of(parent, replacing));
+        BuildingPart replaced = new BuildingPart(null, List.of(parent, replacing));
         assertTrue(replaced.getMetaBoolean("nowater"));
         assertFalse(replaced.getMetaBoolean("support"), "a bare array replaces");
 
-        BuildingPart appended = new BuildingPart(List.of(parent, appending));
+        BuildingPart appended = new BuildingPart(null, List.of(parent, appending));
         assertTrue(appended.getMetaBoolean("nowater"));
         assertTrue(appended.getMetaBoolean("support"), "{\"replace\": false} keeps the inherited meta");
     }
@@ -151,7 +151,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_rusted", inherits("urbex:tower")
                 .inlinePalette(entry('a', "minecraft:deepslate")));
 
-        Palette resolved = new BuildingPart(List.of(parent, child)).getLocalPalette(null);
+        Palette resolved = new BuildingPart(null, List.of(parent, child)).getLocalPalette(null);
 
         assertEquals(3, resolved.getPalette().size(),
                 "the two characters the child never mentions must survive");
@@ -168,7 +168,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_ref", inherits("urbex:tower")
                 .refpalette("urbex:somewhere_else"));
 
-        BuildingPart resolved = new BuildingPart(List.of(parent, child));
+        BuildingPart resolved = new BuildingPart(null, List.of(parent, child));
 
         assertEquals("urbex:somewhere_else", resolved.getRefPaletteName());
         // The inherited inline palette is gone: getLocalPalette has to go to the registry for the
@@ -187,7 +187,7 @@ class BuildingPartExtendsTest {
                         entry('a', "minecraft:stone")));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(List.of(part)));
+                () -> new BuildingPart(null, List.of(part)));
 
         assertTrue(error.getMessage().contains("urbex:tower"), error::getMessage);
         assertTrue(error.getMessage().contains("urbex:common"), error::getMessage);

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CommonPaletteLightingTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CommonPaletteLightingTest.java
@@ -76,7 +76,7 @@ class CommonPaletteLightingTest {
         assertNull(redstoneTorch.getTorch());
         assertNull(redstoneTorch.getLight());
 
-        Palette compiled = new Palette(List.of(common));
+        Palette compiled = new Palette(null, List.of(common));
         LightPool torchPool = compiled.getPalette().get('T').info().light();
         LightPool freePool = compiled.getPalette().get('h').info().light();
         assertNotNull(torchPool);

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/LightPoolTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/LightPoolTest.java
@@ -62,7 +62,7 @@ class LightPoolTest {
                 """);
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> new Palette(List.of(palette)));
+                () -> new Palette(null, List.of(palette)));
         assertTrue(error.getMessage().contains("urbex:test_lights"));
         assertTrue(error.getMessage().contains("marker 'L'"));
         assertTrue(error.getMessage().contains("floor, wall, ceiling, or free"));
@@ -78,7 +78,7 @@ class LightPoolTest {
                     """.formatted(weight));
 
             IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                    () -> new Palette(List.of(palette)));
+                    () -> new Palette(null, List.of(palette)));
             assertTrue(error.getMessage().contains("urbex:test_lights"));
             assertTrue(error.getMessage().contains("marker 'L'"));
             assertTrue(error.getMessage().contains("placement 'floor'"));
@@ -246,7 +246,7 @@ class LightPoolTest {
         PaletteRE paletteRE = result.result().orElseThrow()
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "legacy_torch"));
 
-        Palette.PE entry = new Palette(List.of(paletteRE)).getPalette().get('L');
+        Palette.PE entry = new Palette(null, List.of(paletteRE)).getPalette().get('L');
         assertInstanceOf(BlockState.class, entry.blocks());
         assertTrue(entry.info().isTorch());
         assertNull(entry.info().light());
@@ -267,7 +267,7 @@ class LightPoolTest {
         PaletteRE paletteRE = result.result().orElseThrow()
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "typed_lights"));
 
-        Palette.PE entry = new Palette(List.of(paletteRE)).getPalette().get('L');
+        Palette.PE entry = new Palette(null, List.of(paletteRE)).getPalette().get('L');
         BlockState representative = assertInstanceOf(BlockState.class, entry.blocks());
         assertEquals(Blocks.SOUL_WALL_TORCH, representative.getBlock());
         assertTrue(entry.info().isSpecial());

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteExtendsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteExtendsTest.java
@@ -37,7 +37,7 @@ class PaletteExtendsTest {
                 entry('g', "minecraft:glass"));
         PaletteRE child = palette("child", entry('S', "minecraft:deepslate"));
 
-        Palette resolved = new Palette(List.of(parent, child));
+        Palette resolved = new Palette(null, List.of(parent, child));
 
         assertEquals("minecraft:deepslate", blockOf(resolved, 'S'), "the child's character wins");
         assertEquals("minecraft:bricks", blockOf(resolved, 'b'), "characters it never mentions survive");
@@ -51,7 +51,7 @@ class PaletteExtendsTest {
         PaletteRE parent = palette("parent", entry('S', "minecraft:stone"));
         PaletteRE child = palette("child", entry('w', "minecraft:oak_planks"));
 
-        Palette resolved = new Palette(List.of(parent, child));
+        Palette resolved = new Palette(null, List.of(parent, child));
 
         assertEquals(2, resolved.getPalette().size());
         assertEquals("minecraft:stone", blockOf(resolved, 'S'));
@@ -64,8 +64,8 @@ class PaletteExtendsTest {
         PaletteRE middle = palette("middle", entry('S', "minecraft:andesite"));
         PaletteRE leaf = palette("leaf", entry('S', "minecraft:deepslate"));
 
-        assertEquals("minecraft:deepslate", blockOf(new Palette(List.of(root, middle, leaf)), 'S'));
-        assertEquals("minecraft:andesite", blockOf(new Palette(List.of(root, middle)), 'S'));
+        assertEquals("minecraft:deepslate", blockOf(new Palette(null, List.of(root, middle, leaf)), 'S'));
+        assertEquals("minecraft:andesite", blockOf(new Palette(null, List.of(root, middle)), 'S'));
     }
 
     @Test
@@ -75,14 +75,14 @@ class PaletteExtendsTest {
         PaletteRE parent = palette("parent", damagedEntry('S', "minecraft:stone", "minecraft:cobblestone"));
         PaletteRE child = palette("child", entry('S', "minecraft:deepslate"));
 
-        Palette resolved = new Palette(List.of(parent, child));
+        Palette resolved = new Palette(null, List.of(parent, child));
 
         assertNull(resolved.getDamaged().get(state("minecraft:stone")),
                 "the replaced parent entry must not leave its damaged mapping behind");
         assertEquals(1, resolved.getPalette().size());
 
         // ... and a mapping on a character nobody overrides is still there.
-        Palette parentOnly = new Palette(List.of(parent));
+        Palette parentOnly = new Palette(null, List.of(parent));
         assertNotNull(parentOnly.getDamaged().get(state("minecraft:stone")));
     }
 

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteVariantResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteVariantResolutionTest.java
@@ -1,0 +1,138 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import com.mojang.serialization.Lifecycle;
+import dev.krona.urbex.setup.CustomRegistries;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
+import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.RegistrationInfo;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.block.state.BlockState;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A palette entry naming a {@code variant} resolves it against the registries the palette itself
+ * came from (issue #60).
+ * <p>
+ * It used to resolve against {@code ServerAccess.getServer().getLevel(Level.OVERWORLD)} - the
+ * process-wide server reference, and then unconditionally that server's overworld. Two things were
+ * wrong with that, and only the second is visible in a single-dimension world: a palette compiled
+ * for any other dimension took the overworld's variants, and a palette compiled on a worldgen
+ * worker before the static server reference was populated threw a {@link NullPointerException} out
+ * of asset compilation.
+ */
+class PaletteVariantResolutionTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @BeforeEach
+    @AfterEach
+    void clearRegistries() {
+        // AssetRegistries.VARIANTS caches by id, and these tests deliberately register different
+        // blocks under the same id in different registry accesses.
+        AssetRegistries.reset();
+    }
+
+    @Test
+    void aVariantResolvesAgainstTheRegistriesThePaletteCameFrom() {
+        RegistryAccess access = variantsWith("minecraft:deepslate");
+
+        Palette compiled = new Palette(access, List.of(paletteNamingVariant()));
+
+        assertEquals(List.of("minecraft:deepslate"), blocksOf(compiled, 'V'));
+    }
+
+    /**
+     * The bug, stated as a test. Two dimensions whose registries define {@code urbex:rubble}
+     * differently must each get their own - the old code handed both the overworld's.
+     */
+    @Test
+    void twoRegistryAccessesResolveTheSameVariantIdIndependently() {
+        Palette fromFirst = new Palette(variantsWith("minecraft:deepslate"),
+                List.of(paletteNamingVariant()));
+        AssetRegistries.reset();
+        Palette fromSecond = new Palette(variantsWith("minecraft:sandstone"),
+                List.of(paletteNamingVariant()));
+
+        assertEquals(List.of("minecraft:deepslate"), blocksOf(fromFirst, 'V'));
+        assertEquals(List.of("minecraft:sandstone"), blocksOf(fromSecond, 'V'),
+                "the second palette must not inherit the first's answer for the same variant id");
+    }
+
+    /**
+     * Compiling a variant entry with no registry access to resolve it against is refused, naming
+     * the variant. The old shape's answer to the same situation was a {@code NullPointerException}
+     * from {@code server.getLevel(...)}, in asset compilation, on a worker thread.
+     */
+    @Test
+    void aVariantEntryWithNoRegistryAccessFailsNamingTheVariant() {
+        RuntimeException failure = assertThrows(RuntimeException.class,
+                () -> new Palette(null, List.of(paletteNamingVariant())));
+
+        String message = String.valueOf(rootCause(failure).getMessage());
+        assertTrue(message.contains("urbex:rubble"), () -> "message must name the variant: " + message);
+    }
+
+    private static Throwable rootCause(Throwable t) {
+        return t.getCause() == null ? t : rootCause(t.getCause());
+    }
+
+    private static List<String> blocksOf(Palette palette, char marker) {
+        Object blocks = palette.getPalette().get(marker).blocks();
+        if (blocks instanceof BlockState single) {
+            return List.of(nameOf(single));
+        }
+        @SuppressWarnings("unchecked")
+        Pair<Integer, BlockState>[] weighted = (Pair<Integer, BlockState>[]) blocks;
+        return java.util.Arrays.stream(weighted).map(pair -> nameOf(pair.getRight())).distinct().toList();
+    }
+
+    private static String nameOf(BlockState state) {
+        return BuiltInRegistries.BLOCK.getKey(state.getBlock()).toString();
+    }
+
+    private static PaletteRE paletteNamingVariant() {
+        PaletteEntry entry = new PaletteEntry("V", Optional.empty(), Optional.of("urbex:rubble"),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        return new PaletteRE(Optional.empty(), Optional.of(List.of(entry)))
+                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "variant-palette"));
+    }
+
+    /** A registry access whose only {@code urbex:rubble} variant is one weighted block. */
+    private static RegistryAccess variantsWith(String block) {
+        MappedRegistry<VariantRE> variants = new MappedRegistry<>(
+                CustomRegistries.VARIANTS_REGISTRY_KEY, Lifecycle.stable());
+        variants.register(
+                ResourceKey.create(CustomRegistries.VARIANTS_REGISTRY_KEY,
+                        Identifier.fromNamespaceAndPath("urbex", "rubble")),
+                new VariantRE(Optional.empty(),
+                        Optional.of(new Mergeable<>(true, List.of(new BlockEntry(1, block))))),
+                RegistrationInfo.BUILT_IN);
+        return new RegistryAccess.ImmutableRegistryAccess(List.<Registry<?>>of(variants.freeze())).freeze();
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
@@ -380,7 +380,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildInheritsTheFillerAndPartsItDoesNotDeclare() {
-        Building resolved = new Building(List.of(
+        Building resolved = new Building(null, List.of(
                 building("library").filler("#").parts("urbex:library_floor").minFloors(2).build(),
                 building("library_burnt").rubble("R").build()));
 
@@ -393,13 +393,13 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildCanSetAnInheritedPrefersLonelyBackToZero() {
-        Building resolved = new Building(List.of(
+        Building resolved = new Building(null, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").prefersLonely(0.8f).build(),
                 building("tower_row").prefersLonely(0.0f).build()));
 
         assertEquals(0.0f, resolved.getPrefersLonely(),
                 "0.0 is a value a file can mean, not a marker for 'undeclared'");
-        assertEquals(0.8f, new Building(List.of(
+        assertEquals(0.8f, new Building(null, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").prefersLonely(0.8f).build(),
                 building("tower_row").build())).getPrefersLonely(),
                 "omitting it still inherits");
@@ -407,7 +407,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildCanSetAnInheritedFloorLimitBackToTheLevelDefault() {
-        Building resolved = new Building(List.of(
+        Building resolved = new Building(null, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").minFloors(4).build(),
                 building("tower_short").minFloors(-1).build()));
 


### PR DESCRIPTION
Closes #60. First phase-2 item in epic #134. Stacked on #138.

## What was wrong

`Palette.compile` resolved a `variant` entry through
`ServerAccess.getServer().getLevel(Level.OVERWORLD)` — the process-wide server reference, and then
unconditionally *that server's overworld* — ignoring the registries the palette had just been read
from. Two consequences:

- a palette compiled for any dimension other than the overworld took the overworld's variants;
- a palette compiled on a worldgen worker before the static server reference was populated threw a
  `NullPointerException` out of asset compilation.

## What changed

`RegistryAssetRegistry` already held a `RegistryAccess` at all three of its compile sites
(`get(CommonLevelAccessor, …)`, `get(RegistryAccess, …)`, `loadAll`), so the fix is to hand it to
the asset constructor rather than have the constructor go looking for one.

Only `Palette` needs it — and `Building`/`BuildingPart`, which build inline palettes. The other
nine compile from their resolved chain alone, and the declarations in `AssetRegistries` now say so
at a glance.

A palette compiled with no registry access and a `variant` entry to resolve fails naming the
variant instead of dereferencing null.

## Scope

This retires one of the `ServerAccess` users #128 enumerates. The remaining ones are out of scope
here and assigned elsewhere in the milestone: `Tools.stringToState`/`WorldTools.getOverworld` move
to compile time in #128, error reporting is scoped by #131, and the editor's own overworld lookup
stays with #69.

## Tests

`PaletteVariantResolutionTest`, including the bug stated directly: two registry accesses defining
`urbex:rubble` differently must each resolve their own, where the old code handed both the
overworld's.

- `./gradlew test` — pass
- `./gradlew runDigestCheck` — `688914e862e938fb`, unchanged
- `./gradlew runDigestCheckFeatures` — `7b5348f28e0a6d23`, unchanged
