### PR TITLE
feat: aggregate asset diagnostics and add /urbex validate (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **A datapack's mistakes are reported all at once, and `/urbex validate` asks for them on demand.**
+  Load-time asset resolution stopped at the first broken file. That is the right outcome — the world
+  must not load — but the wrong report: an author with four typos fixed one, reloaded the world,
+  found the second, and went round again. Every registered asset is now resolved before anything is
+  reported, and the world refuses to load with one message listing every problem, each line naming
+  the registry, the asset and what is missing (issue #56).
+  - *`/urbex validate`* runs the same pass on demand and changes nothing — it does not populate,
+    replace or clear the compiled assets the running world's chunks are generating against. On a
+    world that is running it finds nothing, which is the answer worth being able to confirm after
+    installing a pack. The full list goes to the server log; chat gets the first ten.
+  - *`ErrorLogger.report` no longer dereferences a null server.* It is called from the handler
+    around chunk generation, and the window it most needs to survive is shutdown — a worker
+    finishing a chunk after the static server reference has been cleared. The error *handler* threw
+    an exception of its own there, turning a reported chunk failure into a dead worldgen worker and
+    losing the message being reported. The report now always reaches the log, whether or not anyone
+    is listening.
+  - *No worldgen change*: both digest goldens are unchanged.
+
 - **A palette's `variant` resolves against its own dimension's registries.** `Palette.compile`
   looked a variant up through `ServerAccess.getServer().getLevel(Level.OVERWORLD)` — the
   process-wide server reference, and then unconditionally that server's overworld — ignoring the

--- a/docs/datapacks.md
+++ b/docs/datapacks.md
@@ -867,3 +867,15 @@ values. For presets, `/urbex savepreset` writes the fully resolved preset for yo
 dimension to disk; [`docs/presets.md`](presets.md) covers it. The other twelve registries have no
 equivalent export yet — for those, the load errors are the feedback loop, which is why they are
 worded to name the asset and the field rather than the file.
+
+Those errors come all at once. Every registered asset is resolved while the world loads, and
+everything that fails is collected and reported together, each line naming the registry, the asset
+and what is missing — so a pack with four mistakes takes one world load to diagnose rather than
+four.
+
+`/urbex validate` runs the same pass on demand and reports the same list, without changing anything.
+On a world that is running it finds nothing, because anything it could find would have refused the
+world already; it is there to confirm that after installing a pack, and to give you the whole list
+in the server log. It cannot see an edit made since the world opened: the thirteen registries are
+dynamic registries, loaded once with the world and frozen, so an edited file needs the world
+reopened — exactly as a vanilla worldgen file does.

--- a/src/main/java/dev/krona/urbex/commands/CommandValidate.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandValidate.java
@@ -1,0 +1,65 @@
+package dev.krona.urbex.commands;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetDiagnostics;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetRegistries;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Re-resolves every registered Urbex asset and reports what is wrong, changing nothing.
+ * <p>
+ * For a datapack author, who otherwise learns about a broken reference either from a world that
+ * refuses to load or - before load-time resolution existed - from a chunk that generated wrong
+ * (issue #56). Every problem this can find has already refused the world at load, so on a running
+ * world it reports nothing; that is the answer worth being able to ask for after installing a pack.
+ * <p>
+ * It cannot see an edit made since the world opened: the thirteen asset registries are Fabric
+ * dynamic registries, loaded once with the world and frozen, so an edited file needs the world
+ * reopened exactly as a vanilla worldgen file does.
+ */
+public class CommandValidate implements Command<CommandSourceStack> {
+
+    private static final CommandValidate CMD = new CommandValidate();
+
+    /** How many problems to put in chat before pointing at the log. */
+    private static final int CHAT_LIMIT = 10;
+
+    public static ArgumentBuilder<CommandSourceStack, ?> register() {
+        return Commands.literal("validate")
+                .requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS))
+                .executes(CMD);
+    }
+
+    @Override
+    public int run(CommandContext<CommandSourceStack> context) {
+        CommandSourceStack source = context.getSource();
+        AssetDiagnostics diagnostics = AssetRegistries.validate(source.registryAccess());
+
+        if (diagnostics.isEmpty()) {
+            source.sendSuccess(() -> Component.literal("Urbex assets: no problems found.")
+                    .withStyle(ChatFormatting.GREEN), false);
+            return Command.SINGLE_SUCCESS;
+        }
+
+        // The whole report goes to the log whatever its size; chat gets the head of it. A pack with
+        // fifty broken files would otherwise scroll the useful part of the session away.
+        Urbex.getLogger().error(diagnostics.format(
+                diagnostics.size() + " Urbex asset problem(s) found by /urbex validate:"));
+        source.sendFailure(Component.literal(diagnostics.size() + " Urbex asset problem(s):")
+                .withStyle(ChatFormatting.RED));
+        diagnostics.problems().stream().limit(CHAT_LIMIT).forEach(problem ->
+                source.sendSystemMessage(Component.literal("  " + problem).withStyle(ChatFormatting.RED)));
+        int remaining = diagnostics.size() - CHAT_LIMIT;
+        if (remaining > 0) {
+            source.sendSystemMessage(Component.literal("  ... and " + remaining
+                    + " more; the full list is in the server log.").withStyle(ChatFormatting.GRAY));
+        }
+        return 0;
+    }
+}

--- a/src/main/java/dev/krona/urbex/commands/ModCommands.java
+++ b/src/main/java/dev/krona/urbex/commands/ModCommands.java
@@ -35,6 +35,7 @@ public class ModCommands {
                         .then(CommandListParts.register())
                         .then(CommandExportPart.register())
                         .then(CommandDigest.register())
+                        .then(CommandValidate.register())
         );
 
         dispatcher.register(Commands.literal("ubx").redirect(commands));

--- a/src/main/java/dev/krona/urbex/worldgen/ErrorLogger.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ErrorLogger.java
@@ -20,15 +20,30 @@ public class ErrorLogger {
 
     private static long lastReportTime = -1;
 
+    /**
+     * Tells whoever is playing that a chunk went wrong, at most once every ten seconds.
+     * <p>
+     * The null guard is not defensive tidiness. This is called from the handler around chunk
+     * generation, and the window it most wants to survive is shutdown - a worker finishing a chunk
+     * after {@code SERVER_STOPPED} has cleared the static server reference. Without it the error
+     * <em>handler</em> threw a {@link NullPointerException} of its own, turning a reported chunk
+     * failure into a dead worldgen worker and losing the message that was being reported (issue
+     * #56). The log line below is not a fallback for the chat message; it is where the report has
+     * always actually belonged, and now happens whether or not anyone is listening.
+     */
     public static void report(String message) {
         long time = System.currentTimeMillis();
-        if (lastReportTime == -1 || lastReportTime < (time-10000)) {
-            // Not reported before or too long ago
-            lastReportTime = time;
-            MinecraftServer server = ServerAccess.getServer();
-            for (ServerPlayer player : server.getPlayerList().getPlayers()) {
-                player.sendSystemMessage(Component.literal(message).withStyle(ChatFormatting.RED));
-            }
+        if (lastReportTime != -1 && lastReportTime >= (time - 10000)) {
+            return;
+        }
+        lastReportTime = time;
+        Urbex.getLogger().error(message);
+        MinecraftServer server = ServerAccess.getServer();
+        if (server == null) {
+            return;
+        }
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            player.sendSystemMessage(Component.literal(message).withStyle(ChatFormatting.RED));
         }
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
@@ -66,14 +66,15 @@ public class Stuff {
         // (GenerationSession, issue #125). This guard is what would say so if that ever stopped
         // being true - the failure it detects is otherwise completely silent.
         //
-        // Logged rather than thrown, for two reasons. generateStuff is the last statement of
-        // CityGenerator.doCityChunk, which generate() calls at CityGenerator.java:290, well before
-        // ctx.driver.actuallyGenerate(chunk) at :310 - so a throw here would unwind past the commit
-        // and lose the chunk's entire cached write set, costing the whole chunk rather than its
-        // decoration. And it would route through CityFeature.generateFromPipeline's handler into
-        // ErrorLogger.report, which dereferences ServerAccess.getServer() with no null check
-        // (ErrorLogger.java:28-29) - during the shutdown window this fires in, that turns a
-        // decoration bug into a dead worldgen worker.
+        // Logged rather than thrown: generateStuff is the last statement of
+        // CityGenerator.doCityChunk, which generate() calls well before
+        // ctx.driver.actuallyGenerate(chunk) - so a throw here would unwind past the commit and lose
+        // the chunk's entire cached write set, costing the whole chunk rather than its decoration.
+        // (It would also have routed through CityFeature.generateFromPipeline's handler into
+        // ErrorLogger.report, which used to dereference ServerAccess.getServer() with no null check
+        // and so could turn a decoration bug into a dead worldgen worker during exactly the shutdown
+        // window this fires in. That null check exists now - issue #56 - but the reason above stands
+        // on its own.)
         AssetRegistries.StuffIndex stuffIndex = AssetRegistries.stuffIndex();
         if (stuffIndex.byTag().isEmpty() && !stuffIndex.loaded()) {
             if (REPORTED_UNLOADED.compareAndSet(false, true)) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetDiagnostics.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetDiagnostics.java
@@ -1,0 +1,99 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import net.minecraft.resources.Identifier;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Everything wrong with a datapack, collected before any of it is reported.
+ *
+ * <p>Asset resolution used to stop at the first broken file. That is the right <em>outcome</em> -
+ * the world must not load - but the wrong report: an author with four typos fixed one, reloaded the
+ * world, found the second, and went round again. Four world loads to learn four things the compiler
+ * knew on the first (issue #56).</p>
+ *
+ * <p>Each problem carries where it was found - registry, then asset id - so a message like
+ * "declares no 'filler'" is attributable without the reader having to guess which of thirty
+ * buildings raised it. Problems are reported in a stable order (registry, then asset id) rather
+ * than in the order the registries happened to be walked, so re-running the pass produces the same
+ * text and two runs can be diffed.</p>
+ */
+public final class AssetDiagnostics {
+
+    /**
+     * @param registry the registry being resolved, e.g. {@code urbex/buildings}
+     * @param asset    the asset that failed, or null when the problem belongs to the sweep rather
+     *                 than to one entry
+     * @param message  what is wrong, already phrased for an author
+     */
+    public record Problem(String registry, @Nullable Identifier asset, String message) {
+        @Override
+        public String toString() {
+            return registry + (asset == null ? "" : " / " + asset) + ": " + message;
+        }
+    }
+
+    private final List<Problem> problems = new ArrayList<>();
+
+    public synchronized void record(String registry, @Nullable Identifier asset, String message) {
+        problems.add(new Problem(registry, asset, message));
+    }
+
+    /**
+     * Records a resolution failure, using the deepest message in the chain.
+     *
+     * <p>The wrappers above it say "Error getting resource x" at every level; what an author needs
+     * is the innermost sentence, which names the field or the missing reference. The wrapping is
+     * still in the log - this is the summary line, not the stack trace.</p>
+     */
+    public void record(String registry, @Nullable Identifier asset, Throwable failure) {
+        Throwable root = failure;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        String message = root.getMessage();
+        record(registry, asset, message == null ? root.toString() : message);
+    }
+
+    public synchronized boolean isEmpty() {
+        return problems.isEmpty();
+    }
+
+    public synchronized int size() {
+        return problems.size();
+    }
+
+    /** Every problem, in a stable order. */
+    public synchronized List<Problem> problems() {
+        return problems.stream()
+                .sorted(Comparator.comparing(Problem::registry)
+                        .thenComparing(problem -> problem.asset() == null ? "" : problem.asset().toString())
+                        .thenComparing(Problem::message))
+                .toList();
+    }
+
+    /** One block of text: a headline, then one line per problem. */
+    public String format(String headline) {
+        StringBuilder text = new StringBuilder(headline);
+        for (Problem problem : problems()) {
+            text.append("\n  - ").append(problem);
+        }
+        return text.toString();
+    }
+
+    /**
+     * Refuses the world if anything is wrong, naming everything at once.
+     *
+     * @throws IllegalStateException listing every problem
+     */
+    public void throwIfAny() {
+        if (isEmpty()) {
+            return;
+        }
+        throw new IllegalStateException(format(
+                size() + " Urbex asset problem(s) must be fixed before this world can load:"));
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetRegistries.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetRegistries.java
@@ -3,10 +3,12 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 import dev.krona.urbex.config.Presets;
 import dev.krona.urbex.setup.CustomRegistries;
 import dev.krona.urbex.worldgen.lost.regassets.*;
+import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.CitySettings;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.world.level.CommonLevelAccessor;
 import net.minecraft.world.level.biome.Biome;
 import org.apache.commons.lang3.tuple.Pair;
@@ -188,21 +190,58 @@ public class AssetRegistries {
             if (stuffIndex.loaded()) {
                 return;
             }
-            VARIANTS.loadAll(level);
-            PALETTES.loadAll(level);
-            CONDITIONS.loadAll(level);
-            STYLES.loadAll(level);
-            PARTS.loadAll(level);
-            BUILDINGS.loadAll(level);
-            MULTI_BUILDINGS.loadAll(level);
-            SCATTERED.loadAll(level);
-            WORLDSTYLES.loadAll(level);
-            loadReachableCityStyles(level);
-            STUFF.loadAll(level);
+            // One accumulator across every registry, so a pack with problems in three of them is
+            // one report rather than three world loads (issue #56).
+            AssetDiagnostics diagnostics = new AssetDiagnostics();
+            VARIANTS.loadAll(level, diagnostics);
+            PALETTES.loadAll(level, diagnostics);
+            CONDITIONS.loadAll(level, diagnostics);
+            STYLES.loadAll(level, diagnostics);
+            PARTS.loadAll(level, diagnostics);
+            BUILDINGS.loadAll(level, diagnostics);
+            MULTI_BUILDINGS.loadAll(level, diagnostics);
+            SCATTERED.loadAll(level, diagnostics);
+            WORLDSTYLES.loadAll(level, diagnostics);
+            loadReachableCityStyles(level, diagnostics);
+            STUFF.loadAll(level, diagnostics);
+            // Before publication, not after: the flag below says the registries are usable, and a
+            // pack that failed to compile has not earned it.
+            diagnostics.throwIfAny();
             // One write, publishing a map that is complete before the reference escapes - and
             // publishing the flag with it, so the two can never be observed out of step.
             stuffIndex = new StuffIndex(groupStuffByTag(STUFF.getIterable()), true);
         }
+    }
+
+    /**
+     * Re-resolves every registered asset and reports what is wrong, without changing anything.
+     * <p>
+     * What {@code /urbex validate} runs. Every problem it can find has already refused the world at
+     * load - {@link #load} throws on exactly the same set - so on a world that is running this
+     * reports nothing, which is the answer an author installing a pack wants confirmed. It is a
+     * separate pass rather than a re-run of {@code load} because {@code load} caches: asking it
+     * again returns the latch, and clearing the registries to make it answer afresh is precisely the
+     * mid-session reset that issue #125 removed.
+     * <p>
+     * The thirteen registries are frozen at world load (see {@code ServerEventHandlers}), so this
+     * cannot pick up an edit made since - the world has to be reopened for that, as it does for any
+     * vanilla worldgen file.
+     */
+    public static AssetDiagnostics validate(RegistryAccess access) {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        VARIANTS.validate(access, diagnostics);
+        PALETTES.validate(access, diagnostics);
+        CONDITIONS.validate(access, diagnostics);
+        STYLES.validate(access, diagnostics);
+        PARTS.validate(access, diagnostics);
+        BUILDINGS.validate(access, diagnostics);
+        MULTI_BUILDINGS.validate(access, diagnostics);
+        SCATTERED.validate(access, diagnostics);
+        WORLDSTYLES.validate(access, diagnostics);
+        CITYSTYLES.validate(access, diagnostics);
+        PREDEFINED_CITIES.validate(access, diagnostics);
+        STUFF.validate(access, diagnostics);
+        return diagnostics;
     }
 
     /**
@@ -244,24 +283,42 @@ public class AssetRegistries {
      * A null level resolves nothing, matching {@code RegistryAssetRegistry.loadAll}: the caller in
      * {@code AssetsLoadedBeforeGenerationTest} hands one in deliberately.
      */
-    private static void loadReachableCityStyles(CommonLevelAccessor level) {
+    private static void loadReachableCityStyles(CommonLevelAccessor level, AssetDiagnostics diagnostics) {
         if (level == null) {
             return;
         }
         for (WorldStyle style : WORLDSTYLES.getIterable()) {
             for (Pair<Predicate<Holder<Biome>>, Pair<Float, String>> selector : style.cityStyleSelectors()) {
-                requireCityStyle(level, selector.getRight().getRight(), style.getId());
+                recordCityStyle(level, selector.getRight().getRight(), style.getId(), diagnostics);
             }
         }
         Registry<PresetRE> presets = level.registryAccess().lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY);
         for (PresetRE preset : presets) {
             preset.cities().flatMap(CitySettings::cityStyleAlternative).ifPresent(
-                    name -> requireCityStyle(level, name, presets.getKey(preset)));
+                    name -> recordCityStyle(level, name, presets.getKey(preset), diagnostics));
         }
         Registry<PredefinedCityRE> cities =
                 level.registryAccess().lookupOrThrow(CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY);
         for (PredefinedCityRE city : cities) {
-            requireCityStyle(level, city.getCityStyle(), cities.getKey(city));
+            recordCityStyle(level, city.getCityStyle(), cities.getKey(city), diagnostics);
+        }
+    }
+
+    /**
+     * {@link #requireCityStyle} for the load-time sweep: one unusable city style is one more line in
+     * the report, not the end of the sweep. The throwing form stays for
+     * {@code DimensionRuntime.create}, which checks a single style named by the world's own
+     * selection and has nothing to aggregate with.
+     */
+    private static void recordCityStyle(CommonLevelAccessor level, @Nullable String name,
+                                        Object selectedBy, AssetDiagnostics diagnostics) {
+        if (name == null || name.isBlank()) {
+            return;
+        }
+        try {
+            requireCityStyle(level, name, selectedBy);
+        } catch (RuntimeException e) {
+            diagnostics.record(CITYSTYLES.registryName(), DataTools.fromName(name), e);
         }
     }
 
@@ -338,7 +395,12 @@ public class AssetRegistries {
             if (loadedPredefined) {
                 return;
             }
-            PREDEFINED_CITIES.loadAll(level);
+            AssetDiagnostics diagnostics = new AssetDiagnostics();
+            PREDEFINED_CITIES.loadAll(level, diagnostics);
+            // Thrown rather than folded into load()'s report: this runs lazily, from wherever a
+            // predefined city is first needed, so there is no world load left to refuse. Aggregated
+            // all the same - one bad predefined city should not hide the other three.
+            diagnostics.throwIfAny();
             loadedPredefined = true;
         }
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryAssetRegistry.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryAssetRegistry.java
@@ -171,7 +171,15 @@ public class RegistryAssetRegistry<T, R> {
         return t;
     }
 
-    public void loadAll(CommonLevelAccessor level) {
+    /**
+     * Resolves and caches every registered entry, recording what fails instead of stopping at it.
+     * <p>
+     * A pack with four broken files used to cost four world loads to diagnose, because the first
+     * failure threw out of the whole sweep. The world still refuses to load - {@code AssetRegistries
+     * .load} throws once the sweep is complete - but it now says everything that is wrong (issue
+     * #56). An entry that fails is simply not cached; nothing half-built is published.
+     */
+    public void loadAll(CommonLevelAccessor level, AssetDiagnostics diagnostics) {
         if (level == null) {
             return;
         }
@@ -179,20 +187,56 @@ public class RegistryAssetRegistry<T, R> {
         Registry<R> registry = access.lookupOrThrow(registryKey);
         for (R r : registry) {
             Identifier name = registry.getKey(r);
-            if (!assets.containsKey(name)) {
-                List<R> chain = ExtendsChain.resolve(name,
-                        key -> {
-                            R entry = registry.getValue(ResourceKey.create(registryKey, key));
-                            if (entry instanceof IAsset asset) {
-                                asset.setRegistryName(key);
-                            }
-                            return entry;
-                        },
-                        entry -> entry instanceof Extendable ext ? ext.getExtends() : Optional.empty());
-                T t = assetConstructor.apply(access, chain);
-                assets.putIfAbsent(name, t);
+            if (assets.containsKey(name)) {
+                continue;
+            }
+            try {
+                assets.putIfAbsent(name, compile(access, registry, name));
+            } catch (Exception e) {
+                diagnostics.record(registryName(), name, e);
             }
         }
+    }
+
+    /**
+     * Resolves every registered entry into a throwaway, recording what fails - without touching
+     * what is already cached.
+     * <p>
+     * This is what {@code /urbex validate} runs. It deliberately does not populate {@link #assets}:
+     * the live compiled assets belong to the loaded world and chunks are generating against them,
+     * so a validation pass must be able to fail without leaving anything different behind.
+     */
+    public void validate(RegistryAccess access, AssetDiagnostics diagnostics) {
+        if (access == null) {
+            return;
+        }
+        Registry<R> registry = access.lookupOrThrow(registryKey);
+        for (R r : registry) {
+            Identifier name = registry.getKey(r);
+            try {
+                compile(access, registry, name);
+            } catch (Exception e) {
+                diagnostics.record(registryName(), name, e);
+            }
+        }
+    }
+
+    private T compile(RegistryAccess access, Registry<R> registry, Identifier name) {
+        List<R> chain = ExtendsChain.resolve(name,
+                key -> {
+                    R entry = registry.getValue(ResourceKey.create(registryKey, key));
+                    if (entry instanceof IAsset asset) {
+                        asset.setRegistryName(key);
+                    }
+                    return entry;
+                },
+                entry -> entry instanceof Extendable ext ? ext.getExtends() : Optional.empty());
+        return assetConstructor.apply(access, chain);
+    }
+
+    /** The registry's own id, for a diagnostic that has to say where it came from. */
+    public String registryName() {
+        return registryKey.registry().toString();
     }
 
     public Iterable<T> getIterable() {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetDiagnosticsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetDiagnosticsTest.java
@@ -1,0 +1,95 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The accumulator that turns "the first thing wrong with this pack" into "everything wrong with this
+ * pack" (issue #56).
+ */
+class AssetDiagnosticsTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void anEmptyReportRefusesNothing() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+
+        assertTrue(diagnostics.isEmpty());
+        assertEquals(0, diagnostics.size());
+        diagnostics.throwIfAny();
+    }
+
+    @Test
+    void everyProblemIsNamedAtOnceRatherThanOnePerWorldLoad() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        diagnostics.record("urbex/buildings", id("radiotower"), "declares no 'filler'");
+        diagnostics.record("urbex/parts", id("floor"), "declares no 'xsize'");
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, diagnostics::throwIfAny);
+
+        assertTrue(failure.getMessage().contains("urbex:radiotower"), failure.getMessage());
+        assertTrue(failure.getMessage().contains("urbex:floor"), failure.getMessage());
+        assertTrue(failure.getMessage().startsWith("2 Urbex asset problem(s)"), failure.getMessage());
+    }
+
+    /**
+     * A stable order, so the report is the same text on two runs of the same pack and an author can
+     * diff two of them. Registry-walk order is a {@code ConcurrentHashMap}'s, which is to say a
+     * function of the ids' hashes.
+     */
+    @Test
+    void problemsAreReportedInAStableOrderRatherThanRegistryWalkOrder() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        diagnostics.record("urbex/parts", id("zzz"), "second");
+        diagnostics.record("urbex/buildings", id("mmm"), "first");
+        diagnostics.record("urbex/parts", id("aaa"), "also second");
+
+        assertEquals(List.of("urbex/buildings / urbex:mmm: first",
+                        "urbex/parts / urbex:aaa: also second",
+                        "urbex/parts / urbex:zzz: second"),
+                diagnostics.problems().stream().map(AssetDiagnostics.Problem::toString).toList());
+    }
+
+    /**
+     * The resolution wrappers say "Error getting resource x" at every level; what an author needs is
+     * the innermost sentence, which names the field or the missing reference.
+     */
+    @Test
+    void aWrappedFailureIsReportedByItsInnermostMessage() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Exception root = new IllegalStateException("'urbex:radiotower' declares no 'filler'");
+        Exception wrapped = new RuntimeException("Error getting resource urbex:radiotower!", root);
+
+        diagnostics.record("urbex/buildings", id("radiotower"), wrapped);
+
+        assertEquals("urbex/buildings / urbex:radiotower: 'urbex:radiotower' declares no 'filler'",
+                diagnostics.problems().getFirst().toString());
+    }
+
+    @Test
+    void aProblemWithNoOneAssetToBlameStillSaysWhereItCameFrom() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        diagnostics.record("urbex/worldstyles", null, "nothing selects a city style");
+
+        assertEquals("urbex/worldstyles: nothing selects a city style",
+                diagnostics.problems().getFirst().toString());
+    }
+
+    private static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath("urbex", path);
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetValidationTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetValidationTest.java
@@ -1,0 +1,129 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import com.mojang.serialization.Lifecycle;
+import dev.krona.urbex.setup.CustomRegistries;
+import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.RegistrationInfo;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A pack with several broken files is diagnosed once, not once per world load (issue #56), and
+ * asking for that diagnosis on a running world changes nothing.
+ * <p>
+ * Both properties are exercised through the {@code variants} registry, whose entries are the
+ * cheapest asset to break: a {@code VariantRE} declaring no {@code blocks} anywhere in its chain is
+ * exactly the "a field nothing declares" failure {@link Resolved} raises, and it needs no other
+ * registry to be populated to reach it.
+ */
+class AssetValidationTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @BeforeEach
+    @AfterEach
+    void clearRegistries() {
+        AssetRegistries.reset();
+    }
+
+    @Test
+    void everyBrokenAssetIsReportedRatherThanOnlyTheFirst() {
+        RegistryAccess access = registriesWithBrokenVariants("rubble", "leaves", "gravel");
+
+        AssetDiagnostics diagnostics = AssetRegistries.validate(access);
+
+        assertEquals(3, diagnostics.size(),
+                () -> "all three must be named at once, not one per world load: "
+                        + diagnostics.format("found"));
+        List<String> lines = diagnostics.problems().stream()
+                .map(AssetDiagnostics.Problem::toString).toList();
+        assertTrue(lines.stream().allMatch(line -> line.contains("declares no 'blocks'")), lines::toString);
+        for (String path : List.of("urbex:gravel", "urbex:leaves", "urbex:rubble")) {
+            assertTrue(lines.stream().anyMatch(line -> line.contains(path)),
+                    () -> path + " is missing from " + lines);
+        }
+    }
+
+    @Test
+    void aPackWithNothingWrongReportsNothing() {
+        RegistryAccess access = registriesWithBrokenVariants();
+
+        assertTrue(AssetRegistries.validate(access).isEmpty());
+    }
+
+    /**
+     * Validation is a throwaway pass. The live compiled assets belong to the loaded world and chunks
+     * are generating against them, so asking what is wrong must not populate, replace or clear them -
+     * clearing them mid-session is exactly what issue #125 removed.
+     */
+    @Test
+    void validatingLeavesTheLiveRegistriesAlone() {
+        RegistryAccess access = registriesWithBrokenVariants("rubble");
+
+        AssetRegistries.validate(access);
+
+        assertFalse(AssetRegistries.isLoaded(), "validation does not latch the registries as loaded");
+        assertEquals(List.of(), copyOf(AssetRegistries.VARIANTS.getIterable()),
+                "nor cache anything it compiled on the way");
+    }
+
+    private static List<Object> copyOf(Iterable<?> iterable) {
+        List<Object> copy = new ArrayList<>();
+        iterable.forEach(copy::add);
+        return copy;
+    }
+
+    /**
+     * A registry access holding every registry {@code validate} walks, all empty except
+     * {@code variants}, which holds one entry per name given - each declaring no {@code blocks}.
+     */
+    private static RegistryAccess registriesWithBrokenVariants(String... brokenPaths) {
+        MappedRegistry<VariantRE> variants = new MappedRegistry<>(
+                CustomRegistries.VARIANTS_REGISTRY_KEY, Lifecycle.stable());
+        for (String path : brokenPaths) {
+            variants.register(
+                    ResourceKey.create(CustomRegistries.VARIANTS_REGISTRY_KEY,
+                            Identifier.fromNamespaceAndPath("urbex", path)),
+                    new VariantRE(Optional.empty(), Optional.empty()),
+                    RegistrationInfo.BUILT_IN);
+        }
+        return new RegistryAccess.ImmutableRegistryAccess(List.of(
+                variants.freeze(),
+                empty(CustomRegistries.PALETTE_REGISTRY_KEY),
+                empty(CustomRegistries.CONDITIONS_REGISTRY_KEY),
+                empty(CustomRegistries.STYLE_REGISTRY_KEY),
+                empty(CustomRegistries.PART_REGISTRY_KEY),
+                empty(CustomRegistries.BUILDING_REGISTRY_KEY),
+                empty(CustomRegistries.MULTIBUILDINGS_REGISTRY_KEY),
+                empty(CustomRegistries.SCATTERED_REGISTRY_KEY),
+                empty(CustomRegistries.WORLDSTYLES_REGISTRY_KEY),
+                empty(CustomRegistries.CITYSTYLES_REGISTRY_KEY),
+                empty(CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY),
+                empty(CustomRegistries.STUFF_REGISTRY_KEY))).freeze();
+    }
+
+    private static <T> Registry<T> empty(ResourceKey<Registry<T>> key) {
+        return new MappedRegistry<>(key, Lifecycle.stable()).freeze();
+    }
+}


### PR DESCRIPTION
Part of #56 (the aggregated-diagnostics and `/urbex validate` half; see **Scope** below for what
stays open). Phase-2 item in epic #134. Stacked on #139.

## What was wrong

Asset resolution stopped at the first broken file. That is the right *outcome* — the world must not
load — but the wrong *report*: an author with four typos fixed one, reloaded the world, found the
second, and went round again. Four world loads to learn four things the compiler knew on the first.

`ErrorLogger.report` also dereferenced `ServerAccess.getServer()` with no null check, so the error
handler could throw an exception of its own — and it is called from the handler around chunk
generation, whose most important window is shutdown, where a worker finishes a chunk after the
static server reference has been cleared.

## What changed

**One accumulator across every registry.** `AssetDiagnostics` collects problems; the load throws
once, at the end, listing all of them. Each line names the registry, the asset and what is missing,
and the innermost message is used rather than the "Error getting resource x" wrappers above it. The
order is stable (registry, then asset id) rather than registry-walk order — which is a
`ConcurrentHashMap`'s, i.e. a function of the ids' hashes — so two runs of the same pack produce the
same text and can be diffed.

Nothing half-built is published: the diagnostics are thrown *before* the readiness latch and the
stuff index are set.

**`/urbex validate`.** The same pass, on demand. It resolves into throwaways rather than into the
live registries, because the compiled assets belong to the loaded world and chunks are generating
against them — so asking what is wrong must not populate, replace or clear them. (Clearing them
mid-session is exactly what #125 removed.) The whole report goes to the server log; chat gets the
first ten and a count.

Frozen dynamic registries mean it cannot pick up an edit made since the world opened, and both the
command's javadoc and `docs/datapacks.md` say so rather than implying a reload loop that does not
exist.

**`ErrorLogger.report` is null-guarded**, and now always writes the report to the log whether or not
there is anyone to send it to.

## Scope

The part of #56 that is *not* here is the per-character cross-check — "undefined palette chars and
bad slice sizes". Doing that correctly means replicating the palette merge that
`CityGenerator.computePalette` performs at generation time (style palette + the part's local or
referenced palette), and a validation pass that approximates that merge would either miss real
breakage or refuse packs that generate fine. That merge is what #128 moves to compile time, which is
why the epic files this work "as part of the asset compiler". #56 stays open with that remainder.

## Tests

- `AssetDiagnosticsTest` — aggregation, stable ordering, innermost-message extraction, and a
  problem with no single asset to blame.
- `AssetValidationTest` — three broken assets reported at once rather than one; a clean pack
  reporting nothing; and validation leaving the live registries untouched (nothing cached, latch not
  set).

- `./gradlew test` — pass
- `./gradlew runDigestCheck` — `688914e862e938fb`, unchanged
- `./gradlew runDigestCheckFeatures` — `7b5348f28e0a6d23`, unchanged
