### PR TITLE
refactor: block-tag state into a swappable TagSnapshot (#128, 128b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **`/reload` refreshes block tags without rebuilding everything a level generates with.** Block tags
+  are the one piece of Urbex's compiled state a reload genuinely changes, and they now live in their
+  own immutable `TagSnapshot` that a reload swaps in a single write (issue #128).
+  - *A reload used to republish every loaded level's runtime.* `CityGenerator` expanded
+    `urbex:lights`, `urbex:needspoi` and the vanilla plant tags into `BlockState` sets in its
+    constructor, so a fresh generator was the only way to see an edited tag — and it took the
+    level's road field, its heightmaps and every chunk plan it had cached with it. None of that is
+    derived from a tag; all of it was rebuilt to exactly what it already was.
+  - *A chunk sees one tag epoch, start to finish.* The snapshot is captured once, when a chunk's
+    generation begins, so a reload landing halfway through a building cannot put one slice of it on
+    the old tag membership and the next slice on the new one.
+  - *Block tags are read in exactly one place now*: while an epoch is being captured, on the thread
+    capturing it. `Tools.hasTag`, which the driver loop called per block, is gone.
+  - *No worldgen change*: both digest goldens are unchanged, verified by running `runDigestCheck`
+    and `runDigestCheckFeatures`.
+
 - **Compiled assets are one immutable snapshot, finished before any chunk generates.** Twelve
   `static` registries, a readiness latch and a `reset()` are gone. Every asset is now compiled once
   per world load into an `AssetSnapshot` the level's runtime holds, and every lookup goes through it

--- a/src/main/java/dev/krona/urbex/setup/ServerEventHandlers.java
+++ b/src/main/java/dev/krona/urbex/setup/ServerEventHandlers.java
@@ -52,18 +52,18 @@ public class ServerEventHandlers {
         // reload, so an edited building or palette JSON needs the world reopened whatever we do
         // here, exactly as a vanilla worldgen file does.
         //
-        // Block tags are a different matter: those do reload, and Urbex reads several of them once
-        // and caches the result. CityGenerator's constructor expands urbex:lights and
-        // urbex:needspoi into BlockState sets and holds them for the lifetime of the runtime, so
-        // without this an edited tag kept generating against the pre-reload membership, silently,
-        // until the world was reopened. Republishing every level's runtime rebuilds those sets and
-        // drops the per-level caches, so the next chunk plans from what the reload produced.
+        // Block tags are a different matter: those do reload, and they are the whole of what this
+        // hook has to refresh. GenerationSession.reload re-captures them into the server's one
+        // TagEpoch, which the next chunk to start reads and a chunk already generating does not.
         //
-        // What it no longer does is reset the asset registries. That is not a capability being
-        // dropped: they cannot change on a reload (see above), and clearing them from the server
-        // thread while workers were generating is precisely how a chunk got written and saved with
-        // an emptied stuff index behind it. A republished runtime replaces what the next chunk
-        // picks up and leaves chunks already in flight on the epoch they captured.
+        // What it no longer does is rebuild anything else. It used to republish every loaded
+        // level's runtime, because CityGenerator's constructor expanded urbex:lights and
+        // urbex:needspoi into BlockState sets, so a fresh generator was the only way to see an
+        // edited tag - and a fresh generator brought a fresh road field, fresh heightmaps and an
+        // empty plan cache with it, none of which a tag can affect (issue #128). Nor does it reset
+        // the asset registries: they cannot change on a reload (see above), and clearing them from
+        // the server thread while workers were generating is precisely how a chunk got written and
+        // saved with an emptied stuff index behind it.
         ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, resourceManager, success) -> {
             if (success) {
                 GenerationSession current = GenerationSession.current();

--- a/src/main/java/dev/krona/urbex/varia/Tools.java
+++ b/src/main/java/dev/krona/urbex/varia/Tools.java
@@ -9,13 +9,11 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.commands.arguments.blocks.BlockStateParser;
 import net.minecraft.core.DefaultedRegistry;
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerChunkCache;
-import net.minecraft.tags.TagKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.datafix.fixes.BlockStateData;
 import net.minecraft.world.level.LevelReader;
@@ -137,16 +135,6 @@ public class Tools {
             }
         }
         return elements.get(elements.size() - 1);
-    }
-
-    public static Iterable<Holder<Block>> getBlocksForTag(TagKey<Block> rl) {
-        @SuppressWarnings("deprecation") DefaultedRegistry<Block> registry = BuiltInRegistries.BLOCK;
-        return registry.getTagOrEmpty(rl);
-    }
-
-    public static boolean hasTag(Block block, TagKey<Block> tag) {
-        //noinspection deprecation
-        return BuiltInRegistries.BLOCK.get(block.builtInRegistryHolder().key()).get().is(tag);
     }
 
     public static int getSeaLevel(LevelReader level) {

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
@@ -36,6 +36,13 @@ public final class ChunkGenContext {
     public final char street;
     public final NoiseBuffers buffers;
     /**
+     * The block tags this generation answers from, captured with the rest of its epoch. Read once
+     * from the level's {@link TagEpoch} by the caller, never per block: a {@code /reload} landing
+     * mid-chunk must not be able to give one slice of a building the old tag membership and the
+     * next slice the new one (issue #128).
+     */
+    public final TagSnapshot tags;
+    /**
      * Deferred writes this generation queues for after the driver has run. Owned here, not on the
      * cached {@link BuildingInfo}: see {@link PostTodoQueue}.
      */
@@ -61,8 +68,9 @@ public final class ChunkGenContext {
 
     public ChunkGenContext(WorldGenRegion region, ChunkAccess chunk, ChunkCoord coord,
                            IDimensionInfo provider, Preset profile, BuildingInfo info,
-                           LevelTaskQueue levelTasks) {
+                           LevelTaskQueue levelTasks, TagSnapshot tags) {
         this.levelTasks = levelTasks;
+        this.tags = tags;
         this.region = region;
         this.chunk = chunk;
         this.coord = coord;

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -22,8 +22,6 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.tags.BiomeTags;
-import net.minecraft.tags.BlockTags;
-import net.minecraft.tags.TagKey;
 import net.minecraft.tags.StructureTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.*;
@@ -63,14 +61,13 @@ public class CityGenerator {
     private final BlockState base;
     public final BlockState liquid;
 
-    // Every one of these used to be built on first use and cached on this object, which is shared
-    // by the whole dimension. That was safe only because generation held a lock on this feature.
-    // They are all derived from block tags and block states - nothing here needs a Level - so they
-    // are built once in the constructor and never written again.
+    // Built on first use and cached on this object, which is shared by the whole dimension. That was
+    // safe only because generation held a lock on this feature. It is a pure function of two vanilla
+    // blocks - no Level, no tag, no datapack - so it is built once in the constructor and never
+    // written again. The three fields that used to sit beside it were block-tag expansions and have
+    // moved to TagSnapshot, so a /reload can refresh them without rebuilding this generator and
+    // everything the level plans with (issue #128); this one has nothing to reload.
     private final Set<BlockState> railStates;
-    private final Set<BlockState> statesNeedingTodo;
-    private final Set<BlockState> statesNeedingLightingUpdate;
-    private final Set<BlockState> statesNeedingPoiUpdate;
 
     private final NoiseGeneratorPerlin rubbleNoise;
     private final NoiseGeneratorPerlin leavesNoise;
@@ -107,24 +104,6 @@ public class CityGenerator {
         railStates = new HashSet<>();
         addStates(Blocks.RAIL, railStates);
         addStates(Blocks.POWERED_RAIL, railStates);
-
-        statesNeedingTodo = new HashSet<>();
-        for (Holder<Block> bh : Tools.getBlocksForTag(TagKey.create(Registries.BLOCK, Identifier.withDefaultNamespace("saplings")))) {
-            addStates(bh.value(), statesNeedingTodo);
-        }
-        for (Holder<Block> bh : Tools.getBlocksForTag(BlockTags.SMALL_FLOWERS)) {
-            addStates(bh.value(), statesNeedingTodo);
-        }
-
-        statesNeedingLightingUpdate = new HashSet<>();
-        for (Holder<Block> bh : Tools.getBlocksForTag(UrbexTags.LIGHTS_TAG)) {
-            addStates(bh.value(), statesNeedingLightingUpdate);
-        }
-
-        statesNeedingPoiUpdate = new HashSet<>();
-        for (Holder<Block> bh : Tools.getBlocksForTag(UrbexTags.NEEDSPOI_TAG)) {
-            addStates(bh.value(), statesNeedingPoiUpdate);
-        }
 
         randomLeafs = buildRandomLeafs();
         randomDirt = buildRandomDirt();
@@ -221,18 +200,6 @@ public class CityGenerator {
         return railStates;
     }
 
-    private Set<BlockState> getStatesNeedingTodo() {
-        return statesNeedingTodo;
-    }
-
-    private Set<BlockState> getStatesNeedingLightingUpdate() {
-        return statesNeedingLightingUpdate;
-    }
-
-    private Set<BlockState> getStatesNeedingPoiUpdate() {
-        return statesNeedingPoiUpdate;
-    }
-
     private static void addStates(Block block, Set<BlockState> set) {
         set.addAll(block.getStateDefinition().getPossibleStates());
     }
@@ -270,7 +237,10 @@ public class CityGenerator {
         // order. See Arilas/urbex#24.
         ChunkHeightmap heightmap = new ChunkHeightmap(getHeightmap(coord, provider.getWorld()));
         BuildingInfo info = BuildingInfo.getBuildingInfo(coord, provider);
-        ChunkGenContext ctx = new ChunkGenContext(region, chunk, coord, provider, profile, info, runtime.tasks());
+        // runtime.tags() is read here and nowhere else in this generation: one call, at the start,
+        // so a /reload landing mid-chunk cannot be observed halfway through a building (issue #128).
+        ChunkGenContext ctx = new ChunkGenContext(region, chunk, coord, provider, profile, info,
+                runtime.tasks(), runtime.tags());
 
         boolean doCity = info.isCity;
 
@@ -504,7 +474,7 @@ public class CityGenerator {
                             if (d != air || cury <= info.waterLevel) {
                                 float damage = collectedDamage[x][z];
                                 if (damage >= 0.001) {
-                                    BlockState newd = damageArea.damageBlock(d, provider, cx + x, cury, cz + z, damage, info.getCompiledPalette(), liquid);
+                                    BlockState newd = damageArea.damageBlock(d, provider, ctx.tags, cx + x, cury, cz + z, damage, info.getCompiledPalette(), liquid);
                                     if (newd != d) {
                                         driver.block(newd);
                                         cntDamaged++;
@@ -709,11 +679,11 @@ public class CityGenerator {
     }
 
     // Return true if state is Empty or Plant based - stops (most) funny tree/mushroom action on chunk borders
-    private static boolean isFoliageOrEmpty(BlockState state) {
+    private static boolean isFoliageOrEmpty(TagSnapshot tags, BlockState state) {
         if (isEmpty(state)) {
             return true;
         }
-        return Tools.hasTag(state.getBlock(), UrbexTags.FOLIAGE_TAG);
+        return tags.isFoliage(state);
     }
 
     /**
@@ -739,7 +709,7 @@ public class CityGenerator {
         driver.current(x, height, z);
         int minHeight = provider.getWorld().getMinY();
         // We assume here we are not in a void chunk
-        while (isFoliageOrEmpty(driver.getBlock()) && driver.getY() > minHeight) {
+        while (isFoliageOrEmpty(ctx.tags, driver.getBlock()) && driver.getY() > minHeight) {
             driver.decY();
         }
 
@@ -1835,7 +1805,7 @@ public class CityGenerator {
                         Palette.Info inf = compiledPalette.getInfo(c);
 
                         if (transform != Transform.ROTATE_NONE) {
-                            b = transformBlockState(info, transform, b);
+                            b = transformBlockState(ctx.tags, info, transform, b);
                         }
 
                         // We don't replace the world where the part is empty (air)
@@ -1872,7 +1842,7 @@ public class CityGenerator {
                                 } else if (inf.tag() != null) {
                                     b = handleBlockEntity(ctx, info, oy, ctx.region, rx, rz, y, b, inf);
                                 }
-                            } else if (getStatesNeedingPoiUpdate().contains(b)) {
+                            } else if (ctx.tags.needsPoiUpdate(b)) {
                                 // If this block has POI data we need to delay setting it
                                 BlockState finalB = b;
                                 BlockPos p = driver.getCurrentCopy();
@@ -1882,9 +1852,9 @@ public class CityGenerator {
                                     }
                                 });
                                 b = Blocks.DIRT.defaultBlockState();
-                            } else if (getStatesNeedingLightingUpdate().contains(b)) {
+                            } else if (ctx.tags.needsLightingUpdate(b)) {
                                 updateNeeded(ctx, driver.getCurrentCopy(), Block.UPDATE_CLIENTS);
-                            } else if (getStatesNeedingTodo().contains(b)) {
+                            } else if (ctx.tags.needsTodo(b)) {
                                 b = handleTodo(ctx, info, oy, ctx.region, rx, rz, y, b);
                             }
                             driver.add(b);
@@ -2082,9 +2052,13 @@ public class CityGenerator {
      * {@link BuildingInfo#worldStyle()} memoises it per chunk, so this stays a field read in the hot
      * path rather than a neighbourhood walk. A world style that declares no {@code rotatable}
      * resolves {@code urbex:rotatable}, as before.
+     * <p>
+     * Membership is answered by the chunk's own {@link TagSnapshot} rather than by a live registry
+     * read, so every block of every part in this chunk sees one tag epoch even if a {@code /reload}
+     * lands halfway through it (issue #128).
      */
-    private BlockState transformBlockState(BuildingInfo info, Transform transform, BlockState b) {
-        if (Tools.hasTag(b.getBlock(), info.worldStyle().getRotatableTag())) {
+    private BlockState transformBlockState(TagSnapshot tags, BuildingInfo info, Transform transform, BlockState b) {
+        if (tags.isRotatable(info.worldStyle().getRotatableTag(), b)) {
             // Vanilla structure order: mirror first, then rotate. The mirror used to be
             // approximated with a 180/90 rotation, which turned mirrored stairs/doors/logs
             // the wrong way (issue #45).

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
@@ -37,19 +37,26 @@ import javax.annotation.Nullable;
  * become while still delegating to the one object that owns them today - two record components
  * holding the same objects would be two owners of one thing, which is the mistake this whole epic
  * is about. {@code tasks} is a real component, because nothing else owns it.</p>
+ *
+ * <p>{@code tagEpoch} is the server's, not this level's: it is the same instance in every loaded
+ * level's runtime, because block tags come from the server's reloadable resources. It is a slot
+ * rather than a {@link TagSnapshot} so that a {@code /reload} can swap the epoch without rebuilding
+ * anything here - which is the whole of what a reload changes (issue #128).</p>
  */
-public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo planning, LevelTaskQueue tasks) {
+public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo planning, LevelTaskQueue tasks,
+                               @Nullable TagEpoch tagEpoch) {
 
-    public DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo planning) {
-        this(level, planning, new LevelTaskQueue(level.dimension().identifier().toString()));
+    public DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo planning, @Nullable TagEpoch tagEpoch) {
+        this(level, planning, new LevelTaskQueue(level.dimension().identifier().toString()), tagEpoch);
     }
 
     /**
      * A runtime for a level Urbex does not generate in. It still carries a task queue: the tick
-     * handler drains whatever runtime the level has, and an empty queue costs nothing.
+     * handler drains whatever runtime the level has, and an empty queue costs nothing. It carries no
+     * tag epoch, for the same reason it carries no planning context - nothing generates here.
      */
     public static DimensionRuntime disabled(ServerLevel level) {
-        return new DimensionRuntime(level, null);
+        return new DimensionRuntime(level, null, null);
     }
 
     public boolean isEnabled() {
@@ -67,6 +74,17 @@ public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo plann
     }
 
     /**
+     * The block tags a chunk starting now generates against. Never call on a disabled runtime.
+     * <p>
+     * Call it <em>once</em>, at the start of a generation, and pass the result down: this is the
+     * live slot, so a second call later in the same chunk may answer from a different epoch. That is
+     * what {@link ChunkGenContext} holds it for.
+     */
+    public TagSnapshot tags() {
+        return tagEpoch.current();
+    }
+
+    /**
      * Builds the runtime for {@code level}.
      *
      * <p>Everything here used to happen lazily on the generation path, the first time a chunk of the
@@ -77,9 +95,10 @@ public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo plann
      *
      * <p>The snapshot arrives already compiled; {@link GenerationSession#load} is the one caller and
      * builds it before calling this. A runtime cannot exist without one, which is what makes "no
-     * chunk generates against unloaded assets" structural rather than a check.</p>
+     * chunk generates against unloaded assets" structural rather than a check. The tag epoch arrives
+     * the same way and for the same reason.</p>
      */
-    static DimensionRuntime create(ServerLevel level, AssetSnapshot assets) {
+    static DimensionRuntime create(ServerLevel level, AssetSnapshot assets, TagEpoch tagEpoch) {
         ResourceKey<Level> type = level.dimension();
         PresetChoice choice = Config.getPresetChoiceForDimension(level, type);
         if (choice == null) {
@@ -112,7 +131,7 @@ public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo plann
         // fallback - City.getCityStyle would simply hand null on to generation.
         requireCityStyle(assets, preset.CITY_STYLE_ALTERNATIVE, type.identifier());
         return new DimensionRuntime(level,
-                new DefaultDimensionInfo(level, assets, preset, choice.worldStyles()));
+                new DefaultDimensionInfo(level, assets, preset, choice.worldStyles()), tagEpoch);
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
+++ b/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
@@ -68,13 +68,26 @@ public final class GenerationSession {
     private final Object owner;
     private final RuntimeRepository<ServerLevel, DimensionRuntime> dimensions = new RuntimeRepository<>();
     /**
-     * Compiled once, by the first level to load, and shared by every level in this world. The asset
-     * registries are frozen when the world loads (issue #61), so there is nothing per-level about
-     * what they compile to - and nothing a reload can change, which is why {@link #reload} leaves
-     * this alone.
+     * Everything this world compiled, or null until the first level load compiles it. One field
+     * rather than two, because the two halves are captured together and neither is usable without
+     * the other: the tag epoch is expanded <em>from</em> the assets, so a reader that could see one
+     * of them written and not the other would have an epoch that knows about no world style's
+     * {@code rotatable} tag.
      */
     @Nullable
-    private volatile AssetSnapshot assets;
+    private volatile Compiled compiled;
+
+    /**
+     * What one world load produces.
+     *
+     * @param assets compiled once, by the first level to load, and shared by every level in this
+     *               world. The asset registries are frozen when the world loads (issue #61), so
+     *               there is nothing per-level about what they compile to - and nothing a reload can
+     *               change, which is why {@link #reload} leaves this alone.
+     * @param tags   the block tags every level of this world generates against, in the one slot a
+     *               {@code /reload} swaps.
+     */
+    private record Compiled(AssetSnapshot assets, TagEpoch tags) {}
 
     private GenerationSession(@Nullable Object owner) {
         this.owner = owner;
@@ -168,7 +181,8 @@ public final class GenerationSession {
      * reads the level; nothing before it does.</p>
      */
     public DimensionRuntime load(ServerLevel level) {
-        DimensionRuntime runtime = DimensionRuntime.create(level, compileAssetsOnce(level));
+        Compiled world = compileOnce(level);
+        DimensionRuntime runtime = DimensionRuntime.create(level, world.assets(), world.tags());
         // Logged per level, at debug, because the ordering this line sits in is the invariant: in a
         // real server log every one of these lands before "Preparing spawn area", which is what a
         // unit test cannot show. (Verified on the digest run's dedicated server: overworld, nether
@@ -180,31 +194,44 @@ public final class GenerationSession {
     }
 
     /**
-     * Compiles this world's assets, once, before the first level that needs them can generate.
+     * Compiles this world, once, before the first level that needs it can generate.
      *
      * <p>The whole of the asset-load invariant, in one place: a runtime cannot be built without a
      * snapshot, a snapshot is only built here, and a pack that does not compile refuses the world
      * naming every problem at once rather than failing from a worldgen worker on the first chunk that
      * touches the broken file.</p>
+     *
+     * <p>The first tag epoch is opened here too, rather than at session open, because
+     * {@link TagSnapshot#capture} needs the compiled world styles to know which {@code rotatable}
+     * tags to expand.</p>
      */
-    private synchronized AssetSnapshot compileAssetsOnce(ServerLevel level) {
-        AssetSnapshot known = assets;
+    private synchronized Compiled compileOnce(ServerLevel level) {
+        Compiled known = compiled;
         if (known != null) {
             return known;
         }
         AssetDiagnostics diagnostics = new AssetDiagnostics();
-        AssetSnapshot compiled = AssetCompiler.compile(level.registryAccess(), diagnostics);
+        AssetSnapshot assets = AssetCompiler.compile(level.registryAccess(), diagnostics);
         // Before publication, not after: a snapshot nobody validated is exactly the partially
         // compiled view this whole issue removes.
         diagnostics.throwIfAny();
-        assets = compiled;
-        return compiled;
+        Compiled world = new Compiled(assets, new TagEpoch(TagSnapshot.capture(assets)));
+        compiled = world;
+        return world;
     }
 
     /** This world's compiled assets, or null before the first level has loaded. */
     @Nullable
     public AssetSnapshot assets() {
-        return assets;
+        Compiled world = compiled;
+        return world == null ? null : world.assets();
+    }
+
+    /** This world's block-tag epoch, or null before the first level has loaded. */
+    @Nullable
+    public TagEpoch tagEpoch() {
+        Compiled world = compiled;
+        return world == null ? null : world.tags();
     }
 
     /** Retires a level's runtime. Chunks already generating keep the runtime they captured. */
@@ -232,21 +259,28 @@ public final class GenerationSession {
     }
 
     /**
-     * Rebuilds every loaded level's runtime, for a {@code /reload}.
+     * Re-captures the block tags, for a {@code /reload}.
      *
-     * <p>Rebuilding is what {@code /reload} can honestly do. The thirteen asset registries are
-     * Fabric dynamic registries, loaded once with the world and frozen (issue #61), so an edited
-     * building or palette JSON needs the world reopened whatever happens here - the old counter bump
-     * cleared and re-resolved them anyway, which changed nothing an author could see and is exactly
-     * how a running worker ended up reading an emptied stuff index. Block tags <em>do</em> reload,
-     * and {@code CityGenerator} expands several of them into {@code BlockState} sets in its
-     * constructor, so a fresh runtime per level is what makes an edited tag take effect.</p>
+     * <p>That is the whole of what {@code /reload} can honestly do. The thirteen asset registries
+     * are Fabric dynamic registries, loaded once with the world and frozen (issue #61), so an edited
+     * building or palette JSON needs the world reopened whatever happens here. Block tags
+     * <em>do</em> reload, and until this issue they were expanded into {@code BlockState} sets in
+     * {@code CityGenerator}'s constructor - so the only way to refresh them was to rebuild every
+     * loaded level's runtime, discarding its road field, its heightmaps and every chunk plan it had
+     * cached. None of that is derived from a tag; all of it is derived from the seed and the frozen
+     * assets, so all of it was rebuilt to exactly what it already was (issue #128).</p>
      *
-     * <p>Each replacement is published whole; a chunk already generating finishes against the
-     * runtime it captured.</p>
+     * <p>The epoch is swapped, never mutated: a chunk already generating finishes against the
+     * {@link TagSnapshot} it captured, and the swap decides what the next one picks up. Called with
+     * no level loaded - or before the first one has - there is nothing captured yet and nothing to
+     * do; the load that follows captures the reloaded tags itself.</p>
      */
     public void reload() {
-        dimensions.republish(level -> DimensionRuntime.create(level, compileAssetsOnce(level)));
+        Compiled world = compiled;
+        if (world == null) {
+            return;
+        }
+        world.tags().publish(TagSnapshot.capture(world.assets()));
     }
 
     /** Who this session belongs to, for a caller that has to close it without holding that server. */

--- a/src/main/java/dev/krona/urbex/worldgen/RuntimeRepository.java
+++ b/src/main/java/dev/krona/urbex/worldgen/RuntimeRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 
 /**
  * The publish/retire rules a set of scoped runtimes obeys, with the scope's own types kept out.
@@ -18,10 +17,11 @@ import java.util.function.Function;
  * level-typed edge that uses them.</p>
  *
  * <p>The rule that matters most is what a <em>reader</em> sees. {@link #find} hands back a value,
- * and whoever holds it keeps it: a {@link #republish} or a {@link #retire} that lands afterwards
+ * and whoever holds it keeps it: a {@link #publish} or a {@link #retire} that lands afterwards
  * replaces what the <em>next</em> reader gets and never mutates or empties the value already handed
  * out. That is what lets a chunk that is already generating finish against the epoch it started
- * with, instead of having its assets cleared underneath it (issue #125).</p>
+ * with, instead of having its assets cleared underneath it (issue #125). {@link TagEpoch} keeps the
+ * same rule for the one thing a {@code /reload} can still change.</p>
  */
 final class RuntimeRepository<K, V> {
 
@@ -52,27 +52,6 @@ final class RuntimeRepository<K, V> {
     @Nullable
     V retire(K key) {
         return published.remove(key);
-    }
-
-    /**
-     * Rebuilds every published runtime and swaps each in, one key at a time.
-     *
-     * <p>One key at a time is deliberate, and it is not a weaker guarantee than a whole-map swap:
-     * every reader looks one key up, so the only atomicity a reader can observe is per key, and
-     * {@code ConcurrentHashMap.put} gives that. Building outside the map matters more - a reader
-     * must never see a half-built runtime, so each one is finished before it is published.</p>
-     */
-    void republish(Function<K, V> rebuild) {
-        if (closed) {
-            throw new IllegalStateException("Cannot republish into a closed runtime repository");
-        }
-        for (K key : List.copyOf(published.keySet())) {
-            V rebuilt = rebuild.apply(key);
-            // Not putIfAbsent/replace: the key may have been retired while this ran (a level
-            // unloading during a reload), and a rebuilt runtime for a retired level must not
-            // resurrect it.
-            published.computeIfPresent(key, (k, old) -> rebuilt);
-        }
     }
 
     /** Retires everything and refuses further publication. Idempotent. */

--- a/src/main/java/dev/krona/urbex/worldgen/TagEpoch.java
+++ b/src/main/java/dev/krona/urbex/worldgen/TagEpoch.java
@@ -1,0 +1,42 @@
+package dev.krona.urbex.worldgen;
+
+/**
+ * The one block-tag snapshot a running server generates against, and the only thing a
+ * {@code /reload} replaces.
+ *
+ * <p>One slot, one writer. The writer is {@code GenerationSession} on the server thread, at world
+ * load and after each successful data-pack reload; every reader is a chunk generation taking
+ * {@link #current()} once, at its start, into its {@link ChunkGenContext}. A generation that spans a
+ * swap therefore sees one coherent epoch - the one it captured - because the swap replaces what the
+ * <em>next</em> chunk picks up and cannot reach into a {@link TagSnapshot} already handed out.</p>
+ *
+ * <p>That is the same rule {@code RuntimeRepository} used to keep for whole {@link DimensionRuntime}s
+ * on a reload, narrowed to the only state a reload can actually change. Rebuilding a level's runtime
+ * to refresh a tag also threw away its road field, its heightmaps and every chunk plan it had cached,
+ * none of which a tag can affect (issue #128).</p>
+ *
+ * <p>Shared by every level of a server rather than held per level: block tags come from the server's
+ * reloadable resources, so all of its levels are always on the same epoch, and a per-level copy would
+ * be a chance for them not to be.</p>
+ */
+public final class TagEpoch {
+
+    private volatile TagSnapshot current;
+
+    TagEpoch(TagSnapshot initial) {
+        this.current = initial;
+    }
+
+    /**
+     * The epoch to generate against. Read <em>once</em> per chunk, not per block: two reads in one
+     * generation are two chances to straddle a reload.
+     */
+    public TagSnapshot current() {
+        return current;
+    }
+
+    /** Swaps in a freshly captured epoch. Whatever already holds the old one keeps it. */
+    void publish(TagSnapshot snapshot) {
+        current = snapshot;
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/TagSnapshot.java
+++ b/src/main/java/dev/krona/urbex/worldgen/TagSnapshot.java
@@ -1,0 +1,192 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
+import net.minecraft.core.DefaultedRegistry;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Every block-tag answer one generation epoch gives, expanded once when that epoch opens.
+ *
+ * <p>Block tags are the one piece of Urbex's compiled state that a {@code /reload} genuinely
+ * changes. The thirteen asset registries are Fabric dynamic registries, loaded with the world and
+ * frozen (issue #61), so an edited building or palette needs the world reopened whatever a reload
+ * does - but {@code urbex:lights}, {@code urbex:needspoi}, {@code urbex:rotatable} and the rest come
+ * back with every one. That single difference used to cost a whole {@link DimensionRuntime} per
+ * loaded level: {@code CityGenerator} expanded those tags into {@code BlockState} sets in its
+ * constructor, so refreshing them meant rebuilding the generator, the road field, the world-style
+ * field and every seed-derived cache beside them - none of which a tag can affect (issue #128).</p>
+ *
+ * <p>Separating them buys two things. A tag reload becomes one reference write into
+ * {@link TagEpoch}, so the caches a world spent its chunks building survive it. And an <em>asset</em>
+ * reload becomes impossible to write by accident: no tag-derived state is left on the objects that
+ * hold the {@link AssetSnapshot}, so nothing tempts a future reload into republishing them.</p>
+ *
+ * <p>Captured per chunk rather than read per block, exactly like the asset snapshot beside it:
+ * {@link ChunkGenContext} takes {@link TagEpoch#current()} once at the start of a generation and
+ * every question that chunk asks is answered by that one instance. A reload landing mid-chunk
+ * therefore cannot show one slice of a building the old membership and the next slice the new one.
+ * That is also why the old {@code Tools.hasTag} is gone: a live registry read from the driver loop
+ * is precisely the incoherence this type removes.</p>
+ *
+ * <p><strong>Block tags only.</strong> The one biome tag Urbex reads ({@code c:is_void}, in
+ * {@code CityFeature}) is asked of a {@code Holder<Biome>} that comes from the level's own frozen
+ * biome registry, so a reload cannot change it and there is nothing to capture.</p>
+ */
+public final class TagSnapshot {
+
+    private static final TagKey<Block> SAPLINGS =
+            TagKey.create(Registries.BLOCK, Identifier.withDefaultNamespace("saplings"));
+
+    private final Set<BlockState> statesNeedingTodo;
+    private final Set<BlockState> statesNeedingLightingUpdate;
+    private final Set<BlockState> statesNeedingPoiUpdate;
+    private final Set<Block> foliage;
+    private final Set<Block> notBreakable;
+    private final Set<Block> easyBreakable;
+    /**
+     * One entry per {@code rotatable} tag the loaded pack can name. Keyed rather than a single set
+     * because the tag is authored per world style: two cities in one world can come from packs whose
+     * {@code rotatable} tags differ, so the answer follows the chunk's style (issue #117).
+     */
+    private final Map<TagKey<Block>, Set<Block>> rotatable;
+
+    private TagSnapshot(Set<BlockState> statesNeedingTodo,
+                        Set<BlockState> statesNeedingLightingUpdate,
+                        Set<BlockState> statesNeedingPoiUpdate,
+                        Set<Block> foliage,
+                        Set<Block> notBreakable,
+                        Set<Block> easyBreakable,
+                        Map<TagKey<Block>, Set<Block>> rotatable) {
+        this.statesNeedingTodo = Set.copyOf(statesNeedingTodo);
+        this.statesNeedingLightingUpdate = Set.copyOf(statesNeedingLightingUpdate);
+        this.statesNeedingPoiUpdate = Set.copyOf(statesNeedingPoiUpdate);
+        this.foliage = Set.copyOf(foliage);
+        this.notBreakable = Set.copyOf(notBreakable);
+        this.easyBreakable = Set.copyOf(easyBreakable);
+        this.rotatable = Map.copyOf(rotatable);
+    }
+
+    /**
+     * Expands every block tag this world's generation can ask about, from the block registry's
+     * current tag bindings.
+     *
+     * <p>It takes the compiled assets because {@code rotatable} is authored, not fixed: which tags
+     * matter is a property of the loaded pack. Every world style in the snapshot contributes its
+     * tag, and {@code urbex:rotatable} is always expanded because that is what a style declaring
+     * none resolves to. So every tag {@link #isRotatable} can be handed is one this expanded, which
+     * is what makes a miss there a wiring bug rather than a datapack's problem.</p>
+     */
+    public static TagSnapshot capture(AssetSnapshot assets) {
+        Set<BlockState> needingTodo = new HashSet<>();
+        addStates(SAPLINGS, needingTodo);
+        addStates(BlockTags.SMALL_FLOWERS, needingTodo);
+
+        Map<TagKey<Block>, Set<Block>> rotatable = new HashMap<>();
+        rotatable.put(UrbexTags.ROTATABLE_TAG, blocksIn(UrbexTags.ROTATABLE_TAG));
+        for (WorldStyle style : assets.worldStyles().all()) {
+            rotatable.computeIfAbsent(style.getRotatableTag(), TagSnapshot::blocksIn);
+        }
+
+        return new TagSnapshot(
+                needingTodo,
+                statesIn(UrbexTags.LIGHTS_TAG),
+                statesIn(UrbexTags.NEEDSPOI_TAG),
+                blocksIn(UrbexTags.FOLIAGE_TAG),
+                blocksIn(UrbexTags.NOT_BREAKABLE_TAG),
+                blocksIn(UrbexTags.EASY_BREAKABLE_TAG),
+                rotatable);
+    }
+
+    /** Whether {@code state} carries POI data, so its write has to be deferred past generation. */
+    public boolean needsPoiUpdate(BlockState state) {
+        return statesNeedingPoiUpdate.contains(state);
+    }
+
+    /** Whether placing {@code state} has to tell the client to relight around it. */
+    public boolean needsLightingUpdate(BlockState state) {
+        return statesNeedingLightingUpdate.contains(state);
+    }
+
+    /** Whether {@code state} is one of the plants that only survives being placed after the fact. */
+    public boolean needsTodo(BlockState state) {
+        return statesNeedingTodo.contains(state);
+    }
+
+    /** {@code urbex:foliage}: what a column scan may look straight through. */
+    public boolean isFoliage(BlockState state) {
+        return foliage.contains(state.getBlock());
+    }
+
+    /** {@code urbex:notbreakable}: what an explosion leaves alone. */
+    public boolean isNotBreakable(BlockState state) {
+        return notBreakable.contains(state.getBlock());
+    }
+
+    /** {@code urbex:easybreakable}: what an explosion damages as if it were hit twice as hard. */
+    public boolean isEasyBreakable(BlockState state) {
+        return easyBreakable.contains(state.getBlock());
+    }
+
+    /**
+     * Whether {@code state} rotates with the part it sits in, under the governing world style's
+     * {@code rotatable} tag.
+     *
+     * @throws IllegalStateException for a tag this snapshot did not expand. Reachable only from a
+     *                               {@link WorldStyle} that is not in the {@link AssetSnapshot} this
+     *                               was captured against - and since a world compiles its assets
+     *                               once and never swaps them, that is a wiring error in Urbex,
+     *                               not something a datapack can provoke. Loud rather than
+     *                               {@code false}: silently not rotating is issue #117 again, and
+     *                               that one took a ladder attached to nothing to notice.
+     */
+    public boolean isRotatable(TagKey<Block> tag, BlockState state) {
+        Set<Block> blocks = rotatable.get(tag);
+        if (blocks == null) {
+            throw new IllegalStateException("Block tag '" + tag.location() + "' was never expanded by this "
+                    + "tag snapshot; it belongs to a world style outside the compiled assets.");
+        }
+        return blocks.contains(state.getBlock());
+    }
+
+    private static Set<BlockState> statesIn(TagKey<Block> tag) {
+        Set<BlockState> states = new HashSet<>();
+        addStates(tag, states);
+        return states;
+    }
+
+    private static void addStates(TagKey<Block> tag, Set<BlockState> into) {
+        for (Holder<Block> block : blocksTagged(tag)) {
+            into.addAll(block.value().getStateDefinition().getPossibleStates());
+        }
+    }
+
+    private static Set<Block> blocksIn(TagKey<Block> tag) {
+        Set<Block> blocks = new HashSet<>();
+        for (Holder<Block> block : blocksTagged(tag)) {
+            blocks.add(block.value());
+        }
+        return blocks;
+    }
+
+    /**
+     * The one read of the block registry's tag bindings left in Urbex, so "when are block tags
+     * read" has a single answer: while an epoch is being captured, on the thread that captures it.
+     */
+    private static Iterable<Holder<Block>> blocksTagged(TagKey<Block> tag) {
+        @SuppressWarnings("deprecation") DefaultedRegistry<Block> registry = BuiltInRegistries.BLOCK;
+        return registry.getTagOrEmpty(tag);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
@@ -6,7 +6,7 @@ import dev.krona.urbex.varia.GeometryTools;
 import dev.krona.urbex.varia.Rng;
 import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.IDimensionInfo;
-import dev.krona.urbex.worldgen.UrbexTags;
+import dev.krona.urbex.worldgen.TagSnapshot;
 import dev.krona.urbex.worldgen.lost.cityassets.CompiledPalette;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
@@ -93,13 +93,17 @@ public class DamageArea {
      * Damage one block. The two rolls are addressed by the block's own position rather than drawn
      * from a stream: whether a block is damaged is decided per block, and the number of blocks
      * damaged before it depends on what was already in the world.
+     * <p>
+     * {@code tags} is passed in rather than held on this object: a {@code DamageArea} is cached on
+     * the chunk's {@link BuildingInfo} and outlives any one generation, so a tag epoch stored here
+     * would be the wrong one for every chunk after the next {@code /reload} (issue #128).
      */
-    public BlockState damageBlock(BlockState b, IDimensionInfo provider, int x, int y, int z, float damage, CompiledPalette palette, BlockState liquidChar) {
-        if (Tools.hasTag(b.getBlock(), UrbexTags.NOT_BREAKABLE_TAG)) {
+    public BlockState damageBlock(BlockState b, IDimensionInfo provider, TagSnapshot tags, int x, int y, int z, float damage, CompiledPalette palette, BlockState liquidChar) {
+        if (tags.isNotBreakable(b)) {
             return b;
         }
 
-        if (Tools.hasTag(b.getBlock(), UrbexTags.EASY_BREAKABLE_TAG)) {
+        if (tags.isEasyBreakable(b)) {
             damage *= 2.5f;    // As if this block gets double the damage
         }
         if (Rng.floatAtPos(seed, x, y, z, Rng.Purpose.DAMAGE) <= damage) {

--- a/src/test/java/dev/krona/urbex/worldgen/GenerationSessionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/GenerationSessionTest.java
@@ -105,4 +105,21 @@ class GenerationSessionTest {
 
         assertNull(GenerationSession.current());
     }
+
+    /**
+     * A {@code /reload} on a server whose levels have not loaded yet. Nothing has been compiled, so
+     * there is no epoch to re-capture and no assets to capture one against - and the level load that
+     * follows reads the reloaded tags itself. Worth pinning because the reload hook is registered
+     * at mod init and the session is opened at {@code SERVER_STARTING}, so the ordering is Fabric's
+     * to decide, not ours.
+     */
+    @Test
+    void reloadingBeforeAnyLevelHasLoadedIsHarmless() {
+        GenerationSession session = GenerationSession.openFor(new Object());
+
+        session.reload();
+
+        assertNull(session.assets());
+        assertNull(session.tagEpoch(), "the first level load opens the epoch, not the reload");
+    }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/RuntimeRepositoryTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/RuntimeRepositoryTest.java
@@ -18,7 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The lifetime rules {@link GenerationSession} keeps its level runtimes by (issue #125): load,
- * unload, replacement on reload, and the fact that a server's runtimes die with that server.
+ * unload, and the fact that a server's runtimes die with that server.
+ * <p>
+ * A {@code /reload} no longer appears here. It used to rebuild every published runtime through a
+ * {@code republish}; it now swaps one {@link TagEpoch} instead, because block tags were the only
+ * thing in a runtime a reload could change (issue #128). The epoch-retention property those tests
+ * held - a reader keeps what it was handed, a swap decides what the next reader gets - moved with
+ * it, to {@link TagEpochTest}.
  * <p>
  * Driven through plain strings rather than {@code ServerLevel}s. That is why the repository is a
  * separate, generic class: a {@code ServerLevel} cannot be constructed, subclassed usefully or
@@ -51,35 +57,20 @@ class RuntimeRepositoryTest {
 
     /**
      * The property the whole ownership move exists for. A chunk that is already generating holds
-     * the runtime it started with; a reload swaps what the <em>next</em> chunk picks up and cannot
-     * reach into the epoch already in flight. The dirty counter did the opposite - it cleared shared
-     * state in place, from whichever thread happened to notice.
+     * the runtime it started with; publishing a replacement decides what the <em>next</em> chunk
+     * picks up and cannot reach into the epoch already in flight. The dirty counter did the opposite
+     * - it cleared shared state in place, from whichever thread happened to notice.
      */
     @Test
-    void aReloadReplacesWhatTheNextLookupFindsAndLeavesTheOneInFlightAlone() {
+    void publishingAReplacementLeavesTheOneAlreadyInFlightAlone() {
         RuntimeRepository<String, String> repository = new RuntimeRepository<>();
         repository.publish("overworld", "runtime-1");
         String inFlight = repository.find("overworld");
 
-        repository.republish(key -> "runtime-2");
+        repository.publish("overworld", "runtime-2");
 
         assertEquals("runtime-1", inFlight, "work already holding an epoch keeps it");
         assertEquals("runtime-2", repository.find("overworld"));
-    }
-
-    /** A level unloading during a reload must not be brought back by the rebuild that overtook it. */
-    @Test
-    void aReloadDoesNotResurrectALevelRetiredWhileItRan() {
-        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
-        repository.publish("overworld", "runtime-1");
-
-        repository.republish(key -> {
-            repository.retire(key);
-            return "runtime-2";
-        });
-
-        assertNull(repository.find("overworld"));
-        assertEquals(0, repository.size());
     }
 
     /**
@@ -98,7 +89,6 @@ class RuntimeRepositoryTest {
         assertNull(first.find("overworld"));
         assertThrows(IllegalStateException.class, () -> first.publish("overworld", "runtime-2"),
                 "a runtime published into a stopped server would never be retired again");
-        assertThrows(IllegalStateException.class, () -> first.republish(key -> "runtime-2"));
 
         RuntimeRepository<String, String> second = new RuntimeRepository<>();
         assertNull(second.find("overworld"), "the next server starts with nothing published");
@@ -131,12 +121,12 @@ class RuntimeRepositoryTest {
     }
 
     /**
-     * A reload landing while chunks are generating. Every lookup must answer with some complete
-     * runtime - never null, never a half-built one - which is the difference between republishing
-     * and the clear-then-refill the counter protocol performed.
+     * Replacements landing while chunks are generating. Every lookup must answer with some complete
+     * runtime - never null, never a half-built one - which is the difference between publishing a
+     * finished replacement and the clear-then-refill the counter protocol performed.
      */
     @Test
-    void aReloadOverlappingGenerationNeverExposesClearedState() throws Exception {
+    void aReplacementOverlappingGenerationNeverExposesClearedState() throws Exception {
         RuntimeRepository<String, String> repository = new RuntimeRepository<>();
         repository.publish("overworld", "runtime-0");
         AtomicInteger epoch = new AtomicInteger();
@@ -151,32 +141,20 @@ class RuntimeRepositoryTest {
                 }
                 return seen;
             });
-            Future<?> reloads = executor.submit(() -> {
+            Future<?> writers = executor.submit(() -> {
                 readerStarted.await();
                 for (int i = 0; i < 500; i++) {
-                    repository.republish(key -> "runtime-" + epoch.incrementAndGet());
+                    repository.publish("overworld", "runtime-" + epoch.incrementAndGet());
                 }
                 return null;
             });
 
-            reloads.get();
+            writers.get();
             for (String seen : readers.get()) {
-                assertNotNull(seen, "a lookup during a reload must never find the level unpublished");
+                assertNotNull(seen, "a lookup during a replacement must never find the level unpublished");
                 assertTrue(seen.startsWith("runtime-"), "and never a value that is not a runtime");
             }
         }
-    }
-
-    @Test
-    void republishSeesTheKeysThatWerePublished() {
-        RuntimeRepository<String, String> repository = new RuntimeRepository<>();
-        repository.publish("overworld", "runtime-1");
-        repository.publish("nether", "runtime-1");
-
-        repository.republish(key -> key + "-rebuilt");
-
-        assertEquals("overworld-rebuilt", repository.find("overworld"));
-        assertEquals("nether-rebuilt", repository.find("nether"));
     }
 
     @Test

--- a/src/test/java/dev/krona/urbex/worldgen/TagEpochTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/TagEpochTest.java
@@ -1,0 +1,99 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * What a {@code /reload} may and may not do to a chunk that is already generating (issue #128).
+ * <p>
+ * These are the rules {@link RuntimeRepositoryTest} used to hold for whole {@link DimensionRuntime}s,
+ * narrowed to the one thing a reload can actually change. A generation captures a
+ * {@link TagSnapshot} once, at its start; a reload publishes a new one; the generation in flight
+ * must finish against the one it captured, and the next one must see the new one. Anything weaker
+ * puts one slice of a building on the old tag membership and the next slice on the new one.
+ */
+class TagEpochTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        // TagSnapshot.capture reads the block registry's tag bindings. Nothing binds a block tag
+        // without a running server, so every snapshot here is empty - which is fine, because these
+        // tests are about which instance a reader gets, not what is in it.
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static TagSnapshot snapshot() {
+        return TagSnapshot.capture(AssetSnapshot.empty());
+    }
+
+    @Test
+    void aReaderKeepsTheSnapshotItWasHanded() {
+        TagSnapshot first = snapshot();
+        TagEpoch epoch = new TagEpoch(first);
+        TagSnapshot inFlight = epoch.current();
+
+        epoch.publish(snapshot());
+
+        assertSame(first, inFlight, "a chunk already generating finishes on the epoch it captured");
+        assertNotSame(inFlight, epoch.current(), "and the next chunk starts on the new one");
+    }
+
+    @Test
+    void aSwapDecidesWhatTheNextReaderGets() {
+        TagEpoch epoch = new TagEpoch(snapshot());
+        TagSnapshot reloaded = snapshot();
+
+        epoch.publish(reloaded);
+
+        assertSame(reloaded, epoch.current());
+    }
+
+    /**
+     * A reload landing while chunks are generating. Every read must answer with a complete snapshot
+     * - never null, never one being filled in - which is the difference between swapping a finished
+     * epoch and the clear-then-refill the old dirty-counter protocol performed.
+     */
+    @Test
+    void aSwapOverlappingGenerationNeverExposesAnEmptySlot() throws Exception {
+        TagEpoch epoch = new TagEpoch(snapshot());
+        CountDownLatch readerStarted = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<List<TagSnapshot>> readers = executor.submit(() -> {
+                readerStarted.countDown();
+                List<TagSnapshot> seen = new ArrayList<>();
+                for (int i = 0; i < 10_000; i++) {
+                    seen.add(epoch.current());
+                }
+                return seen;
+            });
+            Future<?> reloads = executor.submit(() -> {
+                readerStarted.await();
+                for (int i = 0; i < 200; i++) {
+                    epoch.publish(snapshot());
+                }
+                return null;
+            });
+
+            reloads.get();
+            for (TagSnapshot seen : readers.get()) {
+                assertNotNull(seen, "a read during a reload must never find the epoch empty");
+            }
+        }
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/TagSnapshotTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/TagSnapshotTest.java
@@ -1,0 +1,117 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.worldgen.lost.cityassets.AssetIndex;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which block tags an epoch expands, which is the one thing about {@link TagSnapshot} a unit test
+ * can see.
+ * <p>
+ * <strong>Not membership.</strong> Block tags are bound by the server's tag manager, so nothing is
+ * in any tag without a running server and every snapshot built here is empty. What the tags actually
+ * contain is pinned by the digest runs, which generate against a real dedicated server: if
+ * {@code urbex:lights}, {@code urbex:needspoi} or a {@code rotatable} tag stopped reaching
+ * generation, the digest would move.
+ * <p>
+ * What is worth testing here is the coupling that is easy to get wrong instead. {@code rotatable} is
+ * authored per world style, so the set of tags to expand is a property of the loaded pack rather
+ * than a constant - and {@link TagSnapshot#isRotatable} answers only for tags it expanded, so a
+ * style whose tag was missed would throw from a worldgen worker rather than quietly stop rotating
+ * (issue #117).
+ */
+class TagSnapshotTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static final BlockState ANY = Blocks.OAK_STAIRS.defaultBlockState();
+
+    private static TagKey<Block> tag(String namespace, String path) {
+        return TagKey.create(Registries.BLOCK, Identifier.fromNamespaceAndPath(namespace, path));
+    }
+
+    @Test
+    void theDefaultTagIsExpandedEvenWhenNoWorldStyleNamesIt() {
+        TagSnapshot tags = TagSnapshot.capture(AssetSnapshot.empty());
+
+        assertDoesNotThrow(() -> tags.isRotatable(UrbexTags.ROTATABLE_TAG, ANY),
+                "a world style that declares no 'rotatable' resolves urbex:rotatable, so the "
+                        + "snapshot has to carry it whether or not any style mentions it");
+    }
+
+    @Test
+    void everyWorldStylesOwnTagIsExpanded() {
+        TagSnapshot tags = TagSnapshot.capture(worldStyles(
+                worldStyle("standard", Optional.empty()),
+                worldStyle("zombie", Optional.of(tag("urbexza", "rotatable")))));
+
+        assertDoesNotThrow(() -> tags.isRotatable(tag("urbexza", "rotatable"), ANY));
+        assertDoesNotThrow(() -> tags.isRotatable(UrbexTags.ROTATABLE_TAG, ANY));
+    }
+
+    /**
+     * The failure this shape is chosen to make loud. A tag the snapshot never expanded can only come
+     * from a world style outside the {@link AssetSnapshot} it was captured against - which a world
+     * cannot produce, because it compiles its assets once and never swaps them.
+     */
+    @Test
+    void aTagNoWorldStyleNamesIsAWiringErrorRatherThanASilentFalse() {
+        TagSnapshot tags = TagSnapshot.capture(AssetSnapshot.empty());
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> tags.isRotatable(tag("urbexza", "rotatable"), ANY));
+
+        assertTrue(thrown.getMessage().contains("urbexza:rotatable"),
+                "the message has to name the tag: " + thrown.getMessage());
+    }
+
+    private static AssetSnapshot worldStyles(WorldStyle... styles) {
+        Map<Identifier, WorldStyle> byId = new HashMap<>();
+        for (WorldStyle style : styles) {
+            byId.put(style.getId(), style);
+        }
+        AssetSnapshot empty = AssetSnapshot.empty();
+        return new AssetSnapshot(empty.variants(), empty.palettes(), empty.conditions(), empty.styles(),
+                empty.parts(), empty.buildings(), empty.multiBuildings(), empty.scattered(),
+                new AssetIndex<>("urbex:worldstyles", byId), empty.cityStyles(),
+                empty.predefinedCities(), empty.stuff(), empty.stuffByTag());
+    }
+
+    private static WorldStyle worldStyle(String name, Optional<TagKey<Block>> rotatable) {
+        return new WorldStyle(List.of(new WorldStyleRE(
+                Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.of(TestWiring.partSelector()),
+                Optional.of(new Mergeable<>(true,
+                        List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
+                Optional.empty(), rotatable)
+                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", name))));
+    }
+}


### PR DESCRIPTION
**128b** of #128 — the `TagSnapshot`. Phase 2 step 4 of epic #134.
Decomposition and remaining steps: [`docs/superpowers/specs/2026-08-12-asset-snapshot-design.md`](docs/superpowers/specs/2026-08-12-asset-snapshot-design.md).

## What was wrong

Block tags are the one piece of Urbex's compiled state a `/reload` genuinely changes. The thirteen
asset registries are Fabric dynamic registries, frozen when the world loads (#61), so an edited
building or palette needs the world reopened whatever a reload does — but `urbex:lights`,
`urbex:needspoi`, `urbex:foliage`, the breakable tags and every world style's `rotatable` come back
with every one.

`CityGenerator` expanded three of those into `BlockState` sets **in its constructor**, so the only
way to see an edited tag was a fresh generator — and `GenerationSession.reload()` therefore rebuilt
every loaded level's entire runtime to get one. That took the level's road field, its heightmaps, its
world-style field and every chunk plan it had cached down with it. None of that is derived from a
tag; all of it is a pure function of the seed and the frozen assets, so all of it was rebuilt to
exactly what it already was.

The rest of the tag reads went the other way and were live: `Tools.hasTag` from the driver loop, per
block, against the process-global block registry — which is a registry read a tag reload can land in
the middle of.

## What changed

Block-tag-derived state becomes an immutable `TagSnapshot`, held in the server's one `TagEpoch` slot.

- **A reload is one write.** `reload()` re-captures the snapshot and publishes it into the epoch.
  Nothing else is rebuilt, and the level keeps everything it had planned.
- **A chunk sees one epoch, start to finish.** `CityGenerator.generate` reads `runtime.tags()` once
  and puts it on `ChunkGenContext`; every tag question that chunk asks is answered from that
  instance. A reload landing halfway through a building cannot put one slice on the old membership
  and the next slice on the new one.
- **Block tags are read in exactly one place**: `TagSnapshot.capture`, on the thread capturing.
  `Tools.hasTag` and `Tools.getBlocksForTag` are deleted.
- **An asset reload is now hard to write by accident.** No tag-derived state is left on the objects
  holding the `AssetSnapshot`, so nothing tempts a future reload into republishing them.
- `DamageArea.damageBlock` takes the snapshot as an argument rather than holding one: a `DamageArea`
  is cached on the chunk's `BuildingInfo` and outlives any single generation.
- `railStates` stays on `CityGenerator`. It is `Blocks.RAIL` and `Blocks.POWERED_RAIL` expanded — no
  tag, nothing to reload — and putting it in a type called `TagSnapshot` would be a lie.

## Three things worth reviewing closely

**`capture()` takes the `AssetSnapshot`, and that coupling is deliberate.** `rotatable` is authored
per world style (#117), so *which* tags to expand is a property of the loaded pack, not a constant.
Every world style in the snapshot contributes its tag and `urbex:rotatable` is always expanded,
because that is what a style declaring none resolves to. The edge runs one way only — assets never
read tags — and it holds across a reload because a world compiles its assets once and never swaps
them.

**`isRotatable` throws for a tag it did not expand, rather than returning `false`.** A tag it never
saw can only come from a world style outside the snapshot it was captured against, which is an Urbex
wiring error, not something a datapack can provoke. Returning `false` would mean blocks quietly stop
rotating, which is #117 again — and that one took a ladder attached to nothing to notice.

**`RuntimeRepository.republish` is deleted.** Its only caller was the reload this replaces. Leaving a
tested-but-unreachable "rebuild every runtime" primitive around is an invitation to use it for the
next thing that looks like a reload. The property its tests documented — a reader keeps what it was
handed, a swap decides what the *next* reader gets — is not lost: it moves to `TagEpochTest`, which
is where that rule now lives.

## What is *not* tested here, and why

`TagSnapshotTest` asserts which tags an epoch expands, not what is in them. Block tags are bound by
the server's tag manager, so nothing is in any tag in a unit test and every snapshot built there is
empty. Membership reaching generation is pinned by the digest runs instead, on a real dedicated
server: if `urbex:lights`, `urbex:needspoi` or a `rotatable` tag stopped being applied, the digest
would move. Saying so beats a test named for a rule it does not check.

## Verification

```
./gradlew test               # pass
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK
```

**Both digest goldens are unchanged.** This relocates where block-tag membership lives and when it is
read; it changes nothing about what is placed. `unsafeReads=0` on both runs.
