### PR TITLE
Fix floating terrain slabs from air-only section writes

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -616,7 +616,8 @@ public class ChunkDriver {
 
     private static class S {
         private final BlockState[] section = new BlockState[SECTION_SIZE];
-        private boolean isEmpty = true;
+        // AIR is still a write: it may need to erase terrain already present in the chunk.
+        private boolean touched = false;
     }
 
     private static class SectionCache {
@@ -656,9 +657,7 @@ public class ChunkDriver {
                 if (cache[sectionIdx].section[idx] != state) {
                     dirty = true;
                     cache[sectionIdx].section[idx] = state;
-                    if (!isAir) {
-                        cache[sectionIdx].isEmpty = false;
-                    }
+                    cache[sectionIdx].touched = true;
                 }
                 if (record) {
                     owner.recordWrite(x, y1, z, state);
@@ -709,9 +708,7 @@ public class ChunkDriver {
                 if (st != state && test.test(st)) {
                     dirty = true;
                     cache[sectionIdx].section[idx] = state;
-                    if (!isAir) {
-                        cache[sectionIdx].isEmpty = false;
-                    }
+                    cache[sectionIdx].touched = true;
                     if (record) {
                         owner.recordWrite(x, y1, z, state);
                     }
@@ -741,8 +738,8 @@ public class ChunkDriver {
                 return;
             }
             cache[sectionIdx].section[idx] = state;
+            cache[sectionIdx].touched = true;
             if (!state.isAir()) {
-                cache[sectionIdx].isEmpty = false;
                 if (heightmap[px][pz] < pos.getY()) {
                     heightmap[px][pz] = pos.getY();
                 }
@@ -779,7 +776,7 @@ public class ChunkDriver {
         private void generate(BulkSectionAccess bulk) {
             for (int si = 0 ; si < (maxY - minY) / SECTION_HEIGHT ; si++) {
                 S c = cache[si];
-                if (!c.isEmpty) {
+                if (c.touched) {
                     int cy = si * SECTION_HEIGHT + minY;
                     LevelChunkSection section = bulk.getSection(new BlockPos(cx, cy, cz));
                     if (section == null) {

--- a/src/test/java/dev/krona/urbex/worldgen/ChunkDriverSectionCacheTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/ChunkDriverSectionCacheTest.java
@@ -1,0 +1,127 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.IdMapper;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelHeightAccessor;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.chunk.PalettedContainerFactory;
+import net.minecraft.world.level.chunk.ProtoChunk;
+import net.minecraft.world.level.chunk.Strategy;
+import net.minecraft.world.level.chunk.UpgradeData;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChunkDriverSectionCacheTest {
+
+    private static final LevelHeightAccessor HEIGHT = LevelHeightAccessor.create(-64, 384);
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void airOnlySectionWritesAreFlushedOverExistingTerrain() {
+        ProtoChunk chunk = new ProtoChunk(
+                new ChunkPos(0, 0),
+                UpgradeData.EMPTY,
+                HEIGHT,
+                palettedContainerFactory(),
+                null);
+        BlockPos cleared = new BlockPos(0, 64, 0);
+        chunk.setBlockState(cleared, Blocks.STONE.defaultBlockState(), 0);
+
+        ChunkDriver driver = new ChunkDriver();
+        driver.setPrimer(levelFor(chunk), chunk);
+        driver.current(0, cleared.getY(), 0).block(Blocks.AIR.defaultBlockState());
+        driver.flushToChunk(chunk);
+
+        assertTrue(chunk.getBlockState(cleared).isAir(),
+                "an air-only cache section must still replace existing terrain");
+    }
+
+    private static PalettedContainerFactory palettedContainerFactory() {
+        Holder<Biome> biome = dummyBiome();
+        IdMapper<Holder<Biome>> biomeIds = new IdMapper<>();
+        biomeIds.add(biome);
+        return new PalettedContainerFactory(
+                Strategy.createForBlockStates(Block.BLOCK_STATE_REGISTRY),
+                Blocks.AIR.defaultBlockState(),
+                null,
+                Strategy.createForBiomes(biomeIds),
+                biome,
+                null);
+    }
+
+    private static Holder<Biome> dummyBiome() {
+        BiomeSpecialEffects effects = new BiomeSpecialEffects(
+                0,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                BiomeSpecialEffects.GrassColorModifier.NONE);
+        Biome biome = new Biome.BiomeBuilder()
+                .temperature(0.5f)
+                .downfall(0.5f)
+                .specialEffects(effects)
+                .mobSpawnSettings(MobSpawnSettings.EMPTY)
+                .generationSettings(BiomeGenerationSettings.EMPTY)
+                .build();
+        return Holder.direct(biome);
+    }
+
+    private static LevelAccessor levelFor(ProtoChunk chunk) {
+        return (LevelAccessor) Proxy.newProxyInstance(
+                LevelAccessor.class.getClassLoader(),
+                new Class<?>[]{LevelAccessor.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getMinY" -> HEIGHT.getMinY();
+                    case "getMaxY" -> HEIGHT.getMaxY();
+                    case "getHeight" -> HEIGHT.getHeight();
+                    case "getSectionsCount" -> HEIGHT.getSectionsCount();
+                    case "getSectionIndex" -> HEIGHT.getSectionIndex((int) args[0]);
+                    case "getChunk" -> chunk;
+                    case "getBlockState" -> chunk.getBlockState((BlockPos) args[0]);
+                    case "hasChunk" -> true;
+                    case "toString" -> "chunk-level";
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0.0f;
+        }
+        if (type == double.class) {
+            return 0.0d;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

- flush chunk-cache sections after any write, including AIR-only writes
- add a regression test that clears existing terrain through an otherwise AIR-only section
- prevent floating, 16-block-aligned terrain slabs during terrain-shape correction

## Root cause

`ChunkDriver.SectionCache` used an `isEmpty` flag that was cleared only by non-air writes. When terrain correction wrote only AIR into a section, `generate()` treated that section as untouched and skipped it, leaving the vanilla terrain already in the chunk. Whether a section happened to contain another solid Urbex write made the symptom intermittent and section-aligned.

## User impact

Newly generated chunks now apply terrain-clearing writes consistently. Existing affected chunks still require regeneration or manual repair.

## Validation

- added `ChunkDriverSectionCacheTest.airOnlySectionWritesAreFlushedOverExistingTerrain`
- verified the regression test fails on the old implementation and passes with the fix
- `./gradlew test`
- regenerated the reported seed `757574538732518945` with `urbex:default`; the extra floating slab at x=472, z=-104 no longer appears

Closes #141