### PR TITLE
feat: skip blocks this game does not have instead of failing (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- **A datapack naming a block you do not have still generates the rest of itself.** A block from an
+  uninstalled mod, or one a Minecraft version renamed, drops out of its weighted list and the blocks
+  that remain share its part of the draw; a palette character left with nothing generates as air.
+  Each absent id is named once in the log (issue #91).
+  - *The crash is gone.* A block string carrying properties — `somemod:fancy_block[facing=north]` —
+    threw out of the block-state parser, and since compilation moved to world load that refused the
+    **world**, not just the chunk. It is now the same skipped entry as any other.
+  - *And the silent hole is gone.* A plain id used to become air at its full weight, so a variant
+    meant as "mostly mossy cobble, occasionally something from another mod" placed air wherever the
+    missing entry won the draw. Dropping the entry is what re-normalises the weights: the survivors
+    are apportioned over the character's slots exactly as if the entry had never been written.
+  - *A typo does not refuse the world*, deliberately. The strict reading of #91 was considered and
+    rejected: a pack written around optional cross-mod blocks would then fail to load on a vanilla
+    install. The line is drawn at the block **id** — a property expression on a block you *do* have
+    is still a load error, because installing a mod cannot fix it.
+  - *No worldgen change*: both digest goldens are unchanged. Re-normalisation is only reachable when
+    something is actually dropped, and the bundled pack names no absent block — both digest runs
+    completed without logging a single one.
+
 - **Asset compilation resolves blocks against the world it is compiling, not against a static server
   reference.** Every block string in a palette, variant or light pool is resolved through a block
   registry the compiler hands down, taken once from the world being loaded (issue #128).

--- a/docs/superpowers/specs/2026-08-12-asset-snapshot-design.md
+++ b/docs/superpowers/specs/2026-08-12-asset-snapshot-design.md
@@ -105,6 +105,18 @@ users. Decide #91 (optional/missing mod blocks) here: "resolve blocks before pub
 aggregated diagnostics *is* the load-time validation #91 asks for, and its weight re-normalization
 over surviving entries is digest-affecting, so it needs its own golden approval.
 
+*Landed as two PRs.* The threading of the block lookup is mechanical and moved no golden; #91's
+semantics are separate. **#91 was decided skip-and-renormalise, never fail**: a block this game does
+not have drops out of its weighted list and the survivors share the draw, a character left with
+nothing generates as air, and each absent id is warned about once. The strict alternative — a typo
+refuses the world — was rejected because a pack written around optional cross-mod blocks would then
+refuse to load on a vanilla install. The line is drawn at the block *id*: a property expression on a
+block this game does have is still a load error, because no amount of installing mods fixes it.
+
+Neither golden moved after all. Re-normalisation is only reachable when something is actually
+dropped, and the bundled pack names no absent block — which `ShippedBlockIdsResolveTest` already
+required and both digest runs confirmed by logging no warning.
+
 **128d — rename `*RE` → `*Definition`/`*Patch`.** Mechanical only, no logic, so the rename noise
 never hides a semantic change. Also retires `IAsset.setRegistryName`: identity travels beside the
 decoded value instead of being written into it.
@@ -116,3 +128,7 @@ walk, which needs the compile-time palette merge 128a introduces. See the sequen
 
 128a, 128b and 128d must not move either golden: they relocate where compiled assets live, not what
 they compile to. 128c may move them via #91 and must isolate that.
+
+*Outcome:* nothing moved. Both goldens are `688914e862e938fb` and `7b5348f28e0a6d23` throughout
+128a–128c, including the #91 semantic change — see the note under 128c for why that is a fact about
+the bundled pack rather than a sign the change is inert.

--- a/src/main/java/dev/krona/urbex/varia/Tools.java
+++ b/src/main/java/dev/krona/urbex/varia/Tools.java
@@ -50,24 +50,12 @@ public class Tools {
     }
 
     /**
-     * Resolves a datapack block string against {@code blockLookup}, naming {@code owner} if it cannot be
-     * resolved.
+     * {@link #resolveState}, with air for a block this game does not have.
      * <p>
-     * <b>An unknown id returns air.</b> That is not a decision made here - it is what this has
-     * always done, and it is why {@code minecraft:chain} (renamed {@code minecraft:iron_chain} in
-     * 26.x) made the whole {@code urbex:chains} decoration invisible without anyone noticing. It
-     * used to happen by accident, through {@code BuiltInRegistries.BLOCK} being a
-     * {@link DefaultedRegistry} whose {@code getValue} hands back {@code minecraft:air} rather than
-     * null; it is spelled out below instead, so that #91 - which decides whether a missing block is
-     * a skipped entry, a load error, or air - has one line to change rather than a registry quirk to
-     * discover. The warning is the part that costs nothing and can move no golden, because the state
-     * returned is unchanged.
-     * <p>
-     * The pre-flattening {@code name@meta} form never reaches {@code upgradeBlock}:
-     * {@code Identifier.parse} throws for it first, {@code @} not being a legal path character - and
-     * {@code BlockStateData.upgradeBlock(String)} does not handle that form anyway (measured: it
-     * returns {@code minecraft:red_sandstone@2} unchanged). That is why the one such string the
-     * bundled pack shipped was a hard crash at palette compile rather than an automatic upgrade.
+     * For the callers that have one block to place and no list to fall back on: a palette's single
+     * {@code block}, and a light pool's stand-in state. An entry in a weighted list must use
+     * {@link #resolveState} and drop itself instead, so the survivors share the draw rather than
+     * competing with an invisible entry (issue #91).
      *
      * @param blockLookup what to resolve against, handed down from
      *                    {@link dev.krona.urbex.worldgen.lost.cityassets.AssetCompiler} out of the
@@ -86,35 +74,81 @@ public class Tools {
      *                    be null; every production caller passes one.
      */
     public static BlockState stringToState(String s, HolderLookup<Block> blockLookup, @Nullable Object owner) {
-        if (s.contains("[")) {
+        BlockState resolved = resolveState(s, blockLookup, owner);
+        return resolved == null ? Blocks.AIR.defaultBlockState() : resolved;
+    }
+
+    /**
+     * Resolves a datapack block string, or {@code null} if this game has no such block.
+     * <p>
+     * <b>Null is "this game does not have that block", not "this string is wrong".</b> The
+     * difference decides whether the world loads, so it is drawn at the block id and nowhere else:
+     * an id no installed mod provides, an id a Minecraft version renamed, and an id that is not even
+     * a legal {@link Identifier} are all null - while a block this game <em>does</em> have, written
+     * with a property expression it does not, still throws. That second case is a mistake in the
+     * file and nothing about installing a mod would fix it, so it keeps the load error and the
+     * message that names the palette, marker, placement and candidate.
+     * <p>
+     * A caller choosing from a weighted list drops a null entry and lets the survivors share the
+     * draw; a caller with one block to place uses air ({@link #stringToState}). Neither refuses the
+     * world, which is the decision issue #91 records: a pack naming one absent block generates the
+     * rest of itself.
+     * <p>
+     * Each distinct string is warned about once, however many entries name it, and that warning is
+     * the only report. This deliberately raises no load-time diagnostic: making an absent block
+     * refuse the world is the strict half of #91 and was not chosen, because a pack written around
+     * optional cross-mod blocks would then refuse to load on a vanilla install.
+     * <p>
+     * The pre-flattening {@code name@meta} form lands here as an unparseable id rather than as an
+     * upgrade: {@code @} is not a legal path character so {@link Identifier#tryParse} rejects it,
+     * and {@code BlockStateData.upgradeBlock(String)} does not handle that form anyway (measured: it
+     * returns {@code minecraft:red_sandstone@2} unchanged). It used to take the whole world load
+     * with it from inside {@code Palette}'s constructor.
+     */
+    @Nullable
+    public static BlockState resolveState(String s, HolderLookup<Block> blockLookup, @Nullable Object owner) {
+        int properties = s.indexOf('[');
+        Identifier id = Identifier.tryParse(properties < 0 ? s : s.substring(0, properties));
+        if (id == null) {
+            return missing(s, owner);
+        }
+        boolean known = blockLookup.get(ResourceKey.create(Registries.BLOCK, id)).isPresent();
+
+        if (properties >= 0) {
+            if (!known) {
+                // The crash half of #91: a property-carrying string whose block is absent threw out
+                // of the parser below, and since compilation moved to load time that refused the
+                // whole world rather than one chunk.
+                return missing(s, owner);
+            }
             try {
-                BlockStateParser.BlockResult parser = BlockStateParser.parseForBlock(blockLookup, new StringReader(s), false);
-                return parser.blockState();
+                return BlockStateParser.parseForBlock(blockLookup, new StringReader(s), false).blockState();
             } catch (CommandSyntaxException e) {
                 throw new RuntimeException(e);
             }
         }
 
-        Optional<Holder.Reference<Block>> requested = blockLookup.get(blockKey(s));
-        if (requested.isPresent()) {
-            return requested.get().value().defaultBlockState();
+        if (known) {
+            return blockLookup.getOrThrow(ResourceKey.create(Registries.BLOCK, id)).value().defaultBlockState();
         }
-
-        Optional<Holder.Reference<Block>> upgraded = blockLookup.get(blockKey(BlockStateData.upgradeBlock(s)));
-        if (upgraded.isPresent()) {
-            return upgraded.get().value().defaultBlockState();
-        }
-        if (WARNED_MISSING_BLOCKS.add(s)) {
-            Urbex.LOGGER.warn(
-                    "Block '{}'{} does not exist in this Minecraft version; it will generate as air. " +
-                            "It was most likely renamed - check the current id and update the asset.",
-                    s, owner == null ? "" : " (in " + owner + ")");
-        }
-        return Blocks.AIR.defaultBlockState();
+        Identifier upgradedId = Identifier.tryParse(BlockStateData.upgradeBlock(s));
+        Optional<Holder.Reference<Block>> upgraded = upgradedId == null
+                ? Optional.empty()
+                : blockLookup.get(ResourceKey.create(Registries.BLOCK, upgradedId));
+        return upgraded.map(block -> block.value().defaultBlockState()).orElseGet(() -> missing(s, owner));
     }
 
-    private static ResourceKey<Block> blockKey(String id) {
-        return ResourceKey.create(Registries.BLOCK, Identifier.parse(id));
+    @Nullable
+    private static BlockState missing(String s, @Nullable Object owner) {
+        if (WARNED_MISSING_BLOCKS.add(s)) {
+            Urbex.LOGGER.warn(
+                    "Block '{}'{} does not exist in this Minecraft version. Entries naming it are "
+                            + "skipped and the remaining ones share the draw; a palette character "
+                            + "left with nothing generates as air. If this is not a block from an "
+                            + "uninstalled mod, it was most likely renamed - check the current id.",
+                    s, owner == null ? "" : " (in " + owner + ")");
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/LightPool.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/LightPool.java
@@ -10,6 +10,8 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -42,15 +44,31 @@ public final class LightPool {
         this.allCandidates = List.copyOf(flattened);
     }
 
+    /**
+     * Compiles one marker's light pool, or returns {@code null} when every candidate it declared
+     * names a block this game does not have.
+     * <p>
+     * Null and empty are different answers and only one of them is the author's fault. A pool that
+     * declares no candidates anywhere is a mistake in the file and still refuses the world naming
+     * it; a pool whose candidates all came from an uninstalled mod is issue #91's case, and refusing
+     * the world over that is exactly what #91 says not to do. Before this, an absent block resolved
+     * to air and was rejected two lines later for emitting no light - a load error that named the
+     * right file and gave entirely the wrong reason.
+     */
+    @Nullable
     public static LightPool compile(HolderLookup<Block> blockLookup, Identifier paletteId, char marker,
                                     LightSettings settings) {
         EnumMap<Placement, List<Candidate>> candidates = new EnumMap<>(Placement.class);
         EnumMap<Placement, Integer> totalWeights = new EnumMap<>(Placement.class);
-        compileGroup(blockLookup, paletteId, marker, Placement.FLOOR, settings.floor(), candidates, totalWeights);
-        compileGroup(blockLookup, paletteId, marker, Placement.WALL, settings.wall(), candidates, totalWeights);
-        compileGroup(blockLookup, paletteId, marker, Placement.CEILING, settings.ceiling(), candidates, totalWeights);
-        compileGroup(blockLookup, paletteId, marker, Placement.FREE, settings.free(), candidates, totalWeights);
+        boolean[] dropped = new boolean[1];
+        compileGroup(blockLookup, paletteId, marker, Placement.FLOOR, settings.floor(), candidates, totalWeights, dropped);
+        compileGroup(blockLookup, paletteId, marker, Placement.WALL, settings.wall(), candidates, totalWeights, dropped);
+        compileGroup(blockLookup, paletteId, marker, Placement.CEILING, settings.ceiling(), candidates, totalWeights, dropped);
+        compileGroup(blockLookup, paletteId, marker, Placement.FREE, settings.free(), candidates, totalWeights, dropped);
         if (candidates.values().stream().allMatch(List::isEmpty)) {
+            if (dropped[0]) {
+                return null;
+            }
             throw new IllegalArgumentException("Invalid light pool in palette '" + paletteId + "', marker '" + marker
                     + "': expected at least one candidate in floor, wall, ceiling, or free");
         }
@@ -109,7 +127,8 @@ public final class LightPool {
                                      char marker, Placement placement,
                                      List<LightSettings.Entry> entries,
                                      Map<Placement, List<Candidate>> candidates,
-                                     Map<Placement, Integer> totalWeights) {
+                                     Map<Placement, Integer> totalWeights,
+                                     boolean[] dropped) {
         List<Candidate> compiled = new ArrayList<>(entries.size());
         int totalWeight = 0;
         for (int candidateIndex = 0; candidateIndex < entries.size(); candidateIndex++) {
@@ -118,12 +137,21 @@ public final class LightPool {
                 throw invalidCandidate(paletteId, marker, placement, candidateIndex, entry.block(),
                         "weight must be positive", null);
             }
+            // Dropped rather than rejected: a candidate list is a weighted draw like any other, so
+            // an absent block hands its weight to the lights this game does have (issue #91). Null
+            // and thrown are different answers here - resolveState only returns null for a block
+            // this game does not have, and still throws for a property expression that is wrong
+            // whatever is installed, which is what keeps this candidate's context in the message.
             BlockState state;
             try {
-                state = Tools.stringToState(entry.block(), blockLookup, paletteId);
+                state = Tools.resolveState(entry.block(), blockLookup, paletteId);
             } catch (RuntimeException e) {
                 throw invalidCandidate(paletteId, marker, placement, candidateIndex, entry.block(),
                         "cannot parse block state", e);
+            }
+            if (state == null) {
+                dropped[0] = true;
+                continue;
             }
             if (state.getLightEmission() <= 0) {
                 throw invalidCandidate(paletteId, marker, placement, candidateIndex, entry.block(),

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
@@ -9,6 +9,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -143,10 +144,13 @@ public class Palette {
                          Collection<PaletteEntry> entries) {
         for (PaletteEntry entry : entries) {
             Character c = entry.getChr().charAt(0);
-            BlockState dmg = null;
-            if (entry.getDamaged() != null) {
-                dmg = Tools.stringToState(entry.getDamaged(), blockLookup, name);
-            }
+            // Null when the damaged block is absent from this game, so the mapping is simply not
+            // written. Air would say "damaging this block deletes it", which is a claim the author
+            // did not make (issue #91).
+            BlockState dmg = entry.getDamaged() == null ? null
+                    : Tools.resolveState(entry.getDamaged(), blockLookup, name);
+            // Also null when every candidate in the pool named an absent block; see
+            // LightPool.compile. An authored-empty pool is still a load error.
             LightPool light = entry.getLight() == null ? null
                     : LightPool.compile(blockLookup, name, c, entry.getLight());
             Info info = new Info(entry.getMob(), entry.getLoot(),
@@ -189,7 +193,14 @@ public class Palette {
                 for (BlockEntry ob : entryBlocks) {
                     Integer f = ob.random();
                     String block = ob.block();
-                    BlockState state = Tools.stringToState(block, blockLookup, name);
+                    // Dropped rather than placed as air, exactly as in a variant: the weights that
+                    // remain are apportioned over the character's 128 slots by
+                    // CompiledPalette.distributeSlots, so the survivors take over the missing
+                    // entry's share instead of competing with invisible blocks (issue #91).
+                    BlockState state = Tools.resolveState(block, blockLookup, name);
+                    if (state == null) {
+                        continue;
+                    }
                     blocks.add(Pair.of(f, state));
                     if (dmg != null) {
                         damaged.put(state, dmg);
@@ -198,13 +209,32 @@ public class Palette {
                 addMappingViaState(c, blocks, info);
             } else if (light != null) {
                 palette.put(c, new PE(light.representative(), info));
+            } else if (entry.getLight() != null) {
+                // A light-only entry whose whole pool named absent blocks. The marker still has to
+                // map to something - a character with no entry at all throws from the driver, which
+                // is the crash issue #91 is removing - and air is what a light that cannot be placed
+                // leaves behind anyway.
+                palette.put(c, new PE(Blocks.AIR.defaultBlockState(), info));
             } else {
                 throw new RuntimeException("Illegal palette " + name + "!");
             }
         }
     }
 
+    /**
+     * Maps {@code c} to a weighted list, or to air when nothing is left in it.
+     * <p>
+     * The empty case is reachable only through issue #91: every block the character named is absent
+     * from this game. It has to be handled here rather than left to
+     * {@code CompiledPalette.distributeSlots}, which refuses weights summing to zero - correctly, for
+     * an authored list - and it has to be air rather than no entry at all, because a character the
+     * palette does not map throws from the driver on the first part that uses it.
+     */
     private Palette addMappingViaState(char c, List<Pair<Integer, BlockState>> randomBlocks, Info info) {
+        if (randomBlocks.isEmpty()) {
+            palette.put(c, new PE(Blocks.AIR.defaultBlockState(), info));
+            return this;
+        }
         palette.put(c, new PE(randomBlocks.toArray(new Pair[randomBlocks.size()]), info));
         return this;
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Variant.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Variant.java
@@ -42,8 +42,15 @@ public class Variant {
         }
         Resolved.require(anyBlocks ? entries : null, name, "blocks");
         for (BlockEntry entry : entries) {
-            BlockState state = Tools.stringToState(entry.block(), blockLookup, name);
-            blocks.add(Pair.of(entry.random(), state));
+            BlockState state = Tools.resolveState(entry.block(), blockLookup, name);
+            // Skipped rather than placed as air: this is a weighted list, so dropping the entry
+            // hands its share of the draw to the blocks this game does have, while air at full
+            // weight would punch holes in whatever the variant paints (issue #91). A chain whose
+            // every block is absent resolves to an empty list, which the palette turns into air for
+            // that character - a load error here would refuse the world over an uninstalled mod.
+            if (state != null) {
+                blocks.add(Pair.of(entry.random(), state));
+            }
         }
     }
 

--- a/src/test/java/dev/krona/urbex/varia/BlockResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/varia/BlockResolutionTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -32,6 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * in it (issues #60, #128). It is a parameter now, handed down by {@code AssetCompiler} from the
  * world being loaded, and {@link #resolutionAnswersFromTheLookupItIsGivenNotAGlobalOne} is what
  * makes that a fact rather than a claim.
+ * <p>
+ * The other half of this file is where issue #91 draws its line: a block this game does not have is
+ * absent (dropped from a weighted list, air where there is no list), and a block it does have
+ * written with a property it does not is still a load error.
  */
 class BlockResolutionTest {
 
@@ -59,23 +64,49 @@ class BlockResolutionTest {
     }
 
     /**
-     * The behaviour #91 exists to change, pinned here so that when it does change this test is what
-     * has to be edited — rather than the change being discovered from a moved digest.
-     * <p>
-     * An id this Minecraft version does not have generates as air, silently as far as the world is
-     * concerned and with one warning in the log. That is how {@code minecraft:chain} (renamed
-     * {@code minecraft:iron_chain} in 26.x) made the whole {@code urbex:chains} decoration invisible.
+     * A block this game does not have is {@code null} from {@link Tools#resolveState} and air from
+     * {@link Tools#stringToState} — never an exception, whether or not the string carries
+     * properties. The property-carrying form is the one that used to throw, and since compilation
+     * moved to load time that threw took the whole world with it rather than one chunk (issue #91).
      */
     @Test
-    void anUnknownIdResolvesToAirRatherThanThrowing() {
+    void anAbsentBlockIsNullRatherThanAThrow() {
+        assertNull(Tools.resolveState("somemod:no_such_block", BuiltInRegistries.BLOCK, OWNER));
+        assertNull(Tools.resolveState("somemod:no_such_block[facing=north]", BuiltInRegistries.BLOCK, OWNER));
+
         assertSame(Blocks.AIR.defaultBlockState(),
                 Tools.stringToState("somemod:no_such_block", BuiltInRegistries.BLOCK, OWNER));
+        assertSame(Blocks.AIR.defaultBlockState(),
+                Tools.stringToState("somemod:no_such_block[facing=north]", BuiltInRegistries.BLOCK, OWNER));
+    }
+
+    /**
+     * The line #91 draws, and the reason it is drawn at the block id: a property expression this
+     * game does not have, on a block it <em>does</em>, is a mistake in the file. No amount of
+     * installing mods fixes it, so it stays a load error — which is what keeps {@code LightPool}'s
+     * candidate diagnostics working.
+     */
+    @Test
+    void aBadPropertyOnAKnownBlockIsStillAnError() {
+        assertThrows(RuntimeException.class,
+                () -> Tools.resolveState("minecraft:torch[not_a_property=true]", BuiltInRegistries.BLOCK, OWNER));
+    }
+
+    /**
+     * A string that is not even a legal id resolves as absent rather than throwing. The bundled pack
+     * shipped one — {@code minecraft:red_sandstone@2}, a 1.12 {@code name@meta} string — and because
+     * {@code Identifier.parse} threw on it from inside {@code Palette}'s constructor, it took the
+     * world load with it.
+     */
+    @Test
+    void anIdThatIsNotEvenLegalResolvesAsAbsent() {
+        assertNull(Tools.resolveState("minecraft:red_sandstone@2", BuiltInRegistries.BLOCK, OWNER));
     }
 
     /**
      * The boundary itself: a lookup that does not have the block answers "not here", even though the
-     * process-global registry three lines away does have it. Before this change there was no way to
-     * write this test, because there was no way to say which registry to ask.
+     * process-global registry three lines away does have it. Before the lookup became a parameter
+     * there was no way to write this test, because there was no way to say which registry to ask.
      */
     @Test
     void resolutionAnswersFromTheLookupItIsGivenNotAGlobalOne() {
@@ -83,12 +114,10 @@ class BlockResolutionTest {
 
         assertSame(Blocks.STONE.defaultBlockState(),
                 Tools.stringToState("minecraft:stone", onlyStone, OWNER));
-        assertSame(Blocks.AIR.defaultBlockState(),
-                Tools.stringToState("minecraft:diamond_block", onlyStone, OWNER),
+        assertNull(Tools.resolveState("minecraft:diamond_block", onlyStone, OWNER),
                 "BuiltInRegistries has diamond_block; the lookup handed in does not");
-        assertThrows(RuntimeException.class,
-                () -> Tools.stringToState("minecraft:oak_stairs[facing=east]", onlyStone, OWNER),
-                "and the property-parsing path asks the same lookup");
+        assertNull(Tools.resolveState("minecraft:oak_stairs[facing=east]", onlyStone, OWNER),
+                "and the property-carrying form asks the same lookup for its block");
     }
 
     private static HolderLookup<Block> registryOf(String path, Block block) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/MissingBlocksAreSkippedTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/MissingBlocksAreSkippedTest.java
@@ -1,0 +1,186 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
+import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A pack that names a block this game does not have generates the rest of itself (issue #91).
+ * <p>
+ * Two failure modes were in play before this. A block string carrying properties threw
+ * {@code CommandSyntaxException} out of the parser, and since #128 moved compilation to load time
+ * that refused the <em>world</em> rather than one chunk. A plain id silently became air — at its
+ * full weight, so a variant meant as "mostly mossy cobble, occasionally somemod:fancy_moss" put
+ * holes wherever the missing entry won its share of the draw.
+ * <p>
+ * Both are now the same answer: the entry drops out of its weighted list and the blocks that remain
+ * take over its share. Re-normalisation needs no arithmetic here — {@code CompiledPalette} apportions
+ * the character's 128 slots over whatever weights it is given, so removing an entry <em>is</em>
+ * re-normalising. A character left with nothing at all generates as air, because a character the
+ * palette does not map throws from the driver on the first part that uses it.
+ * <p>
+ * The line is drawn at the block id: see {@code BlockResolutionTest} for why a bad property on a
+ * block this game <em>does</em> have is still a load error.
+ */
+class MissingBlocksAreSkippedTest {
+
+    private static final String ABSENT = "somemod:no_such_block";
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void aVariantKeepsTheBlocksThisGameHas() {
+        Variant variant = new Variant(BuiltInRegistries.BLOCK, List.of(variantOf(
+                new BlockEntry(3, "minecraft:mossy_cobblestone"),
+                new BlockEntry(1, ABSENT),
+                new BlockEntry(2, "minecraft:stone"))));
+
+        assertEquals(List.of(
+                        Pair.of(3, Blocks.MOSSY_COBBLESTONE.defaultBlockState()),
+                        Pair.of(2, Blocks.STONE.defaultBlockState())),
+                variant.getBlocks(),
+                "the absent entry is gone and the survivors keep their authored weights - the "
+                        + "draw is over their total, so they have absorbed its share");
+    }
+
+    @Test
+    void aWeightedPaletteEntryKeepsTheBlocksThisGameHas() {
+        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+                weighted('r', new BlockEntry(1, ABSENT), new BlockEntry(1, "minecraft:gravel")))));
+
+        Pair<Integer, BlockState>[] blocks = weightedBlocksOf(palette, 'r');
+        assertEquals(1, blocks.length);
+        assertSame(Blocks.GRAVEL.defaultBlockState(), blocks[0].getRight());
+    }
+
+    /**
+     * The property-carrying form, which is the half of #91 that used to be a crash rather than a
+     * silent hole.
+     */
+    @Test
+    void aPropertyCarryingEntryFromAMissingModIsSkippedRatherThanThrowing() {
+        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+                weighted('r', new BlockEntry(1, ABSENT + "[facing=north]"),
+                        new BlockEntry(1, "minecraft:gravel")))));
+
+        Pair<Integer, BlockState>[] blocks = weightedBlocksOf(palette, 'r');
+        assertEquals(1, blocks.length);
+        assertSame(Blocks.GRAVEL.defaultBlockState(), blocks[0].getRight());
+    }
+
+    @Test
+    void aCharacterLeftWithNothingGeneratesAsAir() {
+        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+                weighted('r', new BlockEntry(1, ABSENT), new BlockEntry(1, "othermod:also_absent")))));
+
+        Palette.PE entry = palette.getPalette().get('r');
+        assertNotNull(entry, "the character still has to map to something: one the palette does not "
+                + "map throws from the driver on the first part that uses it");
+        assertSame(Blocks.AIR.defaultBlockState(), entry.blocks());
+    }
+
+    /** A variant whose every block is absent reaches the palette as an empty list, not as a crash. */
+    @Test
+    void aVariantWithNothingLeftReachesThePaletteAsAir() {
+        Variant emptied = new Variant(BuiltInRegistries.BLOCK,
+                List.of(variantOf(new BlockEntry(1, ABSENT))));
+        assertTrue(emptied.getBlocks().isEmpty());
+
+        AssetIndex<Variant> variants = new AssetIndex<>("urbex:variants",
+                Map.of(Identifier.fromNamespaceAndPath("urbex", "gone"), emptied));
+        Palette palette = new Palette(BuiltInRegistries.BLOCK, variants, List.of(paletteOf(
+                namingVariant('v', "urbex:gone"))));
+
+        assertSame(Blocks.AIR.defaultBlockState(), palette.getPalette().get('v').blocks());
+    }
+
+    /**
+     * A single {@code block} has no list to fall back on, so it is air — as it always was, except
+     * that the property-carrying form used to throw instead.
+     */
+    @Test
+    void aSingleBlockThatIsAbsentIsAir() {
+        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+                single('x', ABSENT), single('y', ABSENT + "[facing=north]"))));
+
+        assertSame(Blocks.AIR.defaultBlockState(), palette.getPalette().get('x').blocks());
+        assertSame(Blocks.AIR.defaultBlockState(), palette.getPalette().get('y').blocks());
+    }
+
+    /**
+     * An absent {@code damaged} block leaves no mapping at all rather than mapping to air. Air would
+     * say "damaging this block deletes it", which is a claim the author never made.
+     */
+    @Test
+    void anAbsentDamagedBlockLeavesNoMapping() {
+        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+                damaged('S', "minecraft:stone", ABSENT))));
+
+        assertTrue(palette.getDamaged().isEmpty());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Pair<Integer, BlockState>[] weightedBlocksOf(Palette palette, char marker) {
+        Palette.PE entry = palette.getPalette().get(marker);
+        assertNotNull(entry, () -> "No palette entry for marker '" + marker + "'");
+        return (Pair<Integer, BlockState>[]) entry.blocks();
+    }
+
+    private static VariantRE variantOf(BlockEntry... blocks) {
+        return new VariantRE(Optional.empty(), Optional.of(new Mergeable<>(true, List.of(blocks))))
+                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_variant"));
+    }
+
+    private static PaletteRE paletteOf(PaletteEntry... entries) {
+        return new PaletteRE(Optional.empty(), Optional.of(List.of(entries)))
+                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_palette"));
+    }
+
+    private static PaletteEntry single(char marker, String block) {
+        return new PaletteEntry(Character.toString(marker), Optional.of(block),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    private static PaletteEntry damaged(char marker, String block, String damagedBlock) {
+        return new PaletteEntry(Character.toString(marker), Optional.of(block),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(damagedBlock),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    private static PaletteEntry weighted(char marker, BlockEntry... blocks) {
+        return new PaletteEntry(Character.toString(marker), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.of(List.of(blocks)), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    private static PaletteEntry namingVariant(char marker, String variant) {
+        return new PaletteEntry(Character.toString(marker), Optional.empty(),
+                Optional.of(variant), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+}


### PR DESCRIPTION
Closes #91. The semantic half of **128c** (#128), phase 2 of epic #134.

> Stacked on #145, which is stacked on #144. This diff is against #145.

## What was wrong

A palette or variant naming a block this installation does not have — an uninstalled mod, or a
vanilla id a Minecraft version renamed — failed in one of two ways, and both were wrong:

1. **With properties** (`somemod:fancy_block[facing=north]`): `BlockStateParser` threw
   `CommandSyntaxException`. Since #128 moved compilation to world load, that refuses the **world**,
   not one chunk. One optional block from one mod, and the save will not open.
2. **Without** (`somemod:fancy_block`): the id silently became air **at its full weight**. A variant
   written as "mostly mossy cobble, occasionally `somemod:fancy_moss`" placed holes wherever the
   missing entry won the draw — worse than the block simply not being there.

## What changed

`Tools.resolveState` returns `null` for a block this game does not have. An entry in a weighted list
drops itself; a caller with one block and no list uses air (`stringToState`).

**Re-normalisation needs no arithmetic.** `CompiledPalette.distributeSlots` apportions a character's
128 slots over whatever weights it is handed, so removing an entry *is* re-normalising — the
survivors are laid out exactly as if the absent entry had never been written. That is worth stating
because it is the reason this PR has no weight maths in it to get wrong.

Three consequences that are decisions, not fallout:

- **A character left with nothing maps to air**, not to nothing. A character the palette does not map
  throws from the driver on the first part that uses it, which is the crash this issue is removing.
- **An absent `damaged` block leaves no mapping** rather than mapping to air. Air would assert
  "damaging this block deletes it", which the author never wrote.
- **A light pool whose every candidate is absent compiles to `null`**, and its marker maps to air.
  Before, the absent block resolved to air and was rejected two lines later for *emitting no light* —
  a load error naming the right file and giving entirely the wrong reason. An **authored**-empty pool
  is still a load error; the two cases are told apart rather than merged.

## The line is drawn at the block id, and that is the part to review

`resolveState` returns null only when the **block** is absent. A block this game *does* have, written
with a property expression it does not (`minecraft:torch[not_a_property=true]`), still throws.

No amount of installing mods fixes a bad property — it is a mistake in the file, and treating it as
"maybe you're missing a mod" would have deleted `LightPool`'s candidate diagnostics, which name the
palette, marker, placement and candidate index. `LightPoolTest.malformedStateReportsFullCandidateContext`
is what caught me merging the two cases in the first draft.

## What was *not* chosen

**Strict: an unresolvable id refuses the world.** Rejected — a pack written around optional cross-mod
blocks would fail to load on a vanilla install, which is the situation #91 exists to make workable.
The consequence is honest and worth naming: **a typo in a block id is still only a log line.** The
bundled pack is protected from that by `ShippedBlockIdsResolveTest`, which requires every id it ships
to resolve; third-party packs get the warning and a visible hole.

**An opt-in `optional: true` field.** Not added. It would let a pack distinguish "deliberately
cross-mod" from "typo" and re-enable strictness for the rest — but it is a schema change that only
pays off alongside the strict default, which was not chosen.

## Verification

```
./gradlew test               # pass, 551 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK
```

**Both digest goldens are unchanged, and that is not evidence the change is inert.** Re-normalisation
is only reachable when something is actually dropped, and the bundled pack names no absent block —
`ShippedBlockIdsResolveTest` requires it, and both digest runs confirmed it independently by
completing without logging a single missing-block warning. The behaviour change is covered by
`MissingBlocksAreSkippedTest` and `BlockResolutionTest` instead, which is where a change to it will
show up.
