### PR TITLE
refactor: resolve blocks against the compiling world's registry (#128, 128c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Asset compilation resolves blocks against the world it is compiling, not against a static server
+  reference.** Every block string in a palette, variant or light pool is resolved through a block
+  registry the compiler hands down, taken once from the world being loaded (issue #128).
+  - *Which registry a block string parsed against used to depend on timing.* `Tools.stringToState`
+    picked the overworld's lookup if the static server reference happened to be populated and
+    `BuiltInRegistries.BLOCK` if it was not. Both are the same registry — blocks are static and
+    frozen at mod init — so nothing was ever wrong, but nothing said so either, and it was the last
+    place outside the editor that asset compilation reached a server for anything (issue #60).
+  - *An unknown block id still generates as air, warned once.* It used to arrive there through a
+    defaulted registry's default value; it is an explicit return now, so the decision issue #91 has
+    to make is one line rather than a registry quirk to find. Pinned by `BlockResolutionTest`.
+  - *No worldgen change*: both digest goldens are unchanged, verified by running `runDigestCheck`
+    and `runDigestCheckFeatures`.
+
 - **`/reload` refreshes block tags without rebuilding everything a level generates with.** Block tags
   are the one piece of Urbex's compiled state a reload genuinely changes, and they now live in their
   own immutable `TagSnapshot` that a reload swaps in a single write (issue #128).

--- a/src/main/java/dev/krona/urbex/varia/Tools.java
+++ b/src/main/java/dev/krona/urbex/varia/Tools.java
@@ -9,16 +9,19 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.commands.arguments.blocks.BlockStateParser;
 import net.minecraft.core.DefaultedRegistry;
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.datafix.fixes.BlockStateData;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
 
@@ -47,64 +50,71 @@ public class Tools {
     }
 
     /**
-     * Resolves a datapack block string, naming {@code owner} if it cannot be resolved.
+     * Resolves a datapack block string against {@code blockLookup}, naming {@code owner} if it cannot be
+     * resolved.
      * <p>
-     * <b>An unknown id still returns air, exactly as before.</b> {@code BuiltInRegistries.BLOCK} is
-     * a {@link DefaultedRegistry}, so {@code getValue} hands back the registry's default value -
-     * {@code minecraft:air} - for an id it does not know, never null. The {@code value == null}
-     * guard below has therefore never fired, and an id that a Minecraft version renames becomes air
-     * everywhere it is used with no exception and no log line. That is how {@code minecraft:chain}
-     * (renamed {@code minecraft:iron_chain} in 26.x) made the whole {@code urbex:chains} decoration
-     * invisible without anyone noticing. Turning it into a load error is a contract change for every
-     * third-party pack and is tracked separately; the warning below is the part that costs nothing
-     * and can move no golden, because the state returned is unchanged.
+     * <b>An unknown id returns air.</b> That is not a decision made here - it is what this has
+     * always done, and it is why {@code minecraft:chain} (renamed {@code minecraft:iron_chain} in
+     * 26.x) made the whole {@code urbex:chains} decoration invisible without anyone noticing. It
+     * used to happen by accident, through {@code BuiltInRegistries.BLOCK} being a
+     * {@link DefaultedRegistry} whose {@code getValue} hands back {@code minecraft:air} rather than
+     * null; it is spelled out below instead, so that #91 - which decides whether a missing block is
+     * a skipped entry, a load error, or air - has one line to change rather than a registry quirk to
+     * discover. The warning is the part that costs nothing and can move no golden, because the state
+     * returned is unchanged.
      * <p>
-     * The legacy branch under it is dead in both directions, and is kept only because deleting it is
-     * a separate decision. {@code Identifier.parse} on the line above throws for a pre-flattening
-     * {@code name@meta} string - {@code @} is not a legal path character - so such a string can
-     * never reach {@code upgradeBlock}; and {@code BlockStateData.upgradeBlock(String)} does not
-     * handle that form anyway (measured: it returns {@code minecraft:red_sandstone@2} unchanged).
-     * That is why the one such string the bundled pack shipped was a hard crash at palette compile
-     * rather than an automatic upgrade.
+     * The pre-flattening {@code name@meta} form never reaches {@code upgradeBlock}:
+     * {@code Identifier.parse} throws for it first, {@code @} not being a legal path character - and
+     * {@code BlockStateData.upgradeBlock(String)} does not handle that form anyway (measured: it
+     * returns {@code minecraft:red_sandstone@2} unchanged). That is why the one such string the
+     * bundled pack shipped was a hard crash at palette compile rather than an automatic upgrade.
      *
-     * @param owner the asset the string came from, used only in the warning. This is the asset
-     *              <em>id</em>, not the file path, and for a palette written inline in a part or
-     *              building it is the synthetic {@code urbex:__local__<path>} name
-     *              {@link dev.krona.urbex.worldgen.lost.cityassets.Palette#inline} builds rather
-     *              than the owning part - close enough to find, but not a filename. May be null;
-     *              every production caller passes one.
+     * @param blockLookup what to resolve against, handed down from
+     *                    {@link dev.krona.urbex.worldgen.lost.cityassets.AssetCompiler} out of the
+     *                    world's own {@code RegistryAccess}. It used to be picked here, and which
+     *                    one you got depended on whether {@code ServerAccess.getServer()} happened
+     *                    to be populated yet: the overworld's lookup if it was,
+     *                    {@code BuiltInRegistries.BLOCK} if it was not. The two are the same
+     *                    registry - blocks are static and frozen at mod init - so nothing was ever
+     *                    wrong, but "which registry did this parse against" was answered by timing
+     *                    rather than by the caller (issues #60, #128).
+     * @param owner       the asset the string came from, used only in the warning. This is the
+     *                    asset <em>id</em>, not the file path, and for a palette written inline in a
+     *                    part or building it is the synthetic {@code urbex:__local__<path>} name
+     *                    {@link dev.krona.urbex.worldgen.lost.cityassets.Palette#inline} builds
+     *                    rather than the owning part - close enough to find, but not a filename. May
+     *                    be null; every production caller passes one.
      */
-    public static BlockState stringToState(String s, @Nullable Object owner) {
+    public static BlockState stringToState(String s, HolderLookup<Block> blockLookup, @Nullable Object owner) {
         if (s.contains("[")) {
             try {
-                HolderLookup<Block> blocks = ServerAccess.getServer() == null
-                        ? BuiltInRegistries.BLOCK
-                        : WorldTools.getOverworld().holderLookup(Registries.BLOCK);
-                BlockStateParser.BlockResult parser = BlockStateParser.parseForBlock(blocks, new StringReader(s), false);
+                BlockStateParser.BlockResult parser = BlockStateParser.parseForBlock(blockLookup, new StringReader(s), false);
                 return parser.blockState();
             } catch (CommandSyntaxException e) {
                 throw new RuntimeException(e);
             }
         }
 
-        Identifier requested = Identifier.parse(s);
-        if (BuiltInRegistries.BLOCK.containsKey(requested)) {
-            return BuiltInRegistries.BLOCK.getValue(requested).defaultBlockState();
+        Optional<Holder.Reference<Block>> requested = blockLookup.get(blockKey(s));
+        if (requested.isPresent()) {
+            return requested.get().value().defaultBlockState();
         }
 
-        String converted = BlockStateData.upgradeBlock(s);
-        Identifier convertedId = Identifier.parse(converted);
-        if (!BuiltInRegistries.BLOCK.containsKey(convertedId) && WARNED_MISSING_BLOCKS.add(s)) {
+        Optional<Holder.Reference<Block>> upgraded = blockLookup.get(blockKey(BlockStateData.upgradeBlock(s)));
+        if (upgraded.isPresent()) {
+            return upgraded.get().value().defaultBlockState();
+        }
+        if (WARNED_MISSING_BLOCKS.add(s)) {
             Urbex.LOGGER.warn(
                     "Block '{}'{} does not exist in this Minecraft version; it will generate as air. " +
                             "It was most likely renamed - check the current id and update the asset.",
                     s, owner == null ? "" : " (in " + owner + ")");
         }
-        Block value = BuiltInRegistries.BLOCK.getValue(convertedId);
-        if (value == null) {
-            throw new RuntimeException("Cannot find block: '" + s + "'!");
-        }
-        return value.defaultBlockState();
+        return Blocks.AIR.defaultBlockState();
+    }
+
+    private static ResourceKey<Block> blockKey(String id) {
+        return ResourceKey.create(Registries.BLOCK, Identifier.parse(id));
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
@@ -7,9 +7,12 @@ import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.CitySettings;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
@@ -63,18 +66,23 @@ public final class AssetCompiler {
      *         class exists to make impossible, so don't.
      */
     public static AssetSnapshot compile(RegistryAccess access, AssetDiagnostics diagnostics) {
+        // The block registry the whole compilation resolves against, taken once from the world
+        // being loaded. Every block string below reaches it through a parameter: resolution used
+        // to pick a registry for itself, from a static server reference that may or may not have
+        // been populated by the time it ran (issues #60, #128).
+        HolderLookup<Block> blockLookup = access.lookupOrThrow(Registries.BLOCK);
         AssetIndex<Variant> variants = AssetStage.compileAll(access,
-                CustomRegistries.VARIANTS_REGISTRY_KEY, (id, chain) -> new Variant(chain), diagnostics);
+                CustomRegistries.VARIANTS_REGISTRY_KEY, (id, chain) -> new Variant(blockLookup, chain), diagnostics);
         AssetIndex<Palette> palettes = AssetStage.compileAll(access,
-                CustomRegistries.PALETTE_REGISTRY_KEY, (id, chain) -> new Palette(variants, chain), diagnostics);
+                CustomRegistries.PALETTE_REGISTRY_KEY, (id, chain) -> new Palette(blockLookup, variants, chain), diagnostics);
         AssetIndex<Condition> conditions = AssetStage.compileAll(access,
                 CustomRegistries.CONDITIONS_REGISTRY_KEY, (id, chain) -> new Condition(chain), diagnostics);
         AssetIndex<Style> styles = AssetStage.compileAll(access,
                 CustomRegistries.STYLE_REGISTRY_KEY, (id, chain) -> new Style(palettes, chain), diagnostics);
         AssetIndex<BuildingPart> parts = AssetStage.compileAll(access,
-                CustomRegistries.PART_REGISTRY_KEY, (id, chain) -> new BuildingPart(variants, palettes, chain), diagnostics);
+                CustomRegistries.PART_REGISTRY_KEY, (id, chain) -> new BuildingPart(blockLookup, variants, palettes, chain), diagnostics);
         AssetIndex<Building> buildings = AssetStage.compileAll(access,
-                CustomRegistries.BUILDING_REGISTRY_KEY, (id, chain) -> new Building(variants, palettes, chain), diagnostics);
+                CustomRegistries.BUILDING_REGISTRY_KEY, (id, chain) -> new Building(blockLookup, variants, palettes, chain), diagnostics);
         AssetIndex<MultiBuilding> multiBuildings = AssetStage.compileAll(access,
                 CustomRegistries.MULTIBUILDINGS_REGISTRY_KEY, (id, chain) -> new MultiBuilding(chain), diagnostics);
         AssetIndex<ScatteredBuilding> scattered = AssetStage.compileAll(access,

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
@@ -4,8 +4,10 @@ import dev.krona.urbex.worldgen.lost.regassets.BuildingRE;
 import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.CommonLevelAccessor;
+import net.minecraft.world.level.block.Block;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
@@ -54,8 +56,8 @@ public class Building {
      * ancestor that set something else. The defaults the fields start at are this class's own
      * documented fallbacks - {@code -1} for "take the level's limit" - not markers for "undeclared".
      */
-    public Building(@Nullable AssetIndex<Variant> variants, AssetIndex<Palette> palettes,
-                        List<BuildingRE> chainRootFirst) {
+    public Building(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
+                        AssetIndex<Palette> palettes, List<BuildingRE> chainRootFirst) {
         name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
         List<PartRef> partRefs = new ArrayList<>();
         boolean anyParts = false;
@@ -116,7 +118,7 @@ public class Building {
         Resolved.require(anyParts ? partRefs : null, name, "parts");
 
         if (!inlinePalettes.isEmpty()) {
-            localPalette = Palette.inline(variants, name, inlinePalettes); // @todo get the full palette instead
+            localPalette = Palette.inline(blockLookup, variants, name, inlinePalettes); // @todo get the full palette instead
         } else if (refPalette != null) {
             refPaletteName = refPalette;
             // Resolved here, not on the first chunk that asks. The lazy version cached the answer on

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPart.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPart.java
@@ -5,8 +5,10 @@ import dev.krona.urbex.worldgen.lost.regassets.BuildingPartRE;
 import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartMeta;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.CommonLevelAccessor;
+import net.minecraft.world.level.block.Block;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -59,8 +61,8 @@ public class BuildingPart implements IBuildingPart {
      * {@code slices} replaces the inherited ones wholesale; declaring a size that contradicts the
      * slices actually in force is a load error rather than a silent truncation.
      */
-    public BuildingPart(@Nullable AssetIndex<Variant> variants, AssetIndex<Palette> palettes,
-                        List<BuildingPartRE> chainRootFirst) {
+    public BuildingPart(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
+                        AssetIndex<Palette> palettes, List<BuildingPartRE> chainRootFirst) {
         BuildingPartRE leaf = chainRootFirst.get(chainRootFirst.size() - 1);
         name = leaf.getRegistryName();
 
@@ -110,7 +112,7 @@ public class BuildingPart implements IBuildingPart {
         slices = declaredSlices;
 
         if (!inlinePalettes.isEmpty()) {
-            localPalette = Palette.inline(variants, name, inlinePalettes); // @todo get the full palette instead
+            localPalette = Palette.inline(blockLookup, variants, name, inlinePalettes); // @todo get the full palette instead
         } else if (refPalette != null) {
             refPaletteName = refPalette;
             // Resolved here, not on the first chunk that asks. The lazy version cached the answer on

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/LightPool.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/LightPool.java
@@ -2,8 +2,10 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.lost.regassets.data.LightSettings;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -40,13 +42,14 @@ public final class LightPool {
         this.allCandidates = List.copyOf(flattened);
     }
 
-    public static LightPool compile(Identifier paletteId, char marker, LightSettings settings) {
+    public static LightPool compile(HolderLookup<Block> blockLookup, Identifier paletteId, char marker,
+                                    LightSettings settings) {
         EnumMap<Placement, List<Candidate>> candidates = new EnumMap<>(Placement.class);
         EnumMap<Placement, Integer> totalWeights = new EnumMap<>(Placement.class);
-        compileGroup(paletteId, marker, Placement.FLOOR, settings.floor(), candidates, totalWeights);
-        compileGroup(paletteId, marker, Placement.WALL, settings.wall(), candidates, totalWeights);
-        compileGroup(paletteId, marker, Placement.CEILING, settings.ceiling(), candidates, totalWeights);
-        compileGroup(paletteId, marker, Placement.FREE, settings.free(), candidates, totalWeights);
+        compileGroup(blockLookup, paletteId, marker, Placement.FLOOR, settings.floor(), candidates, totalWeights);
+        compileGroup(blockLookup, paletteId, marker, Placement.WALL, settings.wall(), candidates, totalWeights);
+        compileGroup(blockLookup, paletteId, marker, Placement.CEILING, settings.ceiling(), candidates, totalWeights);
+        compileGroup(blockLookup, paletteId, marker, Placement.FREE, settings.free(), candidates, totalWeights);
         if (candidates.values().stream().allMatch(List::isEmpty)) {
             throw new IllegalArgumentException("Invalid light pool in palette '" + paletteId + "', marker '" + marker
                     + "': expected at least one candidate in floor, wall, ceiling, or free");
@@ -102,7 +105,8 @@ public final class LightPool {
         return allCandidates;
     }
 
-    private static void compileGroup(Identifier paletteId, char marker, Placement placement,
+    private static void compileGroup(HolderLookup<Block> blockLookup, Identifier paletteId,
+                                     char marker, Placement placement,
                                      List<LightSettings.Entry> entries,
                                      Map<Placement, List<Candidate>> candidates,
                                      Map<Placement, Integer> totalWeights) {
@@ -116,7 +120,7 @@ public final class LightPool {
             }
             BlockState state;
             try {
-                state = Tools.stringToState(entry.block(), paletteId);
+                state = Tools.stringToState(entry.block(), blockLookup, paletteId);
             } catch (RuntimeException e) {
                 throw invalidCandidate(paletteId, marker, placement, candidateIndex, entry.block(),
                         "cannot parse block state", e);

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
@@ -5,8 +5,10 @@ import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -38,14 +40,17 @@ public class Palette {
      * then compiled, so an overridden entry takes its {@code damaged} mapping with it.
      */
     /**
-     * @param variants the compiled variants this palette's {@code variant} entries resolve against.
-     *                 May be null only for a palette that provably names none; one that does then
-     *                 fails naming itself and the variant rather than reaching for a static server
-     *                 (issue #60) or compiling one on the spot (issue #128).
+     * @param blockLookup the block registry every block string in this palette resolves against,
+     *                    handed down by the compiler from the world being loaded.
+     * @param variants    the compiled variants this palette's {@code variant} entries resolve
+     *                    against. May be null only for a palette that provably names none; one that
+     *                    does then fails naming itself and the variant rather than reaching for a
+     *                    static server (issue #60) or compiling one on the spot (issue #128).
      */
-    public Palette(@Nullable AssetIndex<Variant> variants, List<PaletteRE> chainRootFirst) {
+    public Palette(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
+                   List<PaletteRE> chainRootFirst) {
         name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
-        compile(variants, mergeByCharacter(chainRootFirst, name));
+        compile(blockLookup, variants, mergeByCharacter(chainRootFirst, name));
     }
 
     public Palette(String name) {
@@ -59,14 +64,15 @@ public class Palette {
      * An inline palette is a keyed collection exactly like a registered one, so it merges by
      * character too: a part that extends another and declares an inline palette repainting two
      * markers keeps the rest of its ancestor's. Replacing wholesale here would reproduce, one level
-     * down, the very failure {@link #Palette(List)} exists to prevent.
+     * down, the very failure {@link #mergeByCharacter} exists to prevent.
      *
+     * @param blockLookup    the block registry the inline entries resolve against
      * @param owner          the part or building the block is written in, for error messages and
      *                       for the synthetic palette name
      * @param chainRootFirst the inline blocks along the owner's chain, root first
      */
-    public static Palette inline(@Nullable AssetIndex<Variant> variants, Identifier owner,
-                                 List<PaletteRE> chainRootFirst) {
+    public static Palette inline(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
+                                 Identifier owner, List<PaletteRE> chainRootFirst) {
         for (PaletteRE re : chainRootFirst) {
             // The codec accepts 'extends' wherever a PaletteRE is embedded, but an inline block is
             // not a registry entry, so nothing can resolve it. Rejecting is the honest option:
@@ -80,7 +86,7 @@ public class Palette {
             }
         }
         Palette palette = new Palette("__local__" + owner.getPath());
-        palette.compile(variants, mergeByCharacter(chainRootFirst, owner));
+        palette.compile(blockLookup, variants, mergeByCharacter(chainRootFirst, owner));
         return palette;
     }
 
@@ -133,20 +139,22 @@ public class Palette {
         return palette;
     }
 
-    private void compile(@Nullable AssetIndex<Variant> variants, Collection<PaletteEntry> entries) {
+    private void compile(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
+                         Collection<PaletteEntry> entries) {
         for (PaletteEntry entry : entries) {
             Character c = entry.getChr().charAt(0);
             BlockState dmg = null;
             if (entry.getDamaged() != null) {
-                dmg = Tools.stringToState(entry.getDamaged(), name);
+                dmg = Tools.stringToState(entry.getDamaged(), blockLookup, name);
             }
-            LightPool light = entry.getLight() == null ? null : LightPool.compile(name, c, entry.getLight());
+            LightPool light = entry.getLight() == null ? null
+                    : LightPool.compile(blockLookup, name, c, entry.getLight());
             Info info = new Info(entry.getMob(), entry.getLoot(),
                     entry.getTorch() != null && entry.getTorch(), light, entry.getTag());
 
             if (entry.getBlock() != null) {
                 String block = entry.getBlock();
-                BlockState state = Tools.stringToState(block, name);
+                BlockState state = Tools.stringToState(block, blockLookup, name);
                 palette.put(c, new PE(state, info));
                 if (dmg != null) {
                     damaged.put(state, dmg);
@@ -181,7 +189,7 @@ public class Palette {
                 for (BlockEntry ob : entryBlocks) {
                     Integer f = ob.random();
                     String block = ob.block();
-                    BlockState state = Tools.stringToState(block, name);
+                    BlockState state = Tools.stringToState(block, blockLookup, name);
                     blocks.add(Pair.of(f, state));
                     if (dmg != null) {
                         damaged.put(state, dmg);

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Variant.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Variant.java
@@ -4,7 +4,9 @@ import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -23,8 +25,12 @@ public class Variant {
      * Builds a fully resolved variant from its {@code extends} chain, root first: a declared
      * {@code blocks} replaces the inherited list unless it opts into appending, and an absent one
      * inherits it unchanged. A chain where nothing declares {@code blocks} is a load error.
+     *
+     * @param blockLookup what the block strings resolve against, from the compiling world's own
+     *               registries. Taken rather than fetched: resolution used to reach a static server
+     *               reference from wherever it happened to run (issues #60, #128).
      */
-    public Variant(List<VariantRE> chainRootFirst) {
+    public Variant(HolderLookup<Block> blockLookup, List<VariantRE> chainRootFirst) {
         name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
         List<BlockEntry> entries = new ArrayList<>();
         boolean anyBlocks = false;
@@ -36,7 +42,7 @@ public class Variant {
         }
         Resolved.require(anyBlocks ? entries : null, name, "blocks");
         for (BlockEntry entry : entries) {
-            BlockState state = Tools.stringToState(entry.block(), name);
+            BlockState state = Tools.stringToState(entry.block(), blockLookup, name);
             blocks.add(Pair.of(entry.random(), state));
         }
     }

--- a/src/test/java/dev/krona/urbex/data/DatapackGuideExamplesTest.java
+++ b/src/test/java/dev/krona/urbex/data/DatapackGuideExamplesTest.java
@@ -31,6 +31,7 @@ import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteSelector;
 import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.BeforeAll;
@@ -189,21 +190,21 @@ class DatapackGuideExamplesTest {
         expect(guide, missing, () -> Resolved.require(null, downtown, "streetblocks.parts.stair"));
 
         // A part with no geometry, and a part whose redeclared size contradicts inherited slices.
-        expect(guide, missing, () -> new BuildingPart(null, NO_PALETTES, List.of(namedPart(tower, null, null, null))));
-        expect(guide, missing, () -> new BuildingPart(null, NO_PALETTES, List.of(
+        expect(guide, missing, () -> new BuildingPart(BuiltInRegistries.BLOCK, null, NO_PALETTES, List.of(namedPart(tower, null, null, null))));
+        expect(guide, missing, () -> new BuildingPart(BuiltInRegistries.BLOCK, null, NO_PALETTES, List.of(
                 namedPart(Identifier.fromNamespaceAndPath("urbexmt", "tower_base"), 16, 16,
                         List.of(List.of("x".repeat(256)))),
                 namedPart(tower, 8, null, null))));
 
         // 'extends' inside an inline palette block.
-        expect(guide, missing, () -> Palette.inline(null, tower, List.of(new PaletteRE(
+        expect(guide, missing, () -> Palette.inline(BuiltInRegistries.BLOCK, null, tower, List.of(new PaletteRE(
                 Optional.of(Identifier.fromNamespaceAndPath("urbex", "common")), Optional.empty()))));
 
         // A palette entry that resolves to nothing at all.
         PaletteEntry empty = new PaletteEntry("#", Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        expect(guide, missing, () -> new Palette(null, List.of(
+        expect(guide, missing, () -> new Palette(BuiltInRegistries.BLOCK, null, List.of(
                 new PaletteRE(Optional.empty(), Optional.of(List.of(empty)))
                         .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "x")))));
 

--- a/src/test/java/dev/krona/urbex/data/RotatableTagCoversShippedBlocksTest.java
+++ b/src/test/java/dev/krona/urbex/data/RotatableTagCoversShippedBlocksTest.java
@@ -79,7 +79,7 @@ class RotatableTagCoversShippedBlocksTest {
 
         Set<String> problems = new TreeSet<>();
         for (Ref ref : refs) {
-            BlockState state = Tools.stringToState(ref.value(), ref.file());
+            BlockState state = Tools.stringToState(ref.value(), BuiltInRegistries.BLOCK, ref.file());
             boolean turns = state.rotate(Rotation.CLOCKWISE_90) != state
                     || state.mirror(Mirror.FRONT_BACK) != state;
             Identifier id = BuiltInRegistries.BLOCK.getKey(state.getBlock());

--- a/src/test/java/dev/krona/urbex/data/ShippedBlockIdsResolveTest.java
+++ b/src/test/java/dev/krona/urbex/data/ShippedBlockIdsResolveTest.java
@@ -25,10 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Minecraft version actually has.
  * <p>
  * Nothing checked this, and the failure mode is silent rather than loud: {@code Tools.stringToState}
- * ends at {@code BuiltInRegistries.BLOCK.getValue(id)}, and that returns the block registry's
- * <em>default</em> value - {@code minecraft:air} - for an id it does not know, so the
- * {@code value == null} guard below it never fires. An id that a Minecraft version renames
- * therefore turns into air everywhere it is used, with no exception and no log line.
+ * ends by returning {@code minecraft:air} for an id it cannot resolve. An id that a Minecraft
+ * version renames therefore turns into air everywhere it is used, with no exception and one warning
+ * in the log that nobody reads while playing. (It used to reach that outcome by accident, through
+ * {@code BuiltInRegistries.BLOCK.getValue} handing back a defaulted registry's default; it is
+ * written out as a return now, and pinned by {@code BlockResolutionTest}, so #91 has one line to
+ * change.)
  * <p>
  * Two shipped entries were in exactly that state when this test was written, both surfaced by
  * Task 5c making the load-time validation actually run: {@code minecraft:chain} (renamed

--- a/src/test/java/dev/krona/urbex/varia/BlockResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/varia/BlockResolutionTest.java
@@ -1,0 +1,100 @@
+package dev.krona.urbex.varia;
+
+import com.mojang.serialization.Lifecycle;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.RegistrationInfo;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.StairBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * What a datapack block string resolves to, and — the part this issue is about — <em>what it
+ * resolves against</em>.
+ * <p>
+ * {@code Tools.stringToState} used to choose its own registry: the overworld's block lookup if
+ * {@code ServerAccess.getServer()} happened to be populated, {@code BuiltInRegistries.BLOCK} if it
+ * was not. Both are the same registry, so nothing was ever wrong — but "which registry did this
+ * parse against" was answered by timing rather than by the caller, and asset compilation had no say
+ * in it (issues #60, #128). It is a parameter now, handed down by {@code AssetCompiler} from the
+ * world being loaded, and {@link #resolutionAnswersFromTheLookupItIsGivenNotAGlobalOne} is what
+ * makes that a fact rather than a claim.
+ */
+class BlockResolutionTest {
+
+    private static final Identifier OWNER = Identifier.fromNamespaceAndPath("urbex", "test_palette");
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void aPlainIdResolvesToItsDefaultState() {
+        assertSame(Blocks.STONE.defaultBlockState(),
+                Tools.stringToState("minecraft:stone", BuiltInRegistries.BLOCK, OWNER));
+    }
+
+    @Test
+    void propertiesAreParsedRatherThanIgnored() {
+        BlockState state = Tools.stringToState("minecraft:oak_stairs[facing=east]",
+                BuiltInRegistries.BLOCK, OWNER);
+
+        assertSame(Blocks.OAK_STAIRS, state.getBlock());
+        assertEquals(net.minecraft.core.Direction.EAST, state.getValue(StairBlock.FACING));
+    }
+
+    /**
+     * The behaviour #91 exists to change, pinned here so that when it does change this test is what
+     * has to be edited — rather than the change being discovered from a moved digest.
+     * <p>
+     * An id this Minecraft version does not have generates as air, silently as far as the world is
+     * concerned and with one warning in the log. That is how {@code minecraft:chain} (renamed
+     * {@code minecraft:iron_chain} in 26.x) made the whole {@code urbex:chains} decoration invisible.
+     */
+    @Test
+    void anUnknownIdResolvesToAirRatherThanThrowing() {
+        assertSame(Blocks.AIR.defaultBlockState(),
+                Tools.stringToState("somemod:no_such_block", BuiltInRegistries.BLOCK, OWNER));
+    }
+
+    /**
+     * The boundary itself: a lookup that does not have the block answers "not here", even though the
+     * process-global registry three lines away does have it. Before this change there was no way to
+     * write this test, because there was no way to say which registry to ask.
+     */
+    @Test
+    void resolutionAnswersFromTheLookupItIsGivenNotAGlobalOne() {
+        HolderLookup<Block> onlyStone = registryOf("stone", Blocks.STONE);
+
+        assertSame(Blocks.STONE.defaultBlockState(),
+                Tools.stringToState("minecraft:stone", onlyStone, OWNER));
+        assertSame(Blocks.AIR.defaultBlockState(),
+                Tools.stringToState("minecraft:diamond_block", onlyStone, OWNER),
+                "BuiltInRegistries has diamond_block; the lookup handed in does not");
+        assertThrows(RuntimeException.class,
+                () -> Tools.stringToState("minecraft:oak_stairs[facing=east]", onlyStone, OWNER),
+                "and the property-parsing path asks the same lookup");
+    }
+
+    private static HolderLookup<Block> registryOf(String path, Block block) {
+        MappedRegistry<Block> registry = new MappedRegistry<>(Registries.BLOCK, Lifecycle.stable());
+        registry.register(ResourceKey.create(Registries.BLOCK, Identifier.withDefaultNamespace(path)),
+                block, RegistrationInfo.BUILT_IN);
+        return registry.freeze();
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/DeferredLightPlacerTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/DeferredLightPlacerTest.java
@@ -6,6 +6,7 @@ import dev.krona.urbex.worldgen.lost.regassets.data.LightSettings;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.world.level.block.Blocks;
@@ -195,7 +196,7 @@ class DeferredLightPlacerTest {
                                   List<LightSettings.Entry> wall,
                                   List<LightSettings.Entry> ceiling,
                                   List<LightSettings.Entry> free) {
-        return LightPool.compile(PALETTE_ID, 'L', new LightSettings(floor, wall, ceiling, free));
+        return LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', new LightSettings(floor, wall, ceiling, free));
     }
 
     private static LightSettings.Entry entry(int weight, String block) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompilerTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompilerTest.java
@@ -14,6 +14,7 @@ import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.RegistrationInfo;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.Bootstrap;
@@ -201,6 +202,10 @@ class AssetCompilerTest {
     @SafeVarargs
     private static RegistryAccess registries(Entry<?>... entries) {
         List<Registry<?>> all = new ArrayList<>();
+        // The block registry, because compilation resolves every block string against the world's
+        // own rather than reaching for a static one. A real world always has it; this access is
+        // built by hand, so it has to be said.
+        all.add(BuiltInRegistries.BLOCK);
         for (ResourceKey<? extends Registry<?>> key : List.of(
                 CustomRegistries.VARIANTS_REGISTRY_KEY, CustomRegistries.PALETTE_REGISTRY_KEY,
                 CustomRegistries.CONDITIONS_REGISTRY_KEY, CustomRegistries.STYLE_REGISTRY_KEY,

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetValidationTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetValidationTest.java
@@ -8,6 +8,7 @@ import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.RegistrationInfo;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.Bootstrap;
@@ -102,6 +103,9 @@ class AssetValidationTest {
                     RegistrationInfo.BUILT_IN);
         }
         return new RegistryAccess.ImmutableRegistryAccess(List.of(
+                // Compilation resolves block strings against the world's own block registry, so an
+                // access built by hand has to carry it.
+                BuiltInRegistries.BLOCK,
                 variants.freeze(),
                 empty(CustomRegistries.PALETTE_REGISTRY_KEY),
                 empty(CustomRegistries.CONDITIONS_REGISTRY_KEY),

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BelowPartConditionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BelowPartConditionTest.java
@@ -6,6 +6,7 @@ import dev.krona.urbex.worldgen.lost.regassets.BuildingRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.ConditionTest;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -94,7 +95,7 @@ public class BelowPartConditionTest {
     private static Building buildingWithParts2Condition(Set<String> belowPart, Set<String> inpart) {
         PartRef floor = partRef(FLOOR, null, null);
         PartRef second = partRef("urbex:second_part", belowPart, inpart);
-        return new Building(null, AssetIndex.empty("urbex:palettes"), List.of(new BuildingRE(
+        return new Building(BuiltInRegistries.BLOCK, null, AssetIndex.empty("urbex:palettes"), List.of(new BuildingRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.of('#'), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPartExtendsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPartExtendsTest.java
@@ -47,7 +47,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("radiotower_rusted", inherits("urbex:radiotower")
                 .refpalette("urbexmt:radiotower_rusted"));
 
-        BuildingPart resolved = new BuildingPart(null, PALETTES, List.of(parent, child));
+        BuildingPart resolved = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child));
 
         assertEquals(2, resolved.getXSize());
         assertEquals(2, resolved.getZSize());
@@ -64,7 +64,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_short", inherits("urbex:tower")
                 .slices(List.of(List.of("ij", "kl"))));
 
-        BuildingPart resolved = new BuildingPart(null, PALETTES, List.of(parent, child));
+        BuildingPart resolved = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child));
 
         assertEquals(1, resolved.getSliceCount());
         assertArrayEquals(new String[]{"ijkl"}, resolved.getSlices());
@@ -78,7 +78,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_wide", inherits("urbex:tower").xsize(3));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(null, PALETTES, List.of(parent, child)));
+                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_wide"),
                 () -> "the error must name the part: " + error.getMessage());
@@ -94,7 +94,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_deep", inherits("urbex:tower").zsize(5));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(null, PALETTES, List.of(parent, child)));
+                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_deep"),
                 () -> "the error must name the part: " + error.getMessage());
@@ -107,7 +107,7 @@ class BuildingPartExtendsTest {
                 .refpalette("urbex:rusted"));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(null, PALETTES, List.of(parent, child)));
+                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_rusted"),
                 () -> "the error must name the part that failed to resolve: " + error.getMessage());
@@ -120,7 +120,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE parent = part("sliced_only", new Builder().slices(TOWER));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(null, PALETTES, List.of(parent)));
+                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent)));
 
         assertTrue(error.getMessage().contains("urbex:sliced_only"), error::getMessage);
     }
@@ -131,11 +131,11 @@ class BuildingPartExtendsTest {
         BuildingPartRE replacing = part("tower_a", inherits("urbex:tower").meta(true, meta("nowater")));
         BuildingPartRE appending = part("tower_b", inherits("urbex:tower").meta(false, meta("nowater")));
 
-        BuildingPart replaced = new BuildingPart(null, PALETTES, List.of(parent, replacing));
+        BuildingPart replaced = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, replacing));
         assertTrue(replaced.getMetaBoolean("nowater"));
         assertFalse(replaced.getMetaBoolean("support"), "a bare array replaces");
 
-        BuildingPart appended = new BuildingPart(null, PALETTES, List.of(parent, appending));
+        BuildingPart appended = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, appending));
         assertTrue(appended.getMetaBoolean("nowater"));
         assertTrue(appended.getMetaBoolean("support"), "{\"replace\": false} keeps the inherited meta");
     }
@@ -152,7 +152,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_rusted", inherits("urbex:tower")
                 .inlinePalette(entry('a', "minecraft:deepslate")));
 
-        Palette resolved = new BuildingPart(null, PALETTES, List.of(parent, child)).getLocalPalette();
+        Palette resolved = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)).getLocalPalette();
 
         assertEquals(3, resolved.getPalette().size(),
                 "the two characters the child never mentions must survive");
@@ -173,7 +173,7 @@ class BuildingPartExtendsTest {
         // built at all unless the named palette exists. That is the compile-time resolution doing its
         // job: this used to build fine and blow up on the first chunk that asked for the palette.
         RuntimeException failure = assertThrows(RuntimeException.class,
-                () -> new BuildingPart(null, PALETTES, List.of(parent, child)),
+                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)),
                 "an ancestor's inline palette must not survive the child naming a refpalette");
         assertTrue(failure.getMessage().contains("urbex:somewhere_else"), failure.getMessage());
     }
@@ -188,7 +188,7 @@ class BuildingPartExtendsTest {
                         entry('a', "minecraft:stone")));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(null, PALETTES, List.of(part)));
+                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(part)));
 
         assertTrue(error.getMessage().contains("urbex:tower"), error::getMessage);
         assertTrue(error.getMessage().contains("urbex:common"), error::getMessage);

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CommonPaletteLightingTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CommonPaletteLightingTest.java
@@ -7,6 +7,7 @@ import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
 import dev.krona.urbex.worldgen.lost.regassets.data.LightSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.world.level.block.Blocks;
@@ -76,7 +77,7 @@ class CommonPaletteLightingTest {
         assertNull(redstoneTorch.getTorch());
         assertNull(redstoneTorch.getLight());
 
-        Palette compiled = new Palette(null, List.of(common));
+        Palette compiled = new Palette(BuiltInRegistries.BLOCK, null, List.of(common));
         LightPool torchPool = compiled.getPalette().get('T').info().light();
         LightPool freePool = compiled.getPalette().get('h').info().light();
         assertNotNull(torchPool);

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/LightPoolTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/LightPoolTest.java
@@ -45,7 +45,7 @@ class LightPoolTest {
                 }
                 """);
 
-        LightPool pool = LightPool.compile(PALETTE_ID, 'L', settings);
+        LightPool pool = LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings);
         assertEquals(1, pool.weightedOrder(LightPool.Placement.FLOOR, RandomSource.create(1L)).size());
         assertEquals(1, pool.weightedOrder(LightPool.Placement.WALL, RandomSource.create(1L)).size());
         assertEquals(1, pool.weightedOrder(LightPool.Placement.CEILING, RandomSource.create(1L)).size());
@@ -62,7 +62,7 @@ class LightPoolTest {
                 """);
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> new Palette(null, List.of(palette)));
+                () -> new Palette(BuiltInRegistries.BLOCK, null, List.of(palette)));
         assertTrue(error.getMessage().contains("urbex:test_lights"));
         assertTrue(error.getMessage().contains("marker 'L'"));
         assertTrue(error.getMessage().contains("floor, wall, ceiling, or free"));
@@ -78,7 +78,7 @@ class LightPoolTest {
                     """.formatted(weight));
 
             IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                    () -> new Palette(null, List.of(palette)));
+                    () -> new Palette(BuiltInRegistries.BLOCK, null, List.of(palette)));
             assertTrue(error.getMessage().contains("urbex:test_lights"));
             assertTrue(error.getMessage().contains("marker 'L'"));
             assertTrue(error.getMessage().contains("placement 'floor'"));
@@ -94,7 +94,7 @@ class LightPoolTest {
                 """);
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> LightPool.compile(PALETTE_ID, 'L', settings));
+                () -> LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings));
         assertTrue(error.getMessage().contains("urbex:test_lights"));
         assertTrue(error.getMessage().contains("L"));
         assertTrue(error.getMessage().contains("floor"));
@@ -107,7 +107,7 @@ class LightPoolTest {
                 {"floor":[{"weight":1,"block":"minecraft:redstone_torch[lit=true]"}]}
                 """);
 
-        LightPool pool = LightPool.compile(PALETTE_ID, 'L', settings);
+        LightPool pool = LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings);
         LightPool.Candidate candidate = pool.allCandidates().iterator().next();
         assertTrue(candidate.state().getLightEmission() > 0);
     }
@@ -125,7 +125,7 @@ class LightPoolTest {
                     List.of());
 
             IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                    () -> LightPool.compile(PALETTE_ID, 'L', settings));
+                    () -> LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings));
             assertTrue(error.getMessage().contains("placement '" + placement.name().toLowerCase() + "'"));
             assertTrue(error.getMessage().contains("cannot orient a horizontal-only state"));
         }
@@ -139,7 +139,7 @@ class LightPoolTest {
                 List.of(), List.of());
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> LightPool.compile(PALETTE_ID, 'L', settings));
+                () -> LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings));
         assertTrue(error.getMessage().contains("placement 'wall'"));
         assertTrue(error.getMessage().contains("cannot orient a hanging-only state to a wall"));
     }
@@ -152,7 +152,7 @@ class LightPoolTest {
                 """);
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> LightPool.compile(PALETTE_ID, 'L', settings));
+                () -> LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings));
         assertTrue(error.getMessage().contains("urbex:test_lights"));
         assertTrue(error.getMessage().contains("L"));
         assertTrue(error.getMessage().contains("ceiling"));
@@ -174,7 +174,7 @@ class LightPoolTest {
 
         BlockState expected = BuiltInRegistries.BLOCK.getValue(Identifier.parse("minecraft:soul_wall_torch"))
                 .defaultBlockState();
-        assertEquals(expected, LightPool.compile(PALETTE_ID, 'L', settings).representative());
+        assertEquals(expected, LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings).representative());
     }
 
     @Test
@@ -186,7 +186,7 @@ class LightPoolTest {
                   {"weight":1,"block":"minecraft:redstone_torch[lit=true]"}
                 ]}
                 """);
-        LightPool pool = LightPool.compile(PALETTE_ID, 'L', settings);
+        LightPool pool = LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings);
         List<LightPool.Candidate> order = pool.weightedOrder(LightPool.Placement.FLOOR, RandomSource.create(5L));
 
         List<Block> states = order.stream()
@@ -212,7 +212,7 @@ class LightPoolTest {
                 List.of(), List.of(), List.of());
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> LightPool.compile(PALETTE_ID, 'L', settings));
+                () -> LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings));
         assertTrue(error.getMessage().contains("urbex:test_lights"));
         assertTrue(error.getMessage().contains("L"));
         assertTrue(error.getMessage().contains("floor"));
@@ -226,7 +226,7 @@ class LightPoolTest {
                 List.of(), List.of(), List.of());
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> LightPool.compile(PALETTE_ID, 'L', settings));
+                () -> LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', settings));
         assertTrue(error.getMessage().contains("urbex:test_lights"));
         assertTrue(error.getMessage().contains("L"));
         assertTrue(error.getMessage().contains("floor"));
@@ -246,7 +246,7 @@ class LightPoolTest {
         PaletteRE paletteRE = result.result().orElseThrow()
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "legacy_torch"));
 
-        Palette.PE entry = new Palette(null, List.of(paletteRE)).getPalette().get('L');
+        Palette.PE entry = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteRE)).getPalette().get('L');
         assertInstanceOf(BlockState.class, entry.blocks());
         assertTrue(entry.info().isTorch());
         assertNull(entry.info().light());
@@ -267,7 +267,7 @@ class LightPoolTest {
         PaletteRE paletteRE = result.result().orElseThrow()
                 .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "typed_lights"));
 
-        Palette.PE entry = new Palette(null, List.of(paletteRE)).getPalette().get('L');
+        Palette.PE entry = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteRE)).getPalette().get('L');
         BlockState representative = assertInstanceOf(BlockState.class, entry.blocks());
         assertEquals(Blocks.SOUL_WALL_TORCH, representative.getBlock());
         assertTrue(entry.info().isSpecial());

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/OptionalLightPlacerTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/OptionalLightPlacerTest.java
@@ -3,6 +3,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 import dev.krona.urbex.worldgen.lost.regassets.data.LightSettings;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.util.RandomSource;
@@ -261,7 +262,7 @@ class OptionalLightPlacerTest {
                                   List<LightSettings.Entry> wall,
                                   List<LightSettings.Entry> ceiling,
                                   List<LightSettings.Entry> free) {
-        return LightPool.compile(PALETTE_ID, 'L', new LightSettings(floor, wall, ceiling, free));
+        return LightPool.compile(BuiltInRegistries.BLOCK, PALETTE_ID, 'L', new LightSettings(floor, wall, ceiling, free));
     }
 
     private static LightSettings.Entry entry(String block) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteExtendsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteExtendsTest.java
@@ -37,7 +37,7 @@ class PaletteExtendsTest {
                 entry('g', "minecraft:glass"));
         PaletteRE child = palette("child", entry('S', "minecraft:deepslate"));
 
-        Palette resolved = new Palette(null, List.of(parent, child));
+        Palette resolved = new Palette(BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
         assertEquals("minecraft:deepslate", blockOf(resolved, 'S'), "the child's character wins");
         assertEquals("minecraft:bricks", blockOf(resolved, 'b'), "characters it never mentions survive");
@@ -51,7 +51,7 @@ class PaletteExtendsTest {
         PaletteRE parent = palette("parent", entry('S', "minecraft:stone"));
         PaletteRE child = palette("child", entry('w', "minecraft:oak_planks"));
 
-        Palette resolved = new Palette(null, List.of(parent, child));
+        Palette resolved = new Palette(BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
         assertEquals(2, resolved.getPalette().size());
         assertEquals("minecraft:stone", blockOf(resolved, 'S'));
@@ -64,8 +64,8 @@ class PaletteExtendsTest {
         PaletteRE middle = palette("middle", entry('S', "minecraft:andesite"));
         PaletteRE leaf = palette("leaf", entry('S', "minecraft:deepslate"));
 
-        assertEquals("minecraft:deepslate", blockOf(new Palette(null, List.of(root, middle, leaf)), 'S'));
-        assertEquals("minecraft:andesite", blockOf(new Palette(null, List.of(root, middle)), 'S'));
+        assertEquals("minecraft:deepslate", blockOf(new Palette(BuiltInRegistries.BLOCK, null, List.of(root, middle, leaf)), 'S'));
+        assertEquals("minecraft:andesite", blockOf(new Palette(BuiltInRegistries.BLOCK, null, List.of(root, middle)), 'S'));
     }
 
     @Test
@@ -75,14 +75,14 @@ class PaletteExtendsTest {
         PaletteRE parent = palette("parent", damagedEntry('S', "minecraft:stone", "minecraft:cobblestone"));
         PaletteRE child = palette("child", entry('S', "minecraft:deepslate"));
 
-        Palette resolved = new Palette(null, List.of(parent, child));
+        Palette resolved = new Palette(BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
         assertNull(resolved.getDamaged().get(state("minecraft:stone")),
                 "the replaced parent entry must not leave its damaged mapping behind");
         assertEquals(1, resolved.getPalette().size());
 
         // ... and a mapping on a character nobody overrides is still there.
-        Palette parentOnly = new Palette(null, List.of(parent));
+        Palette parentOnly = new Palette(BuiltInRegistries.BLOCK, null, List.of(parent));
         assertNotNull(parentOnly.getDamaged().get(state("minecraft:stone")));
     }
 

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteVariantResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteVariantResolutionTest.java
@@ -46,7 +46,7 @@ class PaletteVariantResolutionTest {
 
     @Test
     void aVariantResolvesAgainstTheIndexThePaletteWasGiven() {
-        Palette compiled = new Palette(variantsWith("minecraft:deepslate"),
+        Palette compiled = new Palette(BuiltInRegistries.BLOCK, variantsWith("minecraft:deepslate"),
                 List.of(paletteNamingVariant()));
 
         assertEquals(List.of("minecraft:deepslate"), blocksOf(compiled, 'V'));
@@ -58,9 +58,9 @@ class PaletteVariantResolutionTest {
      */
     @Test
     void twoIndexesResolveTheSameVariantIdIndependently() {
-        Palette fromFirst = new Palette(variantsWith("minecraft:deepslate"),
+        Palette fromFirst = new Palette(BuiltInRegistries.BLOCK, variantsWith("minecraft:deepslate"),
                 List.of(paletteNamingVariant()));
-        Palette fromSecond = new Palette(variantsWith("minecraft:sandstone"),
+        Palette fromSecond = new Palette(BuiltInRegistries.BLOCK, variantsWith("minecraft:sandstone"),
                 List.of(paletteNamingVariant()));
 
         assertEquals(List.of("minecraft:deepslate"), blocksOf(fromFirst, 'V'));
@@ -77,7 +77,7 @@ class PaletteVariantResolutionTest {
     @Test
     void aVariantEntryWithNoVariantIndexFailsNamingWhatItWanted() {
         IllegalStateException failure = assertThrows(IllegalStateException.class,
-                () -> new Palette(null, List.of(paletteNamingVariant())));
+                () -> new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteNamingVariant())));
 
         assertTrue(failure.getMessage().contains("urbex:rubble"), failure.getMessage());
         assertTrue(failure.getMessage().contains("variant-palette"), failure.getMessage());
@@ -111,6 +111,6 @@ class PaletteVariantResolutionTest {
         VariantRE definition = new VariantRE(Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of(new BlockEntry(1, block)))));
         definition.setRegistryName(id);
-        return new AssetIndex<>("urbex:variants", Map.of(id, new Variant(List.of(definition))));
+        return new AssetIndex<>("urbex:variants", Map.of(id, new Variant(BuiltInRegistries.BLOCK, List.of(definition))));
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
@@ -243,12 +243,12 @@ class RegistryChainResolutionTest {
         VariantRE parent = variant("stones", true,
                 new BlockEntry(1, "minecraft:stone"), new BlockEntry(2, "minecraft:andesite"));
 
-        Variant replaced = new Variant(List.of(parent,
+        Variant replaced = new Variant(BuiltInRegistries.BLOCK, List.of(parent,
                 variant("stones_deep", true, new BlockEntry(3, "minecraft:deepslate"))));
         assertEquals(List.of("minecraft:deepslate"), blockIdsOf(replaced), "a bare array replaces");
         assertEquals(List.of(3), replaced.getBlocks().stream().map(org.apache.commons.lang3.tuple.Pair::getLeft).toList());
 
-        Variant appended = new Variant(List.of(parent,
+        Variant appended = new Variant(BuiltInRegistries.BLOCK, List.of(parent,
                 variant("stones_deep", false, new BlockEntry(3, "minecraft:deepslate"))));
         assertEquals(List.of("minecraft:stone", "minecraft:andesite", "minecraft:deepslate"),
                 blockIdsOf(appended), "{\"replace\": false} keeps the inherited blocks, in order");
@@ -380,7 +380,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildInheritsTheFillerAndPartsItDoesNotDeclare() {
-        Building resolved = new Building(null, PALETTES, List.of(
+        Building resolved = new Building(BuiltInRegistries.BLOCK, null, PALETTES, List.of(
                 building("library").filler("#").parts("urbex:library_floor").minFloors(2).build(),
                 building("library_burnt").rubble("R").build()));
 
@@ -393,13 +393,13 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildCanSetAnInheritedPrefersLonelyBackToZero() {
-        Building resolved = new Building(null, PALETTES, List.of(
+        Building resolved = new Building(BuiltInRegistries.BLOCK, null, PALETTES, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").prefersLonely(0.8f).build(),
                 building("tower_row").prefersLonely(0.0f).build()));
 
         assertEquals(0.0f, resolved.getPrefersLonely(),
                 "0.0 is a value a file can mean, not a marker for 'undeclared'");
-        assertEquals(0.8f, new Building(null, PALETTES, List.of(
+        assertEquals(0.8f, new Building(BuiltInRegistries.BLOCK, null, PALETTES, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").prefersLonely(0.8f).build(),
                 building("tower_row").build())).getPrefersLonely(),
                 "omitting it still inherits");
@@ -407,7 +407,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildCanSetAnInheritedFloorLimitBackToTheLevelDefault() {
-        Building resolved = new Building(null, PALETTES, List.of(
+        Building resolved = new Building(BuiltInRegistries.BLOCK, null, PALETTES, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").minFloors(4).build(),
                 building("tower_short").minFloors(-1).build()));
 


### PR DESCRIPTION
**128c** of #128 — block resolution at compile time. Phase 2 step 4 of epic #134.
Decomposition: [`docs/superpowers/specs/2026-08-12-asset-snapshot-design.md`](docs/superpowers/specs/2026-08-12-asset-snapshot-design.md).

> Stacked on #144 (128b). Review that first; this diff is against it.

## What was wrong

`Tools.stringToState` picked its own block registry:

```java
HolderLookup<Block> blocks = ServerAccess.getServer() == null
        ? BuiltInRegistries.BLOCK
        : WorldTools.getOverworld().holderLookup(Registries.BLOCK);
```

Both branches are the same registry — blocks are static and frozen at mod init, and a server's
`RegistryAccess` hands back the same `BuiltInRegistries.BLOCK` for `Registries.BLOCK`. So nothing was
ever *wrong*. But **which registry a datapack block string parsed against was decided by whether a
static server field happened to be populated yet**, not by the caller, and this was the last thing
outside the editor that asset compilation reached a `ServerAccess` for (#60).

## What changed

`AssetCompiler` takes the block lookup once, from the world it is compiling, and hands it down:

```
AssetCompiler → Variant
              → Palette (registered and inline) → LightPool
              → BuildingPart / Building (their inline palettes)
```

`WorldTools.getOverworld()` now has exactly one caller left: `EditModeData`, the editor.

`BlockResolutionTest` is the new part that could not have been written before — it builds a
`HolderLookup<Block>` containing only `minecraft:stone` and shows that `minecraft:diamond_block`
resolves to air against it, while the process-global registry three lines away has it. That is the
boundary, asserted rather than asserted-about.

## The unknown-id path: same behaviour, different shape

Unchanged: an id this Minecraft version does not have generates as **air**, with one warning per id.

What changed is how it gets there. It used to be an accident of `BuiltInRegistries.BLOCK` being a
`DefaultedRegistry`, whose `getValue` returns `minecraft:air` rather than null for an unknown key —
which is why the `"Cannot find block"` branch beneath it had never fired in its life, as the method's
own javadoc already stated at length. Air is an explicit `return` now and that dead branch is gone.

Two reasons this is worth doing here rather than leaving for #91:

- **#91 becomes a one-line change** at a `return` statement, instead of a registry quirk someone has
  to rediscover before they can change anything.
- **`BlockResolutionTest.anUnknownIdResolvesToAirRatherThanThrowing` pins today's answer**, so when
  #91 changes it, the change arrives as an edited test with a reason — not as a moved digest that
  someone has to work backwards from.

I checked the substitution empirically rather than by reading vanilla: `BuiltInRegistries.BLOCK` for a
key it does not have returns `Optional.empty` from `get(ResourceKey)`, `false` from `containsKey`, and
`Block{minecraft:air}` from `getValue(Identifier)`. Only the last is defaulted, which is why the
rewrite uses `get` and returns air itself.

## What is *not* in this PR

**#91 — optional/missing mod blocks.** Skipping a missing entry and re-normalising the weights over
the survivors is a semantic change that *will* move both goldens, so it is its own PR with its own
golden approval, per the epic's rules. This PR deliberately leaves the behaviour identical.

## Test churn

~50 call sites gained a `BuiltInRegistries.BLOCK` first argument. Two hand-built `RegistryAccess`
helpers in `AssetCompilerTest`/`AssetValidationTest` gained the block registry — a real world always
has it; an access assembled by hand has to say so.

## Verification

```
./gradlew test               # pass, 542 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK
```

**Both digest goldens are unchanged.** This changes where a block string's registry comes from, not
which block it names.
