### PR TITLE
refactor: a compiled asset takes its id instead of being told it (#128, 128d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Compilation no longer writes registry ids into the definitions it reads.** A compiled asset takes
+  its id as a constructor argument, from the compiler that already has it, instead of reading it off
+  a definition that `IAsset.setRegistryName` had written it into on the way past. The interface, the
+  setter and the field on all thirteen definition types are gone (issue #128).
+  - *Compiling a datapack was mutating the authored model.* Resolving an `extends` chain assigned
+    each link's registry id onto the decoded object, so an entry's identity depended on something
+    having walked a chain that reached it — and two compilations of the same registry were writing
+    to the same objects.
+  - *No worldgen change*: both digest goldens are unchanged. The id an asset ends up with is the same
+    one; only the direction it travels changed.
+
 - **A datapack naming a block you do not have still generates the rest of itself.** A block from an
   uninstalled mod, or one a Minecraft version renamed, drops out of its weighted list and the blocks
   that remain share its part of the draw; a palette character left with nothing generates as air.

--- a/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
@@ -160,7 +160,7 @@ public class NullDimensionInfo implements IDimensionInfo {
                 }
             }
             resolvedEntries.add(new WorldStyleField.Weighted(entry.weight(),
-                    resolved != null ? resolved : new WorldStyle(List.of(placeholderStyle()))));
+                    resolved != null ? resolved : new WorldStyle(PLACEHOLDER_ID, List.of(placeholderStyle()))));
         }
         styles = new WorldStyleField(seed, resolvedEntries);
         this.seed = seed;
@@ -188,6 +188,10 @@ public class NullDimensionInfo implements IDimensionInfo {
      * samples biomes, city placement, road classes and rail/highway chunk <em>types</em>, none of
      * which reads a part name. Naming real parts here would be a claim about a datapack that, on
      * this path, either isn't loaded or doesn't have the style the player asked for.
+     * <p>
+     * It carries no id, because a decoded world style no longer carries one: {@link #PLACEHOLDER_ID}
+     * is handed to the {@link WorldStyle} constructor beside this, which is where a load error looking
+     * for a name will find it (issue #128).
      */
     private static WorldStyleRE placeholderStyle() {
         return new WorldStyleRE(
@@ -213,9 +217,7 @@ public class NullDimensionInfo implements IDimensionInfo {
                 // No 'rotatable': the preview places no parts, so nothing is ever rotated, and
                 // naming a tag here would be a claim about a datapack this path has not loaded.
                 Optional.empty()
-                // Named, so the load error names this placeholder rather than 'null' if a field is
-                // ever added to the required set and not added here.
-        ).setRegistryName(PLACEHOLDER_ID);
+        );
     }
 
     /** One wiring component, declared as empty: the preview places no parts. */

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
@@ -72,23 +72,23 @@ public final class AssetCompiler {
         // been populated by the time it ran (issues #60, #128).
         HolderLookup<Block> blockLookup = access.lookupOrThrow(Registries.BLOCK);
         AssetIndex<Variant> variants = AssetStage.compileAll(access,
-                CustomRegistries.VARIANTS_REGISTRY_KEY, (id, chain) -> new Variant(blockLookup, chain), diagnostics);
+                CustomRegistries.VARIANTS_REGISTRY_KEY, (id, chain) -> new Variant(id, blockLookup, chain), diagnostics);
         AssetIndex<Palette> palettes = AssetStage.compileAll(access,
-                CustomRegistries.PALETTE_REGISTRY_KEY, (id, chain) -> new Palette(blockLookup, variants, chain), diagnostics);
+                CustomRegistries.PALETTE_REGISTRY_KEY, (id, chain) -> new Palette(id, blockLookup, variants, chain), diagnostics);
         AssetIndex<Condition> conditions = AssetStage.compileAll(access,
-                CustomRegistries.CONDITIONS_REGISTRY_KEY, (id, chain) -> new Condition(chain), diagnostics);
+                CustomRegistries.CONDITIONS_REGISTRY_KEY, (id, chain) -> new Condition(id, chain), diagnostics);
         AssetIndex<Style> styles = AssetStage.compileAll(access,
-                CustomRegistries.STYLE_REGISTRY_KEY, (id, chain) -> new Style(palettes, chain), diagnostics);
+                CustomRegistries.STYLE_REGISTRY_KEY, (id, chain) -> new Style(id, palettes, chain), diagnostics);
         AssetIndex<BuildingPart> parts = AssetStage.compileAll(access,
-                CustomRegistries.PART_REGISTRY_KEY, (id, chain) -> new BuildingPart(blockLookup, variants, palettes, chain), diagnostics);
+                CustomRegistries.PART_REGISTRY_KEY, (id, chain) -> new BuildingPart(id, blockLookup, variants, palettes, chain), diagnostics);
         AssetIndex<Building> buildings = AssetStage.compileAll(access,
-                CustomRegistries.BUILDING_REGISTRY_KEY, (id, chain) -> new Building(blockLookup, variants, palettes, chain), diagnostics);
+                CustomRegistries.BUILDING_REGISTRY_KEY, (id, chain) -> new Building(id, blockLookup, variants, palettes, chain), diagnostics);
         AssetIndex<MultiBuilding> multiBuildings = AssetStage.compileAll(access,
-                CustomRegistries.MULTIBUILDINGS_REGISTRY_KEY, (id, chain) -> new MultiBuilding(chain), diagnostics);
+                CustomRegistries.MULTIBUILDINGS_REGISTRY_KEY, (id, chain) -> new MultiBuilding(id, chain), diagnostics);
         AssetIndex<ScatteredBuilding> scattered = AssetStage.compileAll(access,
-                CustomRegistries.SCATTERED_REGISTRY_KEY, (id, chain) -> new ScatteredBuilding(chain), diagnostics);
+                CustomRegistries.SCATTERED_REGISTRY_KEY, (id, chain) -> new ScatteredBuilding(id, chain), diagnostics);
         AssetIndex<WorldStyle> worldStyles = AssetStage.compileAll(access,
-                CustomRegistries.WORLDSTYLES_REGISTRY_KEY, (id, chain) -> new WorldStyle(chain), diagnostics);
+                CustomRegistries.WORLDSTYLES_REGISTRY_KEY, (id, chain) -> new WorldStyle(id, chain), diagnostics);
         // City styles are the one kind where "failed to compile" is not the same as "wrong", so they
         // are compiled into a local report and only the reachable failures are promoted into the
         // caller's. Requiredness is a property of the end of a chain, and a city style may exist only
@@ -98,11 +98,11 @@ public final class AssetCompiler {
         // exactly what an earlier draft of this compiler did.
         AssetDiagnostics cityStyleProblems = new AssetDiagnostics();
         AssetIndex<CityStyle> cityStyles = AssetStage.compileAll(access,
-                CustomRegistries.CITYSTYLES_REGISTRY_KEY, (id, chain) -> new CityStyle(chain), cityStyleProblems);
+                CustomRegistries.CITYSTYLES_REGISTRY_KEY, (id, chain) -> new CityStyle(id, chain), cityStyleProblems);
         AssetIndex<PredefinedCity> predefinedCities = AssetStage.compileAll(access,
-                CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY, (id, chain) -> new PredefinedCity(chain), diagnostics);
+                CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY, (id, chain) -> new PredefinedCity(id, chain), diagnostics);
         AssetIndex<StuffObject> stuff = AssetStage.compileAll(access,
-                CustomRegistries.STUFF_REGISTRY_KEY, (id, chain) -> new StuffObject(chain), diagnostics);
+                CustomRegistries.STUFF_REGISTRY_KEY, (id, chain) -> new StuffObject(id, chain), diagnostics);
 
         promoteReachableCityStyleProblems(access, worldStyles, cityStyles, cityStyleProblems, diagnostics);
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetStage.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetStage.java
@@ -1,7 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.worldgen.lost.regassets.Extendable;
-import dev.krona.urbex.worldgen.lost.regassets.IAsset;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
@@ -55,21 +54,16 @@ final class AssetStage {
     /**
      * The {@code extends} chain of one entry, root-first.
      *
-     * <p>{@code setRegistryName} is still called on each link, because a compiled asset reads its own
-     * id off the last link of its chain. Carrying identity beside the decoded value instead of
-     * writing it into it is 128d's job; doing it here would mean touching all twelve asset
-     * constructors in the same PR that moves where they live.</p>
+     * <p>Nothing is written back into the decoded entries. Each link used to have its registry id
+     * assigned onto it here, so that the compiled asset could read its own name off the last link -
+     * which meant compilation mutated the authored model, and a registry entry's identity depended on
+     * something having walked a chain that reached it. The id travels as a parameter now: the caller
+     * already has it, and hands it to the asset constructor beside the chain (issue #128).</p>
      */
     private static <R> List<R> chainOf(Registry<R> registry, ResourceKey<Registry<R>> registryKey,
                                        Identifier id) {
         return ExtendsChain.resolve(id,
-                key -> {
-                    R entry = registry.getValue(ResourceKey.create(registryKey, key));
-                    if (entry instanceof IAsset asset) {
-                        asset.setRegistryName(key);
-                    }
-                    return entry;
-                },
+                key -> registry.getValue(ResourceKey.create(registryKey, key)),
                 entry -> entry instanceof Extendable ext ? ext.getExtends() : Optional.empty());
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
@@ -56,9 +56,9 @@ public class Building {
      * ancestor that set something else. The defaults the fields start at are this class's own
      * documented fallbacks - {@code -1} for "take the level's limit" - not markers for "undeclared".
      */
-    public Building(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
+    public Building(Identifier id, HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
                         AssetIndex<Palette> palettes, List<BuildingRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+        name = id;
         List<PartRef> partRefs = new ArrayList<>();
         boolean anyParts = false;
         List<PartRef> partRefs2 = new ArrayList<>();

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPart.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPart.java
@@ -61,10 +61,10 @@ public class BuildingPart implements IBuildingPart {
      * {@code slices} replaces the inherited ones wholesale; declaring a size that contradicts the
      * slices actually in force is a load error rather than a silent truncation.
      */
-    public BuildingPart(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
+    public BuildingPart(Identifier id, HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
                         AssetIndex<Palette> palettes, List<BuildingPartRE> chainRootFirst) {
         BuildingPartRE leaf = chainRootFirst.get(chainRootFirst.size() - 1);
-        name = leaf.getRegistryName();
+        name = id;
 
         Integer declaredXSize = null;
         Integer declaredZSize = null;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyle.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyle.java
@@ -100,9 +100,9 @@ public class CityStyle {
      * {@link #declare}). Nothing mutates after this returns, so worldgen worker threads share one
      * immutable instance with no locking.
      */
-    public CityStyle(List<CityStyleRE> chainRootFirst) {
+    public CityStyle(Identifier id, List<CityStyleRE> chainRootFirst) {
         CityStyleRE leaf = chainRootFirst.get(chainRootFirst.size() - 1);
-        name = leaf.getRegistryName();
+        name = id;
         stuffTags.add("all");
         for (CityStyleRE re : chainRootFirst) {
             applyFrom(re);

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Condition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Condition.java
@@ -24,8 +24,8 @@ public class Condition {
      * inherits it unchanged. A chain where nothing declares {@code values} is a load error, since
      * the condition would silently hand back null for every draw.
      */
-    public Condition(List<ConditionRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+    public Condition(Identifier id, List<ConditionRE> chainRootFirst) {
+        name = id;
         List<ConditionPart> values = new ArrayList<>();
         boolean anyValues = false;
         for (ConditionRE object : chainRootFirst) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/MultiBuilding.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/MultiBuilding.java
@@ -21,8 +21,8 @@ public class MultiBuilding {
      * or restate a grid at the size it inherits. The grid replaces its ancestor's wholesale rather
      * than merging, because a half-inherited grid would contradict {@code dimx}/{@code dimz}.
      */
-    public MultiBuilding(List<MultiBuildingRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+    public MultiBuilding(Identifier id, List<MultiBuildingRE> chainRootFirst) {
+        name = id;
         Integer declaredDimX = null;
         Integer declaredDimZ = null;
         List<List<String>> declaredBuildings = null;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
@@ -48,9 +48,9 @@ public class Palette {
      *                    does then fails naming itself and the variant rather than reaching for a
      *                    static server (issue #60) or compiling one on the spot (issue #128).
      */
-    public Palette(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
+    public Palette(Identifier id, HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
                    List<PaletteRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+        name = id;
         compile(blockLookup, variants, mergeByCharacter(chainRootFirst, name));
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PredefinedCity.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PredefinedCity.java
@@ -31,8 +31,8 @@ public class PredefinedCity {
      * and street lists go through {@link Mergeable} so a declared list replaces unless it opts into
      * appending.
      */
-    public PredefinedCity(List<PredefinedCityRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+    public PredefinedCity(Identifier id, List<PredefinedCityRE> chainRootFirst) {
+        name = id;
         String declaredDimension = null;
         Integer declaredChunkX = null;
         Integer declaredChunkZ = null;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ScatteredBuilding.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ScatteredBuilding.java
@@ -31,8 +31,8 @@ public class ScatteredBuilding {
      * {@link Resolved#require} cannot state. Left unchecked, a chain declaring neither loaded and
      * then threw from {@code Scattered.generate} the first time the entry was placed.
      */
-    public ScatteredBuilding(List<ScatteredRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+    public ScatteredBuilding(Identifier id, List<ScatteredRE> chainRootFirst) {
+        name = id;
         List<String> declaredBuildings = new ArrayList<>();
         boolean anyBuildings = false;
         String multibuilding = null;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/StuffObject.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/StuffObject.java
@@ -15,9 +15,9 @@ public class StuffObject {
      * lives on {@link StuffSettingsRE#resolve} so generation keeps reading one settings object and
      * never has to know a chain was involved.
      */
-    public StuffObject(List<StuffSettingsRE> chainRootFirst) {
-        this.settings = StuffSettingsRE.resolve(chainRootFirst);
-        this.name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+    public StuffObject(Identifier id, List<StuffSettingsRE> chainRootFirst) {
+        this.settings = StuffSettingsRE.resolve(id, chainRootFirst);
+        this.name = id;
     }
 
     /** The fully-qualified id, e.g. {@code "urbex:signs"}. */

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Style.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Style.java
@@ -27,8 +27,8 @@ public class Style {
      *                 {@link #getRandomPalette}, from a worldgen worker, which is why that method took
      *                 an {@code IDimensionInfo} it otherwise had no use for (issue #128).
      */
-    public Style(AssetIndex<Palette> palettes, List<StyleRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+    public Style(Identifier id, AssetIndex<Palette> palettes, List<StyleRE> chainRootFirst) {
+        name = id;
         List<List<PaletteSelector>> groups = new ArrayList<>();
         boolean anyGroups = false;
         for (StyleRE object : chainRootFirst) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Variant.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Variant.java
@@ -30,8 +30,8 @@ public class Variant {
      *               registries. Taken rather than fetched: resolution used to reach a static server
      *               reference from wherever it happened to run (issues #60, #128).
      */
-    public Variant(HolderLookup<Block> blockLookup, List<VariantRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+    public Variant(Identifier id, HolderLookup<Block> blockLookup, List<VariantRE> chainRootFirst) {
+        name = id;
         List<BlockEntry> entries = new ArrayList<>();
         boolean anyBlocks = false;
         for (VariantRE object : chainRootFirst) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
@@ -48,8 +48,8 @@ public class WorldStyle {
      * nothing, which is how a third-party pack could generate parts it never mentioned. It is
      * folded field by field, so a child can append one tunnel variant without restating the group.
      */
-    public WorldStyle(List<WorldStyleRE> chainRootFirst) {
-        name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
+    public WorldStyle(Identifier id, List<WorldStyleRE> chainRootFirst) {
+        name = id;
         String outside = null;
         ScatteredSettings scattered = null;
         PartSelector parts = null;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/BuildingPartRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/BuildingPartRE.java
@@ -21,7 +21,7 @@ import java.util.Optional;
  * geometry. Requiredness is checked after the chain is resolved, in
  * {@link dev.krona.urbex.worldgen.lost.cityassets.BuildingPart}.
  */
-public class BuildingPartRE implements IAsset<BuildingPartRE>, Extendable {
+public class BuildingPartRE implements Extendable {
 
     private static final Codec<BuildingPartRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -37,7 +37,6 @@ public class BuildingPartRE implements IAsset<BuildingPartRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<BuildingPartRE> CODEC = RetiredKeys.reject(RAW, "part");
 
-    private Identifier name;
 
     private final Optional<Identifier> extendsId;
 
@@ -133,14 +132,5 @@ public class BuildingPartRE implements IAsset<BuildingPartRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public BuildingPartRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/BuildingRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/BuildingRE.java
@@ -21,7 +21,7 @@ import java.util.Optional;
  * are values a file may legitimately mean, and under a sentinel a child could not override an
  * inherited {@code 0.8} back down to {@code 0.0}.
  */
-public class BuildingRE implements IAsset<BuildingRE>, Extendable {
+public class BuildingRE implements Extendable {
 
     private static final Codec<BuildingRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -46,7 +46,6 @@ public class BuildingRE implements IAsset<BuildingRE>, Extendable {
     public static final Codec<BuildingRE> CODEC = RetiredKeys.reject(RAW, "building");
 
 
-    private Identifier name;
 
     private final Optional<Identifier> extendsId;
 
@@ -95,16 +94,7 @@ public class BuildingRE implements IAsset<BuildingRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public BuildingRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 
     @Nullable
     public Integer getMinFloors() {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/CityStyleRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/CityStyleRE.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Optional;
 
-public class CityStyleRE implements IAsset<CityStyleRE>, Extendable {
+public class CityStyleRE implements Extendable {
 
     private static final Codec<CityStyleRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -30,7 +30,6 @@ public class CityStyleRE implements IAsset<CityStyleRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<CityStyleRE> CODEC = RetiredKeys.reject(RAW, "citystyle");
 
-    private Identifier name;
 
     private final Float explosionChance;
     private final String style;
@@ -127,14 +126,5 @@ public class CityStyleRE implements IAsset<CityStyleRE>, Extendable {
         return Optional.ofNullable(selectors);
     }
 
-    @Override
-    public CityStyleRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/ConditionRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/ConditionRE.java
@@ -19,7 +19,7 @@ import java.util.Optional;
  * Absent means "inherit unchanged", which is what {@code {"replace": false, "values": []}} was
  * being used for.
  */
-public class ConditionRE implements IAsset<ConditionRE>, Extendable {
+public class ConditionRE implements Extendable {
 
     private static final Codec<ConditionRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -30,7 +30,6 @@ public class ConditionRE implements IAsset<ConditionRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<ConditionRE> CODEC = RetiredKeys.reject(RAW, "condition");
 
-    private Identifier name;
     private final Optional<Identifier> extendsId;
     private final Mergeable<ConditionPart> values;   // null when this entry declares none
 
@@ -49,14 +48,5 @@ public class ConditionRE implements IAsset<ConditionRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public ConditionRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/IAsset.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/IAsset.java
@@ -1,7 +1,0 @@
-package dev.krona.urbex.worldgen.lost.regassets;
-
-import net.minecraft.resources.Identifier;
-
-public interface IAsset<T extends IAsset> {
-    T setRegistryName(Identifier name);
-}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/MultiBuildingRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/MultiBuildingRE.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  * Until that change this registry's every field was required, which made {@code extends} on it
  * purely decorative: a child had to restate the whole grid to decode at all.
  */
-public class MultiBuildingRE implements IAsset<MultiBuildingRE>, Extendable {
+public class MultiBuildingRE implements Extendable {
 
     private static final Codec<MultiBuildingRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -33,7 +33,6 @@ public class MultiBuildingRE implements IAsset<MultiBuildingRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<MultiBuildingRE> CODEC = RetiredKeys.reject(RAW, "multibuilding");
 
-    private Identifier name;
     private final Optional<Identifier> extendsId;
     private final Integer dimX;                 // null when this entry declares none and takes its ancestor's
     private final Integer dimZ;                 // null when this entry declares none and takes its ancestor's
@@ -67,14 +66,5 @@ public class MultiBuildingRE implements IAsset<MultiBuildingRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public MultiBuildingRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PaletteRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PaletteRE.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  * {@code palette} is optional here rather than required, because requiredness is checked after the
  * {@code extends} chain is resolved, in {@link dev.krona.urbex.worldgen.lost.cityassets.Palette}.
  */
-public class PaletteRE implements IAsset<PaletteRE>, Extendable {
+public class PaletteRE implements Extendable {
 
     private static final Codec<PaletteRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -28,7 +28,6 @@ public class PaletteRE implements IAsset<PaletteRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<PaletteRE> CODEC = RetiredKeys.reject(RAW, "palette");
 
-    private Identifier name;
     private final Optional<Identifier> extendsId;
     // Null when this entry declares no palette of its own and takes its ancestor's.
     private final List<PaletteEntry> paletteEntries;
@@ -48,14 +47,5 @@ public class PaletteRE implements IAsset<PaletteRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public PaletteRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PredefinedCityRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PredefinedCityRE.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  * {@link dev.krona.urbex.worldgen.lost.cityassets.PredefinedCity} - so a sibling city can be
  * "the same city, elsewhere" by declaring nothing but {@code extends} and its two chunk coordinates.
  */
-public class PredefinedCityRE implements IAsset<PredefinedCityRE>, Extendable {
+public class PredefinedCityRE implements Extendable {
 
     private static final Codec<PredefinedCityRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -37,7 +37,6 @@ public class PredefinedCityRE implements IAsset<PredefinedCityRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<PredefinedCityRE> CODEC = RetiredKeys.reject(RAW, "predefined city");
 
-    private Identifier name;
 
     private final Optional<Identifier> extendsId;
     // Null on any of these means "not declared here", so the chain reads it from an ancestor.
@@ -106,14 +105,5 @@ public class PredefinedCityRE implements IAsset<PredefinedCityRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public PredefinedCityRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PresetRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PresetRE.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * present in the JSON are applied on top of an {@code extends} chain (see {@code Presets.resolve}).
  * Mirrors the {@code WorldStyleRE} registry-entry idiom.
  */
-public class PresetRE implements IAsset<PresetRE>, Extendable {
+public class PresetRE implements Extendable {
 
     public static final Set<String> KEYS = Set.of("extends", "name", "description", "extraDescription", "warning",
             "icon", "terrain", "cities", "buildings", "roads", "highways", "railways", "destruction", "decoration",
@@ -87,7 +87,6 @@ public class PresetRE implements IAsset<PresetRE>, Extendable {
             dev.krona.urbex.worldgen.lost.regassets.data.preset.UnknownKeys.warning(RAW, KEYS, "preset"),
             "preset");
 
-    private Identifier name;
 
     private final Optional<Identifier> extendsId;
     private final Optional<String> displayName;
@@ -259,14 +258,5 @@ public class PresetRE implements IAsset<PresetRE>, Extendable {
         misc.ifPresent(s -> s.apply(p));
     }
 
-    @Override
-    public PresetRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/ScatteredRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/ScatteredRE.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  * resolved chain must leave at least one - neither is required on its own, so neither can be
  * required here. Declaring both is allowed; {@code Scattered.generate} takes the multibuilding.
  */
-public class ScatteredRE implements IAsset<ScatteredRE>, Extendable {
+public class ScatteredRE implements Extendable {
 
     /**
      * {@code rotatable} was decoded and then thrown away: {@link ScatteredBuilding} never copied it
@@ -56,7 +56,6 @@ public class ScatteredRE implements IAsset<ScatteredRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<ScatteredRE> CODEC = RetiredKeys.reject(RAW, "scattered building");
 
-    private Identifier name;
     private final Optional<Identifier> extendsId;
     private final ScatteredBuilding.TerrainHeight terrainheight;
     private final ScatteredBuilding.TerrainFix terrainfix;
@@ -110,14 +109,5 @@ public class ScatteredRE implements IAsset<ScatteredRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public ScatteredRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/StuffSettingsRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/StuffSettingsRE.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * than required, because a rarer variant of an existing decoration should not have to restate them.
  * Requiredness is checked after the chain is resolved, in {@link #resolve}.
  */
-public class StuffSettingsRE implements IAsset<StuffSettingsRE>, Extendable {
+public class StuffSettingsRE implements Extendable {
 
     /**
      * The widest {@code attempts} the RNG slot address can hold, and one more than the widest
@@ -63,7 +63,6 @@ public class StuffSettingsRE implements IAsset<StuffSettingsRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<StuffSettingsRE> CODEC = RetiredKeys.reject(RAW, "stuff entry");
 
-    private Identifier name;
     private final Optional<Identifier> extendsId;
     private final Mergeable<String> tags;
     // Null on any of these means "not declared here", so the chain reads it from an ancestor.
@@ -115,10 +114,10 @@ public class StuffSettingsRE implements IAsset<StuffSettingsRE>, Extendable {
      * file, so a child inherits them, and a chain where nothing declares one is a load error naming
      * the asset and the field rather than an NPE during generation.
      */
-    public static StuffSettingsRE resolve(List<StuffSettingsRE> chainRootFirst) {
+    public static StuffSettingsRE resolve(Identifier id, List<StuffSettingsRE> chainRootFirst) {
         StuffSettingsRE leaf = chainRootFirst.get(chainRootFirst.size() - 1);
         if (chainRootFirst.size() == 1) {
-            return leaf.requireResolved();
+            return leaf.requireResolved(id);
         }
         List<String> tags = new ArrayList<>();
         boolean anyTags = false;
@@ -184,15 +183,18 @@ public class StuffSettingsRE implements IAsset<StuffSettingsRE>, Extendable {
                 Optional.ofNullable(inbuilding), Optional.ofNullable(seesky),
                 Optional.ofNullable(biomeMatcher), Optional.ofNullable(blockMatcher),
                 Optional.ofNullable(upperBlockMatcher), Optional.ofNullable(buildingMatcher))
-                .setRegistryName(leaf.getRegistryName())
-                .requireResolved();
+                .requireResolved(id);
     }
 
     /**
      * Fails the load unless the whole chain, taken together, declared everything generation reads
      * without a fallback. Called on the fold - or on the entry itself when the chain is one long.
+     *
+     * @param name the registry id, for the message. Passed in rather than read off the fold: the
+     *             fold is a synthetic entry no registry holds, and writing an id into it just so an
+     *             error could name it is what {@code IAsset.setRegistryName} was for (issue #128).
      */
-    private StuffSettingsRE requireResolved() {
+    private StuffSettingsRE requireResolved(Identifier name) {
         Resolved.require(column, name, "column");
         Resolved.require(mincount, name, "mincount");
         Resolved.require(maxcount, name, "maxcount");
@@ -298,14 +300,5 @@ public class StuffSettingsRE implements IAsset<StuffSettingsRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public StuffSettingsRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/StyleRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/StyleRE.java
@@ -19,7 +19,7 @@ import java.util.Optional;
  * after the {@code extends} chain is resolved, in
  * {@link dev.krona.urbex.worldgen.lost.cityassets.Style}.
  */
-public class StyleRE implements IAsset<StyleRE>, Extendable {
+public class StyleRE implements Extendable {
 
     private static final Codec<StyleRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -30,7 +30,6 @@ public class StyleRE implements IAsset<StyleRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<StyleRE> CODEC = RetiredKeys.reject(RAW, "style");
 
-    private Identifier name;
 
     private final Optional<Identifier> extendsId;
     private final Mergeable<List<PaletteSelector>> randomPaletteChoices;   // null when undeclared
@@ -50,14 +49,5 @@ public class StyleRE implements IAsset<StyleRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public StyleRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/VariantRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/VariantRE.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  * {@code blocks} is optional here rather than required, because requiredness is checked after the
  * {@code extends} chain is resolved, in {@link dev.krona.urbex.worldgen.lost.cityassets.Variant}.
  */
-public class VariantRE implements IAsset<VariantRE>, Extendable {
+public class VariantRE implements Extendable {
 
     private static final Codec<VariantRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -28,7 +28,6 @@ public class VariantRE implements IAsset<VariantRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<VariantRE> CODEC = RetiredKeys.reject(RAW, "variant");
 
-    private Identifier name;
     private final Optional<Identifier> extendsId;
     private final Mergeable<BlockEntry> blocks;   // null when this entry declares none
 
@@ -47,14 +46,5 @@ public class VariantRE implements IAsset<VariantRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public VariantRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleRE.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleRE.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  * is checked after the chain is resolved, in
  * {@link dev.krona.urbex.worldgen.lost.cityassets.WorldStyle}.
  */
-public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
+public class WorldStyleRE implements Extendable {
 
     private static final Codec<WorldStyleRE> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -37,7 +37,6 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
     public static final Codec<WorldStyleRE> CODEC = RetiredKeys.reject(RAW, "worldstyle");
 
-    private Identifier name;
     private final Optional<Identifier> extendsId;
     // The human-readable label the world-style picker shows instead of the id. Null means "not
     // declared here", so the chain reads it from an ancestor; a chain that declares none anywhere
@@ -128,14 +127,5 @@ public class WorldStyleRE implements IAsset<WorldStyleRE>, Extendable {
         return extendsId;
     }
 
-    @Override
-    public WorldStyleRE setRegistryName(Identifier name) {
-        this.name = name;
-        return this;
-    }
 
-    @Nullable
-    public Identifier getRegistryName() {
-        return name;
-    }
 }

--- a/src/test/java/dev/krona/urbex/data/DatapackGuideExamplesTest.java
+++ b/src/test/java/dev/krona/urbex/data/DatapackGuideExamplesTest.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.data;
 
+import dev.krona.urbex.worldgen.lost.cityassets.TestAssetId;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -190,8 +191,8 @@ class DatapackGuideExamplesTest {
         expect(guide, missing, () -> Resolved.require(null, downtown, "streetblocks.parts.stair"));
 
         // A part with no geometry, and a part whose redeclared size contradicts inherited slices.
-        expect(guide, missing, () -> new BuildingPart(BuiltInRegistries.BLOCK, null, NO_PALETTES, List.of(namedPart(tower, null, null, null))));
-        expect(guide, missing, () -> new BuildingPart(BuiltInRegistries.BLOCK, null, NO_PALETTES, List.of(
+        expect(guide, missing, () -> new BuildingPart(tower, BuiltInRegistries.BLOCK, null, NO_PALETTES, List.of(namedPart(tower, null, null, null))));
+        expect(guide, missing, () -> new BuildingPart(tower, BuiltInRegistries.BLOCK, null, NO_PALETTES, List.of(
                 namedPart(Identifier.fromNamespaceAndPath("urbexmt", "tower_base"), 16, 16,
                         List.of(List.of("x".repeat(256)))),
                 namedPart(tower, 8, null, null))));
@@ -204,17 +205,15 @@ class DatapackGuideExamplesTest {
         PaletteEntry empty = new PaletteEntry("#", Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        expect(guide, missing, () -> new Palette(BuiltInRegistries.BLOCK, null, List.of(
-                new PaletteRE(Optional.empty(), Optional.of(List.of(empty)))
-                        .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "x")))));
+        expect(guide, missing, () -> new Palette(Identifier.fromNamespaceAndPath("urbex", "x"), BuiltInRegistries.BLOCK, null, List.of(
+                new PaletteRE(Optional.empty(), Optional.of(List.of(empty))))));
 
         // A 'randompalettes' group nothing could ever be drawn from, and a stuff entry whose two
         // count bounds contradict. Both are checked at the chain fold rather than per field.
-        expect(guide, missing, () -> new Style(NO_PALETTES, List.of(
+        expect(guide, missing, () -> new Style(Identifier.fromNamespaceAndPath("urbexmt", "downtown"), NO_PALETTES, List.of(
                 new StyleRE(Optional.empty(), Optional.of(new Mergeable<>(true,
-                        List.of(List.of(new PaletteSelector(0f, "urbex:common"))))))
-                        .setRegistryName(downtown))));
-        expect(guide, missing, () -> new StuffObject(List.of(
+                        List.of(List.of(new PaletteSelector(0f, "urbex:common")))))))));
+        expect(guide, missing, () -> new StuffObject(downtown, List.of(
                 stuffCounts(downtown, 5, 2))));
 
         // The two DataResult errors below are not throws, so they cannot go through expect(): a
@@ -245,8 +244,7 @@ class DatapackGuideExamplesTest {
                 Optional.empty(), Optional.empty(),
                 Optional.of(mincount), Optional.of(maxcount), Optional.of(1),
                 Optional.of(false), Optional.empty(),
-                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
-                .setRegistryName(id);
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     /** Decodes {@code json} through {@code codec} and records the error message it must produce. */
@@ -285,7 +283,7 @@ class DatapackGuideExamplesTest {
                                             List<List<String>> slices) {
         return new BuildingPartRE(Optional.empty(), Optional.ofNullable(xSize),
                 Optional.ofNullable(zSize), Optional.ofNullable(slices), Optional.empty(),
-                Optional.empty(), Optional.empty()).setRegistryName(id);
+                Optional.empty(), Optional.empty());
     }
 
     /** Collapses runs of whitespace to one space, so a message wrapped in Markdown still matches. */

--- a/src/test/java/dev/krona/urbex/data/WorldStyleCompletenessTest.java
+++ b/src/test/java/dev/krona/urbex/data/WorldStyleCompletenessTest.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.data;
 
+import dev.krona.urbex.worldgen.lost.cityassets.TestAssetId;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -96,11 +97,10 @@ class WorldStyleCompletenessTest {
             List<Path> chain = chainRootFirst("worldstyles", file);
             List<WorldStyleRE> entries = new ArrayList<>();
             for (Path link : chain) {
-                entries.add(WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, read(link)).getOrThrow()
-                        .setRegistryName(idOf(link)));
+                entries.add(WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, read(link)).getOrThrow());
                 cityStylesNamed.addAll(cityStyleRefs(link));
             }
-            requireWorldStyleWiring(new WorldStyle(entries));
+            requireWorldStyleWiring(new WorldStyle(TestAssetId.ANY, entries));
         }
 
         cityStylesNamed.addAll(namedIn("presets", "cities", "cityStyleAlternative"));
@@ -112,10 +112,9 @@ class WorldStyleCompletenessTest {
             assertTrue(Files.isRegularFile(file), name + " does not resolve to " + file);
             List<CityStyleRE> entries = new ArrayList<>();
             for (Path link : chainRootFirst("citystyles", file)) {
-                entries.add(CityStyleRE.CODEC.parse(JsonOps.INSTANCE, read(link)).getOrThrow()
-                        .setRegistryName(idOf(link)));
+                entries.add(CityStyleRE.CODEC.parse(JsonOps.INSTANCE, read(link)).getOrThrow());
             }
-            requireCityStyleWiring(new CityStyle(entries));
+            requireCityStyleWiring(new CityStyle(TestAssetId.ANY, entries));
         }
     }
 

--- a/src/test/java/dev/krona/urbex/worldgen/TagSnapshotTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/TagSnapshotTest.java
@@ -105,13 +105,12 @@ class TagSnapshotTest {
     }
 
     private static WorldStyle worldStyle(String name, Optional<TagKey<Block>> rotatable) {
-        return new WorldStyle(List.of(new WorldStyleRE(
+        return new WorldStyle(Identifier.fromNamespaceAndPath("urbex", name), List.of(new WorldStyleRE(
                 Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
                         List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
-                Optional.empty(), rotatable)
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", name))));
+                Optional.empty(), rotatable)));
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/WorldStyleFieldTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/WorldStyleFieldTest.java
@@ -68,8 +68,8 @@ class WorldStyleFieldTest {
                 Optional.of(new Mergeable<>(true, Collections.emptyList())),
                 Optional.empty(),
                 Optional.empty()
-        ).setRegistryName(Identifier.fromNamespaceAndPath("urbextest", path));
-        return new WorldStyle(List.of(re));
+        );
+        return new WorldStyle(Identifier.fromNamespaceAndPath("urbextest", path), List.of(re));
     }
 
     private static Optional<Mergeable<String>> noParts() {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/TestProfiles.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/TestProfiles.java
@@ -37,7 +37,7 @@ final class TestProfiles {
      * {@code urbex:test_street_*} ids that no test here places.
      */
     static CityStyle cityStyle() {
-        return new CityStyle(List.of(new CityStyleRE(
+        return new CityStyle(Identifier.fromNamespaceAndPath("urbex", "test_citystyle"), List.of(new CityStyleRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.of(TestWiring.streetSettings()),

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BelowPartConditionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BelowPartConditionTest.java
@@ -95,13 +95,12 @@ public class BelowPartConditionTest {
     private static Building buildingWithParts2Condition(Set<String> belowPart, Set<String> inpart) {
         PartRef floor = partRef(FLOOR, null, null);
         PartRef second = partRef("urbex:second_part", belowPart, inpart);
-        return new Building(BuiltInRegistries.BLOCK, null, AssetIndex.empty("urbex:palettes"), List.of(new BuildingRE(
+        return new Building(TestAssetId.ANY, BuiltInRegistries.BLOCK, null, AssetIndex.empty("urbex:palettes"), List.of(new BuildingRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.of('#'), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of(floor))),
-                Optional.of(new Mergeable<>(true, List.of(second))))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_building"))));
+                Optional.of(new Mergeable<>(true, List.of(second))))));
     }
 
     private static PartRef partRef(String part, Set<String> belowPart, Set<String> inpart) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPartExtendsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPartExtendsTest.java
@@ -47,7 +47,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("radiotower_rusted", inherits("urbex:radiotower")
                 .refpalette("urbexmt:radiotower_rusted"));
 
-        BuildingPart resolved = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child));
+        BuildingPart resolved = new BuildingPart(TestAssetId.of("radiotower_rusted"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child));
 
         assertEquals(2, resolved.getXSize());
         assertEquals(2, resolved.getZSize());
@@ -64,7 +64,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_short", inherits("urbex:tower")
                 .slices(List.of(List.of("ij", "kl"))));
 
-        BuildingPart resolved = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child));
+        BuildingPart resolved = new BuildingPart(TestAssetId.of("tower_short"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child));
 
         assertEquals(1, resolved.getSliceCount());
         assertArrayEquals(new String[]{"ijkl"}, resolved.getSlices());
@@ -78,7 +78,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_wide", inherits("urbex:tower").xsize(3));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
+                () -> new BuildingPart(TestAssetId.of("tower_wide"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_wide"),
                 () -> "the error must name the part: " + error.getMessage());
@@ -94,7 +94,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_deep", inherits("urbex:tower").zsize(5));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
+                () -> new BuildingPart(TestAssetId.of("tower_deep"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_deep"),
                 () -> "the error must name the part: " + error.getMessage());
@@ -107,7 +107,7 @@ class BuildingPartExtendsTest {
                 .refpalette("urbex:rusted"));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
+                () -> new BuildingPart(TestAssetId.of("tower_rusted"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
 
         assertTrue(error.getMessage().contains("urbex:tower_rusted"),
                 () -> "the error must name the part that failed to resolve: " + error.getMessage());
@@ -120,7 +120,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE parent = part("sliced_only", new Builder().slices(TOWER));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent)));
+                () -> new BuildingPart(TestAssetId.of("sliced_only"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent)));
 
         assertTrue(error.getMessage().contains("urbex:sliced_only"), error::getMessage);
     }
@@ -131,11 +131,11 @@ class BuildingPartExtendsTest {
         BuildingPartRE replacing = part("tower_a", inherits("urbex:tower").meta(true, meta("nowater")));
         BuildingPartRE appending = part("tower_b", inherits("urbex:tower").meta(false, meta("nowater")));
 
-        BuildingPart replaced = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, replacing));
+        BuildingPart replaced = new BuildingPart(TestAssetId.of("tower_b"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, replacing));
         assertTrue(replaced.getMetaBoolean("nowater"));
         assertFalse(replaced.getMetaBoolean("support"), "a bare array replaces");
 
-        BuildingPart appended = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, appending));
+        BuildingPart appended = new BuildingPart(TestAssetId.of("tower_b"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, appending));
         assertTrue(appended.getMetaBoolean("nowater"));
         assertTrue(appended.getMetaBoolean("support"), "{\"replace\": false} keeps the inherited meta");
     }
@@ -152,7 +152,7 @@ class BuildingPartExtendsTest {
         BuildingPartRE child = part("tower_rusted", inherits("urbex:tower")
                 .inlinePalette(entry('a', "minecraft:deepslate")));
 
-        Palette resolved = new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)).getLocalPalette();
+        Palette resolved = new BuildingPart(TestAssetId.of("tower_rusted"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)).getLocalPalette();
 
         assertEquals(3, resolved.getPalette().size(),
                 "the two characters the child never mentions must survive");
@@ -173,7 +173,7 @@ class BuildingPartExtendsTest {
         // built at all unless the named palette exists. That is the compile-time resolution doing its
         // job: this used to build fine and blow up on the first chunk that asked for the palette.
         RuntimeException failure = assertThrows(RuntimeException.class,
-                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)),
+                () -> new BuildingPart(TestAssetId.of("tower_ref"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)),
                 "an ancestor's inline palette must not survive the child naming a refpalette");
         assertTrue(failure.getMessage().contains("urbex:somewhere_else"), failure.getMessage());
     }
@@ -188,7 +188,7 @@ class BuildingPartExtendsTest {
                         entry('a', "minecraft:stone")));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> new BuildingPart(BuiltInRegistries.BLOCK, null, PALETTES, List.of(part)));
+                () -> new BuildingPart(TestAssetId.of("tower"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(part)));
 
         assertTrue(error.getMessage().contains("urbex:tower"), error::getMessage);
         assertTrue(error.getMessage().contains("urbex:common"), error::getMessage);
@@ -228,8 +228,13 @@ class BuildingPartExtendsTest {
             Identifier.fromNamespaceAndPath("urbexmt", "radiotower_rusted"), new Palette("radiotower_rusted"),
             Identifier.fromNamespaceAndPath("urbex", "rusted"), new Palette("rusted")));
 
+    /**
+     * {@code path} is the id the part <em>would</em> be registered under. A decoded definition no
+     * longer carries one (issue #128), so it is not written here - it is passed to
+     * {@link BuildingPart}'s constructor at each call site, which is where the compiler passes it.
+     */
     private static BuildingPartRE part(String path, Builder builder) {
-        return builder.build().setRegistryName(Identifier.fromNamespaceAndPath("urbex", path));
+        return builder.build();
     }
 
     private static final class Builder {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyleInheritSelectorsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyleInheritSelectorsTest.java
@@ -90,7 +90,7 @@ class CityStyleInheritSelectorsTest {
         CityStyleRE parent = re(sels("b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8"), null, null);
         CityStyleRE child = re(sels("b1", "b2", "b3", "b4", "b5"), null, null);
 
-        CityStyle merged = new CityStyle(List.of(parent, child));
+        CityStyle merged = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 
         assertEquals(List.of("b1", "b2", "b3", "b4", "b5"), values(merged, CityStyle.Sel.BUILDING),
                 "a declared list is the whole list: no parent entries, no duplicates");
@@ -101,7 +101,7 @@ class CityStyleInheritSelectorsTest {
         CityStyleRE parent = re(null, sels("m1", "m2", "m3"), null);
         CityStyleRE child = re(null, List.of(), null);
 
-        CityStyle merged = new CityStyle(List.of(parent, child));
+        CityStyle merged = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 
         assertTrue(values(merged, CityStyle.Sel.MULTI_BUILDING).isEmpty(),
                 "an explicitly empty list is a declaration of none, not an absence of one");
@@ -112,7 +112,7 @@ class CityStyleInheritSelectorsTest {
         CityStyleRE parent = re(null, null, sels("p1", "p2"));
         CityStyleRE child = re(sels("b1"), null, null);
 
-        CityStyle merged = new CityStyle(List.of(parent, child));
+        CityStyle merged = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 
         assertEquals(List.of("p1", "p2"), values(merged, CityStyle.Sel.PARK),
                 "a list the child never mentions is inherited unchanged");
@@ -123,8 +123,8 @@ class CityStyleInheritSelectorsTest {
         CityStyleRE parent = re(sels("b1"), sels("m1"), sels("p1"));
         CityStyleRE child = re(null, null, null);
 
-        CityStyle parentResolved = new CityStyle(List.of(parent));
-        CityStyle merged = new CityStyle(List.of(parent, child));
+        CityStyle parentResolved = new CityStyle(TestAssetId.ANY, List.of(parent));
+        CityStyle merged = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 
         for (CityStyle.Sel kind : CityStyle.Sel.values()) {
             assertEquals(values(parentResolved, kind), values(merged, kind),
@@ -137,7 +137,7 @@ class CityStyleInheritSelectorsTest {
         CityStyleRE parent = reBuildings(replacing(sels("b1", "b2")));
         CityStyleRE child = reBuildings(appending(sels("b3")));
 
-        CityStyle resolved = new CityStyle(List.of(parent, child));
+        CityStyle resolved = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 
         assertEquals(List.of("b1", "b2", "b3"), values(resolved, CityStyle.Sel.BUILDING),
                 "appended entries follow the parent's, so parent order is stable");

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CommonPaletteLightingTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CommonPaletteLightingTest.java
@@ -45,7 +45,7 @@ class CommonPaletteLightingTest {
 
     @Test
     void commonPaletteCompilesExactTypedLightPoolsWithoutRedstoneTorches() throws IOException {
-        PaletteRE common = decodeClasspathPalette(COMMON_PALETTE).setRegistryName(COMMON_ID);
+        PaletteRE common = decodeClasspathPalette(COMMON_PALETTE);
         PaletteEntry torchMarker = entry(common, 'T');
         PaletteEntry freeMarker = entry(common, 'h');
         PaletteEntry redstoneTorch = entry(common, 'g');
@@ -77,7 +77,7 @@ class CommonPaletteLightingTest {
         assertNull(redstoneTorch.getTorch());
         assertNull(redstoneTorch.getLight());
 
-        Palette compiled = new Palette(BuiltInRegistries.BLOCK, null, List.of(common));
+        Palette compiled = new Palette(COMMON_ID, BuiltInRegistries.BLOCK, null, List.of(common));
         LightPool torchPool = compiled.getPalette().get('T').info().light();
         LightPool freePool = compiled.getPalette().get('h').info().light();
         assertNotNull(torchPool);

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/LightPoolTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/LightPoolTest.java
@@ -62,7 +62,7 @@ class LightPoolTest {
                 """);
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> new Palette(BuiltInRegistries.BLOCK, null, List.of(palette)));
+                () -> new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(palette)));
         assertTrue(error.getMessage().contains("urbex:test_lights"));
         assertTrue(error.getMessage().contains("marker 'L'"));
         assertTrue(error.getMessage().contains("floor, wall, ceiling, or free"));
@@ -78,7 +78,7 @@ class LightPoolTest {
                     """.formatted(weight));
 
             IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                    () -> new Palette(BuiltInRegistries.BLOCK, null, List.of(palette)));
+                    () -> new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(palette)));
             assertTrue(error.getMessage().contains("urbex:test_lights"));
             assertTrue(error.getMessage().contains("marker 'L'"));
             assertTrue(error.getMessage().contains("placement 'floor'"));
@@ -243,10 +243,9 @@ class LightPoolTest {
                 }]}
                 """));
         assertTrue(result.result().isPresent());
-        PaletteRE paletteRE = result.result().orElseThrow()
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "legacy_torch"));
+        PaletteRE paletteRE = result.result().orElseThrow();
 
-        Palette.PE entry = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteRE)).getPalette().get('L');
+        Palette.PE entry = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteRE)).getPalette().get('L');
         assertInstanceOf(BlockState.class, entry.blocks());
         assertTrue(entry.info().isTorch());
         assertNull(entry.info().light());
@@ -264,10 +263,9 @@ class LightPoolTest {
                 }]}
                 """));
         assertTrue(result.result().isPresent());
-        PaletteRE paletteRE = result.result().orElseThrow()
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "typed_lights"));
+        PaletteRE paletteRE = result.result().orElseThrow();
 
-        Palette.PE entry = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteRE)).getPalette().get('L');
+        Palette.PE entry = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteRE)).getPalette().get('L');
         BlockState representative = assertInstanceOf(BlockState.class, entry.blocks());
         assertEquals(Blocks.SOUL_WALL_TORCH, representative.getBlock());
         assertTrue(entry.info().isSpecial());
@@ -301,6 +299,6 @@ class LightPoolTest {
     private static PaletteRE decodePalette(String json) {
         DataResult<PaletteRE> result = PaletteRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(json));
         assertTrue(result.result().isPresent(), () -> result.error().map(Object::toString).orElse("unknown decode error"));
-        return result.result().orElseThrow().setRegistryName(PALETTE_ID);
+        return result.result().orElseThrow();
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/MissingBlocksAreSkippedTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/MissingBlocksAreSkippedTest.java
@@ -45,6 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MissingBlocksAreSkippedTest {
 
     private static final String ABSENT = "somemod:no_such_block";
+    private static final Identifier PALETTE_ID = Identifier.fromNamespaceAndPath("urbex", "test_palette");
+    private static final Identifier VARIANT_ID = Identifier.fromNamespaceAndPath("urbex", "test_variant");
 
     @BeforeAll
     static void bootstrap() {
@@ -54,7 +56,7 @@ class MissingBlocksAreSkippedTest {
 
     @Test
     void aVariantKeepsTheBlocksThisGameHas() {
-        Variant variant = new Variant(BuiltInRegistries.BLOCK, List.of(variantOf(
+        Variant variant = new Variant(VARIANT_ID, BuiltInRegistries.BLOCK, List.of(variantOf(
                 new BlockEntry(3, "minecraft:mossy_cobblestone"),
                 new BlockEntry(1, ABSENT),
                 new BlockEntry(2, "minecraft:stone"))));
@@ -69,7 +71,7 @@ class MissingBlocksAreSkippedTest {
 
     @Test
     void aWeightedPaletteEntryKeepsTheBlocksThisGameHas() {
-        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+        Palette palette = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteOf(
                 weighted('r', new BlockEntry(1, ABSENT), new BlockEntry(1, "minecraft:gravel")))));
 
         Pair<Integer, BlockState>[] blocks = weightedBlocksOf(palette, 'r');
@@ -83,7 +85,7 @@ class MissingBlocksAreSkippedTest {
      */
     @Test
     void aPropertyCarryingEntryFromAMissingModIsSkippedRatherThanThrowing() {
-        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+        Palette palette = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteOf(
                 weighted('r', new BlockEntry(1, ABSENT + "[facing=north]"),
                         new BlockEntry(1, "minecraft:gravel")))));
 
@@ -94,7 +96,7 @@ class MissingBlocksAreSkippedTest {
 
     @Test
     void aCharacterLeftWithNothingGeneratesAsAir() {
-        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+        Palette palette = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteOf(
                 weighted('r', new BlockEntry(1, ABSENT), new BlockEntry(1, "othermod:also_absent")))));
 
         Palette.PE entry = palette.getPalette().get('r');
@@ -106,13 +108,13 @@ class MissingBlocksAreSkippedTest {
     /** A variant whose every block is absent reaches the palette as an empty list, not as a crash. */
     @Test
     void aVariantWithNothingLeftReachesThePaletteAsAir() {
-        Variant emptied = new Variant(BuiltInRegistries.BLOCK,
+        Variant emptied = new Variant(VARIANT_ID, BuiltInRegistries.BLOCK,
                 List.of(variantOf(new BlockEntry(1, ABSENT))));
         assertTrue(emptied.getBlocks().isEmpty());
 
         AssetIndex<Variant> variants = new AssetIndex<>("urbex:variants",
                 Map.of(Identifier.fromNamespaceAndPath("urbex", "gone"), emptied));
-        Palette palette = new Palette(BuiltInRegistries.BLOCK, variants, List.of(paletteOf(
+        Palette palette = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, variants, List.of(paletteOf(
                 namingVariant('v', "urbex:gone"))));
 
         assertSame(Blocks.AIR.defaultBlockState(), palette.getPalette().get('v').blocks());
@@ -124,7 +126,7 @@ class MissingBlocksAreSkippedTest {
      */
     @Test
     void aSingleBlockThatIsAbsentIsAir() {
-        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+        Palette palette = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteOf(
                 single('x', ABSENT), single('y', ABSENT + "[facing=north]"))));
 
         assertSame(Blocks.AIR.defaultBlockState(), palette.getPalette().get('x').blocks());
@@ -137,7 +139,7 @@ class MissingBlocksAreSkippedTest {
      */
     @Test
     void anAbsentDamagedBlockLeavesNoMapping() {
-        Palette palette = new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteOf(
+        Palette palette = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteOf(
                 damaged('S', "minecraft:stone", ABSENT))));
 
         assertTrue(palette.getDamaged().isEmpty());
@@ -151,13 +153,11 @@ class MissingBlocksAreSkippedTest {
     }
 
     private static VariantRE variantOf(BlockEntry... blocks) {
-        return new VariantRE(Optional.empty(), Optional.of(new Mergeable<>(true, List.of(blocks))))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_variant"));
+        return new VariantRE(Optional.empty(), Optional.of(new Mergeable<>(true, List.of(blocks))));
     }
 
     private static PaletteRE paletteOf(PaletteEntry... entries) {
-        return new PaletteRE(Optional.empty(), Optional.of(List.of(entries)))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_palette"));
+        return new PaletteRE(Optional.empty(), Optional.of(List.of(entries)));
     }
 
     private static PaletteEntry single(char marker, String block) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteExtendsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteExtendsTest.java
@@ -23,6 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 class PaletteExtendsTest {
 
+    /** Every chain here is leaf-named "child"; the id is the compiler's to supply, not the file's. */
+    private static final Identifier LEAF_ID = Identifier.fromNamespaceAndPath("urbex", "child");
+
     @BeforeAll
     static void bootstrap() {
         SharedConstants.tryDetectVersion();
@@ -37,7 +40,7 @@ class PaletteExtendsTest {
                 entry('g', "minecraft:glass"));
         PaletteRE child = palette("child", entry('S', "minecraft:deepslate"));
 
-        Palette resolved = new Palette(BuiltInRegistries.BLOCK, null, List.of(parent, child));
+        Palette resolved = new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
         assertEquals("minecraft:deepslate", blockOf(resolved, 'S'), "the child's character wins");
         assertEquals("minecraft:bricks", blockOf(resolved, 'b'), "characters it never mentions survive");
@@ -51,7 +54,7 @@ class PaletteExtendsTest {
         PaletteRE parent = palette("parent", entry('S', "minecraft:stone"));
         PaletteRE child = palette("child", entry('w', "minecraft:oak_planks"));
 
-        Palette resolved = new Palette(BuiltInRegistries.BLOCK, null, List.of(parent, child));
+        Palette resolved = new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
         assertEquals(2, resolved.getPalette().size());
         assertEquals("minecraft:stone", blockOf(resolved, 'S'));
@@ -64,8 +67,8 @@ class PaletteExtendsTest {
         PaletteRE middle = palette("middle", entry('S', "minecraft:andesite"));
         PaletteRE leaf = palette("leaf", entry('S', "minecraft:deepslate"));
 
-        assertEquals("minecraft:deepslate", blockOf(new Palette(BuiltInRegistries.BLOCK, null, List.of(root, middle, leaf)), 'S'));
-        assertEquals("minecraft:andesite", blockOf(new Palette(BuiltInRegistries.BLOCK, null, List.of(root, middle)), 'S'));
+        assertEquals("minecraft:deepslate", blockOf(new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(root, middle, leaf)), 'S'));
+        assertEquals("minecraft:andesite", blockOf(new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(root, middle)), 'S'));
     }
 
     @Test
@@ -75,14 +78,14 @@ class PaletteExtendsTest {
         PaletteRE parent = palette("parent", damagedEntry('S', "minecraft:stone", "minecraft:cobblestone"));
         PaletteRE child = palette("child", entry('S', "minecraft:deepslate"));
 
-        Palette resolved = new Palette(BuiltInRegistries.BLOCK, null, List.of(parent, child));
+        Palette resolved = new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
         assertNull(resolved.getDamaged().get(state("minecraft:stone")),
                 "the replaced parent entry must not leave its damaged mapping behind");
         assertEquals(1, resolved.getPalette().size());
 
         // ... and a mapping on a character nobody overrides is still there.
-        Palette parentOnly = new Palette(BuiltInRegistries.BLOCK, null, List.of(parent));
+        Palette parentOnly = new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(parent));
         assertNotNull(parentOnly.getDamaged().get(state("minecraft:stone")));
     }
 
@@ -98,8 +101,7 @@ class PaletteExtendsTest {
     }
 
     private static PaletteRE palette(String path, PaletteEntry... entries) {
-        return new PaletteRE(Optional.empty(), Optional.of(List.of(entries)))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", path));
+        return new PaletteRE(Optional.empty(), Optional.of(List.of(entries)));
     }
 
     private static PaletteEntry entry(char marker, String block) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteVariantResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteVariantResolutionTest.java
@@ -38,6 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class PaletteVariantResolutionTest {
 
+    private static final Identifier PALETTE_ID = Identifier.fromNamespaceAndPath("urbex", "variant-palette");
+
     @BeforeAll
     static void bootstrap() {
         SharedConstants.tryDetectVersion();
@@ -46,7 +48,7 @@ class PaletteVariantResolutionTest {
 
     @Test
     void aVariantResolvesAgainstTheIndexThePaletteWasGiven() {
-        Palette compiled = new Palette(BuiltInRegistries.BLOCK, variantsWith("minecraft:deepslate"),
+        Palette compiled = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, variantsWith("minecraft:deepslate"),
                 List.of(paletteNamingVariant()));
 
         assertEquals(List.of("minecraft:deepslate"), blocksOf(compiled, 'V'));
@@ -58,9 +60,9 @@ class PaletteVariantResolutionTest {
      */
     @Test
     void twoIndexesResolveTheSameVariantIdIndependently() {
-        Palette fromFirst = new Palette(BuiltInRegistries.BLOCK, variantsWith("minecraft:deepslate"),
+        Palette fromFirst = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, variantsWith("minecraft:deepslate"),
                 List.of(paletteNamingVariant()));
-        Palette fromSecond = new Palette(BuiltInRegistries.BLOCK, variantsWith("minecraft:sandstone"),
+        Palette fromSecond = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, variantsWith("minecraft:sandstone"),
                 List.of(paletteNamingVariant()));
 
         assertEquals(List.of("minecraft:deepslate"), blocksOf(fromFirst, 'V'));
@@ -77,7 +79,7 @@ class PaletteVariantResolutionTest {
     @Test
     void aVariantEntryWithNoVariantIndexFailsNamingWhatItWanted() {
         IllegalStateException failure = assertThrows(IllegalStateException.class,
-                () -> new Palette(BuiltInRegistries.BLOCK, null, List.of(paletteNamingVariant())));
+                () -> new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteNamingVariant())));
 
         assertTrue(failure.getMessage().contains("urbex:rubble"), failure.getMessage());
         assertTrue(failure.getMessage().contains("variant-palette"), failure.getMessage());
@@ -101,8 +103,7 @@ class PaletteVariantResolutionTest {
         PaletteEntry entry = new PaletteEntry("V", Optional.empty(), Optional.of("urbex:rubble"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        return new PaletteRE(Optional.empty(), Optional.of(List.of(entry)))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "variant-palette"));
+        return new PaletteRE(Optional.empty(), Optional.of(List.of(entry)));
     }
 
     /** An index whose only {@code urbex:rubble} variant is one weighted block. */
@@ -110,7 +111,6 @@ class PaletteVariantResolutionTest {
         Identifier id = Identifier.fromNamespaceAndPath("urbex", "rubble");
         VariantRE definition = new VariantRE(Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of(new BlockEntry(1, block)))));
-        definition.setRegistryName(id);
-        return new AssetIndex<>("urbex:variants", Map.of(id, new Variant(BuiltInRegistries.BLOCK, List.of(definition))));
+        return new AssetIndex<>("urbex:variants", Map.of(id, new Variant(id, BuiltInRegistries.BLOCK, List.of(definition))));
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
@@ -74,7 +74,7 @@ class RegistryChainResolutionTest {
     void stuffThatDeclaresNoTagsKeepsItsAncestors() {
         // The silent-damage case: dropping these would unfile the object from the tag index and it
         // would never be selected for placement again.
-        StuffObject resolved = new StuffObject(List.of(
+        StuffObject resolved = new StuffObject(TestAssetId.ANY, List.of(
                 stuff("torches").tags(true, "all", "indoor").build(),
                 stuff("torches_rare").build()));
 
@@ -83,12 +83,12 @@ class RegistryChainResolutionTest {
 
     @Test
     void stuffTagsReplaceByDefaultAndAppendWhenTheChildOptsIn() {
-        StuffObject replaced = new StuffObject(List.of(
+        StuffObject replaced = new StuffObject(TestAssetId.ANY, List.of(
                 stuff("torches").tags(true, "all", "indoor").build(),
                 stuff("torches_rare").tags(true, "rare").build()));
         assertEquals(List.of("rare"), replaced.getSettings().getTags(), "a bare array replaces");
 
-        StuffObject appended = new StuffObject(List.of(
+        StuffObject appended = new StuffObject(TestAssetId.ANY, List.of(
                 stuff("torches").tags(true, "all", "indoor").build(),
                 stuff("torches_rare").tags(false, "rare").build()));
         assertEquals(List.of("all", "indoor", "rare"), appended.getSettings().getTags(),
@@ -108,7 +108,7 @@ class RegistryChainResolutionTest {
         StuffSettingsRE child = stuff("torches_rare").column("XX").counts(2, 9, 7)
                 .undeclaredInbuilding().build();
 
-        StuffSettingsRE resolved = new StuffObject(List.of(parent, child)).getSettings();
+        StuffSettingsRE resolved = new StuffObject(TestAssetId.ANY, List.of(parent, child)).getSettings();
 
         assertNotSame(child, resolved, "a two-entry chain must actually fold, not hand back the leaf");
         assertEquals(40, resolved.getMinheight(), "minheight is inherited");
@@ -118,14 +118,14 @@ class RegistryChainResolutionTest {
                 "seesky is inherited - and 'declared false' must not read as 'undeclared'");
         assertSame(onlyLibraries, resolved.getBuildingMatcher(), "the matcher is inherited");
         assertSame(IdentifierMatcher.ANY,
-                new StuffObject(List.of(stuff("plain").build(), stuff("plain_child").build()))
+                new StuffObject(TestAssetId.of("plain"), List.of(stuff("plain").build(), stuff("plain_child").build()))
                         .getSettings().getBuildingMatcher(),
                 "a matcher no entry in the chain declares still reads as ANY");
     }
 
     @Test
     void stuffRequiredScalarsComeFromTheLeaf() {
-        StuffSettingsRE resolved = new StuffObject(List.of(
+        StuffSettingsRE resolved = new StuffObject(TestAssetId.ANY, List.of(
                 stuff("torches").column("AB").counts(1, 2, 3).build(),
                 stuff("torches_rare").column("CD").counts(4, 5, 6).build())).getSettings();
 
@@ -139,7 +139,7 @@ class RegistryChainResolutionTest {
     void stuffResolvedFromAChainOfOneIsTheEntryItself() {
         StuffSettingsRE only = stuff("torches").tags(true, "all").build();
 
-        assertSame(only, new StuffObject(List.of(only)).getSettings());
+        assertSame(only, new StuffObject(TestAssetId.ANY, List.of(only)).getSettings());
     }
 
     // ------------------------------------------- stuff ordering (RNG addresses)
@@ -153,8 +153,8 @@ class RegistryChainResolutionTest {
      */
     @Test
     void stuffFiledUnderATagIsOrderedByIdRatherThanByArrivalOrder() {
-        StuffObject cobweb = new StuffObject(List.of(stuff("cobweb").tags(true, "rubble").build()));
-        StuffObject chains = new StuffObject(List.of(stuff("chains").tags(true, "rubble").build()));
+        StuffObject cobweb = new StuffObject(TestAssetId.of("cobweb"), List.of(stuff("cobweb").tags(true, "rubble").build()));
+        StuffObject chains = new StuffObject(TestAssetId.of("chains"), List.of(stuff("chains").tags(true, "rubble").build()));
 
         // Deliberately the order AssetRegistries' ConcurrentHashMap actually hands these two over
         // in - hash("urbex:cobweb") lands in a lower bucket than hash("urbex:chains") - so this
@@ -168,9 +168,9 @@ class RegistryChainResolutionTest {
         // Identifier's own order, the same one MultiChunk sorts city styles by and BuildingInfo
         // breaks its cityStyle vote on. Ordering on toString() instead would put both urbex entries
         // ahead of the third-party one and silently relocate its decoration the day it is installed.
-        StuffObject ownRope = new StuffObject(List.of(stuff("urbex", "rope").tags(true, "rubble").build()));
-        StuffObject ownVines = new StuffObject(List.of(stuff("urbex", "vines").tags(true, "rubble").build()));
-        StuffObject thirdPartySoot = new StuffObject(List.of(stuff("urbexmt", "soot").tags(true, "rubble").build()));
+        StuffObject ownRope = new StuffObject(Identifier.fromNamespaceAndPath("urbex", "rope"), List.of(stuff("urbex", "rope").tags(true, "rubble").build()));
+        StuffObject ownVines = new StuffObject(Identifier.fromNamespaceAndPath("urbex", "vines"), List.of(stuff("urbex", "vines").tags(true, "rubble").build()));
+        StuffObject thirdPartySoot = new StuffObject(Identifier.fromNamespaceAndPath("urbexmt", "soot"), List.of(stuff("urbexmt", "soot").tags(true, "rubble").build()));
 
         assertEquals(List.of("urbex:rope", "urbexmt:soot", "urbex:vines"),
                 namesOf(AssetCompiler.groupStuffByTag(List.of(ownVines, thirdPartySoot, ownRope)).get("rubble")));
@@ -178,8 +178,8 @@ class RegistryChainResolutionTest {
 
     @Test
     void stuffWithSeveralTagsIsFiledUnderEachOfThem() {
-        StuffObject both = new StuffObject(List.of(stuff("torches").tags(true, "all", "indoor").build()));
-        StuffObject indoorOnly = new StuffObject(List.of(stuff("banners").tags(true, "indoor").build()));
+        StuffObject both = new StuffObject(TestAssetId.of("torches"), List.of(stuff("torches").tags(true, "all", "indoor").build()));
+        StuffObject indoorOnly = new StuffObject(TestAssetId.of("banners"), List.of(stuff("banners").tags(true, "indoor").build()));
 
         Map<String, List<StuffObject>> byTag = AssetCompiler.groupStuffByTag(List.of(both, indoorOnly));
 
@@ -205,7 +205,7 @@ class RegistryChainResolutionTest {
      */
     @Test
     void cityStyleStuffTagsIterateInASortedOrderRegardlessOfHowTheyWereDeclared() {
-        CityStyle style = new CityStyle(List.of(
+        CityStyle style = new CityStyle(TestAssetId.ANY, List.of(
                 cityStyleWithTags("indoor", "rubble"),
                 cityStyleWithTags("banners", "cobbles")));
 
@@ -218,8 +218,7 @@ class RegistryChainResolutionTest {
         return new CityStyleRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(List.of(tags)),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.of(TestWiring.streetSettings()), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "citystyle_" + tags[0]));
+                Optional.empty(), Optional.of(TestWiring.streetSettings()), Optional.empty());
     }
 
     // ----------------------------------------------------------- conditions
@@ -229,10 +228,10 @@ class RegistryChainResolutionTest {
         ConditionRE parent = condition("loot", true, "urbex:common_loot", "urbex:rare_loot");
 
         assertEquals(Set.of("urbex:barrel_loot"),
-                valuesOf(new Condition(List.of(parent, condition("loot_barrel", true, "urbex:barrel_loot")))),
+                valuesOf(new Condition(TestAssetId.ANY, List.of(parent, condition("loot_barrel", true, "urbex:barrel_loot")))),
                 "a bare array replaces");
         assertEquals(Set.of("urbex:common_loot", "urbex:rare_loot", "urbex:barrel_loot"),
-                valuesOf(new Condition(List.of(parent, condition("loot_barrel", false, "urbex:barrel_loot")))),
+                valuesOf(new Condition(TestAssetId.ANY, List.of(parent, condition("loot_barrel", false, "urbex:barrel_loot")))),
                 "{\"replace\": false} keeps the inherited values");
     }
 
@@ -243,12 +242,12 @@ class RegistryChainResolutionTest {
         VariantRE parent = variant("stones", true,
                 new BlockEntry(1, "minecraft:stone"), new BlockEntry(2, "minecraft:andesite"));
 
-        Variant replaced = new Variant(BuiltInRegistries.BLOCK, List.of(parent,
+        Variant replaced = new Variant(TestAssetId.ANY, BuiltInRegistries.BLOCK, List.of(parent,
                 variant("stones_deep", true, new BlockEntry(3, "minecraft:deepslate"))));
         assertEquals(List.of("minecraft:deepslate"), blockIdsOf(replaced), "a bare array replaces");
         assertEquals(List.of(3), replaced.getBlocks().stream().map(org.apache.commons.lang3.tuple.Pair::getLeft).toList());
 
-        Variant appended = new Variant(BuiltInRegistries.BLOCK, List.of(parent,
+        Variant appended = new Variant(TestAssetId.ANY, BuiltInRegistries.BLOCK, List.of(parent,
                 variant("stones_deep", false, new BlockEntry(3, "minecraft:deepslate"))));
         assertEquals(List.of("minecraft:stone", "minecraft:andesite", "minecraft:deepslate"),
                 blockIdsOf(appended), "{\"replace\": false} keeps the inherited blocks, in order");
@@ -258,7 +257,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void styleThatDeclaresNoPalettesKeepsItsAncestors() {
-        Style resolved = new Style(PALETTES, List.of(
+        Style resolved = new Style(TestAssetId.ANY, PALETTES, List.of(
                 style("nordic", group("urbex:common")),
                 style("nordic_rare")));
 
@@ -271,10 +270,10 @@ class RegistryChainResolutionTest {
         StyleRE parent = style("nordic", group("urbex:common"));
 
         assertEquals(List.of(List.of("urbex:snowy")),
-                paletteNamesOf(new Style(PALETTES, List.of(parent, style("nordic_snow", group("urbex:snowy"))))),
+                paletteNamesOf(new Style(TestAssetId.ANY, PALETTES, List.of(parent, style("nordic_snow", group("urbex:snowy"))))),
                 "a bare array replaces");
         assertEquals(List.of(List.of("urbex:common"), List.of("urbex:snowy")),
-                paletteNamesOf(new Style(PALETTES, List.of(parent, styleAppending("nordic_snow", group("urbex:snowy"))))),
+                paletteNamesOf(new Style(TestAssetId.ANY, PALETTES, List.of(parent, styleAppending("nordic_snow", group("urbex:snowy"))))),
                 "{\"replace\": false} keeps the inherited groups, in order");
     }
 
@@ -287,14 +286,12 @@ class RegistryChainResolutionTest {
                 Optional.empty(),
                 Optional.of(ScatteredBuilding.TerrainHeight.OCEAN),
                 Optional.of(ScatteredBuilding.TerrainFix.CLEAR),
-                Optional.of(3))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "oilrig"));
+                Optional.of(3));
         ScatteredRE child = new ScatteredRE(Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of("urbex:oilrig_burnt"))), Optional.empty(),
-                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "oilrig_burnt"));
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
 
-        ScatteredBuilding resolved = new ScatteredBuilding(List.of(parent, child));
+        ScatteredBuilding resolved = new ScatteredBuilding(TestAssetId.ANY, List.of(parent, child));
 
         assertEquals(ScatteredBuilding.TerrainHeight.OCEAN, resolved.getTerrainheight());
         assertEquals(ScatteredBuilding.TerrainFix.CLEAR, resolved.getTerrainfix());
@@ -312,14 +309,12 @@ class RegistryChainResolutionTest {
                 Optional.of("urbex:citystyle_common"),
                 Optional.of(new Mergeable<>(true,
                         List.of(new PredefinedBuilding("urbex:townhall", 0, 0, false, false)))),
-                Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "capital"));
+                Optional.empty());
         PredefinedCityRE child = new PredefinedCityRE(Optional.empty(),
                 Optional.empty(), Optional.of(100), Optional.of(200), Optional.empty(),
-                Optional.empty(), Optional.empty(), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "colony"));
+                Optional.empty(), Optional.empty(), Optional.empty());
 
-        PredefinedCity resolved = new PredefinedCity(List.of(parent, child));
+        PredefinedCity resolved = new PredefinedCity(TestAssetId.ANY, List.of(parent, child));
 
         assertEquals(100, resolved.getChunkX(), "the child moves the city");
         assertEquals(200, resolved.getChunkZ());
@@ -341,14 +336,12 @@ class RegistryChainResolutionTest {
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
                         List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
-                Optional.empty(), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "standard"));
+                Optional.empty(), Optional.empty());
         WorldStyleRE child = new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:bleak"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.empty(), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "bleak"));
+                Optional.empty(), Optional.empty(), Optional.empty());
 
-        WorldStyle resolved = new WorldStyle(List.of(parent, child));
+        WorldStyle resolved = new WorldStyle(TestAssetId.ANY, List.of(parent, child));
 
         assertEquals("urbex:bleak", resolved.getOutsideStyle(), "what the child declares wins");
         assertSame(scattered, resolved.getScatteredSettings(), "the settings block is inherited");
@@ -362,13 +355,11 @@ class RegistryChainResolutionTest {
     void multiBuildingChildInheritsTheGridItDoesNotDeclare() {
         MultiBuildingRE parent = new MultiBuildingRE(Optional.empty(),
                 Optional.of(1), Optional.of(2),
-                Optional.of(List.of(List.of("urbex:oilrig00", "urbex:oilrig01"))))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "oilrig"));
+                Optional.of(List.of(List.of("urbex:oilrig00", "urbex:oilrig01"))));
         MultiBuildingRE child = new MultiBuildingRE(Optional.empty(),
-                Optional.empty(), Optional.empty(), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "oilrig_burnt"));
+                Optional.empty(), Optional.empty(), Optional.empty());
 
-        MultiBuilding resolved = new MultiBuilding(List.of(parent, child));
+        MultiBuilding resolved = new MultiBuilding(TestAssetId.ANY, List.of(parent, child));
 
         assertEquals(1, resolved.getDimX());
         assertEquals(2, resolved.getDimZ());
@@ -380,7 +371,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildInheritsTheFillerAndPartsItDoesNotDeclare() {
-        Building resolved = new Building(BuiltInRegistries.BLOCK, null, PALETTES, List.of(
+        Building resolved = new Building(TestAssetId.ANY, BuiltInRegistries.BLOCK, null, PALETTES, List.of(
                 building("library").filler("#").parts("urbex:library_floor").minFloors(2).build(),
                 building("library_burnt").rubble("R").build()));
 
@@ -393,13 +384,13 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildCanSetAnInheritedPrefersLonelyBackToZero() {
-        Building resolved = new Building(BuiltInRegistries.BLOCK, null, PALETTES, List.of(
+        Building resolved = new Building(TestAssetId.ANY, BuiltInRegistries.BLOCK, null, PALETTES, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").prefersLonely(0.8f).build(),
                 building("tower_row").prefersLonely(0.0f).build()));
 
         assertEquals(0.0f, resolved.getPrefersLonely(),
                 "0.0 is a value a file can mean, not a marker for 'undeclared'");
-        assertEquals(0.8f, new Building(BuiltInRegistries.BLOCK, null, PALETTES, List.of(
+        assertEquals(0.8f, new Building(TestAssetId.ANY, BuiltInRegistries.BLOCK, null, PALETTES, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").prefersLonely(0.8f).build(),
                 building("tower_row").build())).getPrefersLonely(),
                 "omitting it still inherits");
@@ -407,7 +398,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void buildingChildCanSetAnInheritedFloorLimitBackToTheLevelDefault() {
-        Building resolved = new Building(BuiltInRegistries.BLOCK, null, PALETTES, List.of(
+        Building resolved = new Building(TestAssetId.ANY, BuiltInRegistries.BLOCK, null, PALETTES, List.of(
                 building("tower").filler("#").parts("urbex:tower_floor").minFloors(4).build(),
                 building("tower_short").minFloors(-1).build()));
 
@@ -439,14 +430,12 @@ class RegistryChainResolutionTest {
     private static StyleRE style(String path, List<PaletteSelector>... groups) {
         return new StyleRE(Optional.empty(), groups.length == 0
                 ? Optional.empty()
-                : Optional.of(new Mergeable<>(true, List.of(groups))))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", path));
+                : Optional.of(new Mergeable<>(true, List.of(groups))));
     }
 
     @SafeVarargs
     private static StyleRE styleAppending(String path, List<PaletteSelector>... groups) {
-        return new StyleRE(Optional.empty(), Optional.of(new Mergeable<>(false, List.of(groups))))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", path));
+        return new StyleRE(Optional.empty(), Optional.of(new Mergeable<>(false, List.of(groups))));
     }
 
     private static BuildingBuilder building(String path) {
@@ -504,8 +493,7 @@ class RegistryChainResolutionTest {
                     filler, rubble,
                     Optional.empty(), minFloors, Optional.empty(), Optional.empty(),
                     Optional.empty(), Optional.empty(), Optional.empty(),
-                    prefersLonely, parts, Optional.empty())
-                    .setRegistryName(Identifier.fromNamespaceAndPath("urbex", path));
+                    prefersLonely, parts, Optional.empty());
         }
     }
 
@@ -554,13 +542,11 @@ class RegistryChainResolutionTest {
                         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
                 .toList();
-        return new ConditionRE(Optional.empty(), Optional.of(new Mergeable<>(replace, parts)))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", path));
+        return new ConditionRE(Optional.empty(), Optional.of(new Mergeable<>(replace, parts)));
     }
 
     private static VariantRE variant(String path, boolean replace, BlockEntry... blocks) {
-        return new VariantRE(Optional.empty(), Optional.of(new Mergeable<>(replace, List.of(blocks))))
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", path));
+        return new VariantRE(Optional.empty(), Optional.of(new Mergeable<>(replace, List.of(blocks))));
     }
 
     private static StuffBuilder stuff(String path) {
@@ -644,8 +630,7 @@ class RegistryChainResolutionTest {
         StuffSettingsRE build() {
             return new StuffSettingsRE(Optional.empty(), tags, column, minheight, maxheight,
                     mincount, maxcount, attempts, inbuilding, seesky,
-                    Optional.empty(), Optional.empty(), Optional.empty(), buildings)
-                    .setRegistryName(Identifier.fromNamespaceAndPath(namespace, path));
+                    Optional.empty(), Optional.empty(), Optional.empty(), buildings);
         }
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java
@@ -57,7 +57,7 @@ class RequiredAfterResolutionTest {
         StuffSettingsRE parent = stuff().column("y").counts(2, 5, 10).inbuilding(true).tags("rubble").build();
         StuffSettingsRE child = stuff().tags("debris").build();
 
-        StuffObject resolved = new StuffObject(List.of(parent, child));
+        StuffObject resolved = new StuffObject(TestAssetId.of("test_stuff"), List.of(parent, child));
 
         assertEquals(2, resolved.getSettings().getMincount(),
                 "a field the child omits comes from the chain, not from a codec default");
@@ -73,7 +73,7 @@ class RequiredAfterResolutionTest {
     @Test
     void stuffFieldNoEntryInTheChainDeclaresIsALoadErrorNamingBoth() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new StuffObject(List.of(stuff().column("y").tags("debris").build())));
+                () -> new StuffObject(TestAssetId.of("test_stuff"), List.of(stuff().column("y").tags("debris").build())));
 
         assertTrue(e.getMessage().contains("mincount"), e.getMessage());
         assertTrue(e.getMessage().contains("urbex:test_stuff"), e.getMessage());
@@ -85,7 +85,7 @@ class RequiredAfterResolutionTest {
         // so an undeclared one matched no chunk at all and the decoration was registered, indexed
         // and walked on every city chunk while placing nothing, silently.
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new StuffObject(List.of(stuff().column("y").counts(1, 2, 3).tags("debris").build())));
+                () -> new StuffObject(TestAssetId.of("test_stuff"), List.of(stuff().column("y").counts(1, 2, 3).tags("debris").build())));
 
         assertTrue(e.getMessage().contains("inbuilding"), e.getMessage());
         assertTrue(e.getMessage().contains("urbex:test_stuff"), e.getMessage());
@@ -97,7 +97,7 @@ class RequiredAfterResolutionTest {
         StuffSettingsRE middle = stuff().counts(3, 6, 11).build();
         StuffSettingsRE leaf = stuff().tags("debris").build();
 
-        StuffSettingsRE resolved = new StuffObject(List.of(root, middle, leaf)).getSettings();
+        StuffSettingsRE resolved = new StuffObject(TestAssetId.of("test_stuff"), List.of(root, middle, leaf)).getSettings();
 
         assertEquals("y", resolved.getColumn(), "from the root, two links up");
         assertEquals(3, resolved.getMincount(), "the nearest ancestor that declares one wins");
@@ -112,7 +112,7 @@ class RequiredAfterResolutionTest {
         MultiBuildingRE child = multiBuilding(Optional.empty(), Optional.empty(),
                 Optional.of(List.of(List.of("urbex:w", "urbex:x"), List.of("urbex:y", "urbex:z"))));
 
-        MultiBuilding resolved = new MultiBuilding(List.of(parent, child));
+        MultiBuilding resolved = new MultiBuilding(TestAssetId.of("test_multi"), List.of(parent, child));
 
         assertEquals(2, resolved.getDimX(), "dimx comes from the parent");
         assertEquals(2, resolved.getDimZ(), "dimz comes from the parent");
@@ -126,13 +126,13 @@ class RequiredAfterResolutionTest {
                 Optional.of(List.of(List.of("urbex:tower"))));
         MultiBuildingRE child = multiBuilding(Optional.of(1), Optional.of(1), Optional.empty());
 
-        assertEquals("urbex:tower", new MultiBuilding(List.of(parent, child)).getBuilding(0, 0));
+        assertEquals("urbex:tower", new MultiBuilding(TestAssetId.of("test_multi"), List.of(parent, child)).getBuilding(0, 0));
     }
 
     @Test
     void multiBuildingFieldNoEntryInTheChainDeclaresIsALoadErrorNamingBoth() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new MultiBuilding(List.of(multiBuilding(Optional.empty(), Optional.empty(),
+                () -> new MultiBuilding(TestAssetId.of("test_multi"), List.of(multiBuilding(Optional.empty(), Optional.empty(),
                         Optional.of(List.of(List.of("urbex:a")))))));
 
         assertTrue(e.getMessage().contains("dimx"), e.getMessage());
@@ -153,7 +153,7 @@ class RequiredAfterResolutionTest {
         MultiBuildingRE child = multiBuilding(Optional.of(2), Optional.of(2), Optional.empty());
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new MultiBuilding(List.of(parent, child)));
+                () -> new MultiBuilding(TestAssetId.of("test_multi"), List.of(parent, child)));
 
         assertTrue(e.getMessage().contains("urbex:test_multi"), e.getMessage());
         assertTrue(e.getMessage().contains("dimx"), e.getMessage());
@@ -166,7 +166,7 @@ class RequiredAfterResolutionTest {
                 Optional.of(List.of(List.of("urbex:a", "urbex:b"), List.of("urbex:c"))));
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new MultiBuilding(List.of(entry)));
+                () -> new MultiBuilding(TestAssetId.of("test_multi"), List.of(entry)));
 
         assertTrue(e.getMessage().contains("urbex:test_multi"), e.getMessage());
         assertTrue(e.getMessage().contains("dimz"), e.getMessage());
@@ -175,7 +175,7 @@ class RequiredAfterResolutionTest {
     @Test
     void multiBuildingWithNoGridAnywhereInTheChainIsALoadError() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new MultiBuilding(List.of(
+                () -> new MultiBuilding(TestAssetId.of("test_multi"), List.of(
                         multiBuilding(Optional.of(1), Optional.of(1), Optional.empty()))));
 
         assertTrue(e.getMessage().contains("buildings"), e.getMessage());
@@ -194,7 +194,7 @@ class RequiredAfterResolutionTest {
     @Test
     void scatteredWithNeitherBuildingsNorMultiBuildingInTheChainIsALoadError() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new ScatteredBuilding(List.of(scattered(Optional.empty(), Optional.empty()))));
+                () -> new ScatteredBuilding(TestAssetId.of("test_scattered"), List.of(scattered(Optional.empty(), Optional.empty()))));
 
         assertTrue(e.getMessage().contains("urbex:test_scattered"), e.getMessage());
         assertTrue(e.getMessage().contains("buildings"), e.getMessage());
@@ -207,7 +207,7 @@ class RequiredAfterResolutionTest {
                 Optional.empty());
         ScatteredRE child = scattered(Optional.empty(), Optional.empty());
 
-        ScatteredBuilding resolved = new ScatteredBuilding(List.of(parent, child));
+        ScatteredBuilding resolved = new ScatteredBuilding(TestAssetId.of("test_scattered"), List.of(parent, child));
 
         assertEquals(List.of("urbex:cabin"), resolved.getBuildings(),
                 "a child that only restates terrain still inherits the chain's building list");
@@ -215,7 +215,7 @@ class RequiredAfterResolutionTest {
 
     @Test
     void scatteredSatisfiesThePairWithMultiBuildingAlone() {
-        ScatteredBuilding resolved = new ScatteredBuilding(List.of(
+        ScatteredBuilding resolved = new ScatteredBuilding(TestAssetId.of("test_scattered"), List.of(
                 scattered(Optional.empty(), Optional.of("urbex:oilrig"))));
 
         assertEquals("urbex:oilrig", resolved.getMultibuilding());
@@ -233,7 +233,7 @@ class RequiredAfterResolutionTest {
                 Optional.empty());
         WorldStyleRE child = worldStyle(Optional.empty(), Optional.empty(), Optional.of(scattered));
 
-        WorldStyle resolved = new WorldStyle(List.of(parent, child));
+        WorldStyle resolved = new WorldStyle(TestAssetId.of("test_world"), List.of(parent, child));
 
         assertEquals("urbex:standard", resolved.getOutsideStyle(),
                 "outsidestyle comes from the parent");
@@ -245,7 +245,7 @@ class RequiredAfterResolutionTest {
     @Test
     void worldStyleFieldNoEntryInTheChainDeclaresIsALoadErrorNamingBoth() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new WorldStyle(List.of(worldStyle(Optional.empty(), Optional.empty(),
+                () -> new WorldStyle(TestAssetId.of("test_world"), List.of(worldStyle(Optional.empty(), Optional.empty(),
                         Optional.of(new ScatteredSettings(16, 0.5f, 10, List.of()))))));
 
         assertTrue(e.getMessage().contains("outsidestyle"), e.getMessage());
@@ -255,7 +255,7 @@ class RequiredAfterResolutionTest {
     @Test
     void worldStyleWithNoCityStylesAnywhereInTheChainIsALoadError() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new WorldStyle(List.of(
+                () -> new WorldStyle(TestAssetId.of("test_world"), List.of(
                         worldStyle(Optional.of("urbex:standard"), Optional.empty(), Optional.empty()))));
 
         assertTrue(e.getMessage().contains("citystyles"), e.getMessage());
@@ -264,7 +264,7 @@ class RequiredAfterResolutionTest {
 
     @Test
     void worldStyleThatDeclaresAnEmptyCityStyleListHasDeclaredIt() {
-        WorldStyle resolved = new WorldStyle(List.of(worldStyle(Optional.of("urbex:standard"),
+        WorldStyle resolved = new WorldStyle(TestAssetId.of("test_world"), List.of(worldStyle(Optional.of("urbex:standard"),
                 Optional.of(new Mergeable<>(true, List.of())), Optional.empty())));
 
         assertEquals(List.of(), cityStyleNames(resolved),
@@ -281,14 +281,12 @@ class RequiredAfterResolutionTest {
                                          Optional<String> multibuilding) {
         return new ScatteredRE(Optional.empty(), buildings, multibuilding, Optional.empty(),
                 Optional.of(ScatteredBuilding.TerrainHeight.AVERAGE),
-                Optional.of(ScatteredBuilding.TerrainFix.NONE), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_scattered"));
+                Optional.of(ScatteredBuilding.TerrainFix.NONE), Optional.empty());
     }
 
     private static MultiBuildingRE multiBuilding(Optional<Integer> dimX, Optional<Integer> dimZ,
                                                  Optional<List<List<String>>> buildings) {
-        return new MultiBuildingRE(Optional.empty(), dimX, dimZ, buildings)
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_multi"));
+        return new MultiBuildingRE(Optional.empty(), dimX, dimZ, buildings);
     }
 
     /**
@@ -303,8 +301,7 @@ class RequiredAfterResolutionTest {
         return new WorldStyleRE(Optional.empty(), Optional.empty(), outsideStyle,
                 Optional.empty(), Optional.empty(), scattered,
                 Optional.of(TestWiring.partSelector()),
-                cityStyles, Optional.empty(), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_world"));
+                cityStyles, Optional.empty(), Optional.empty());
     }
 
     private static StuffBuilder stuff() {
@@ -346,8 +343,7 @@ class RequiredAfterResolutionTest {
             return new StuffSettingsRE(Optional.empty(), tags, column,
                     Optional.empty(), Optional.empty(), mincount, maxcount, attempts,
                     inbuilding, Optional.empty(),
-                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
-                    .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "test_stuff"));
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         }
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/StyleDisplayNameTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/StyleDisplayNameTest.java
@@ -40,31 +40,28 @@ class StyleDisplayNameTest {
         return Identifier.fromNamespaceAndPath(namespace, path);
     }
 
-    private static WorldStyleRE worldStyle(Identifier registryName, Optional<String> name) {
+    private static WorldStyleRE worldStyle(Optional<String> name) {
         return new WorldStyleRE(Optional.empty(), name, Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
                         List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
-                Optional.empty(), Optional.empty())
-                .setRegistryName(registryName);
+                Optional.empty(), Optional.empty());
     }
 
-    private static CityStyleRE cityStyle(Identifier registryName, Optional<String> name) {
+    private static CityStyleRE cityStyle(Optional<String> name) {
         return new CityStyleRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), name,
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.of(TestWiring.streetSettings()),
-                Optional.empty())
-                .setRegistryName(registryName);
+                Optional.empty());
     }
 
     // ---------------------------------------------------------------- world styles
 
     @Test
     void aWorldStyleDeclaringNoNameIsLabelledByItsId() {
-        WorldStyle resolved = new WorldStyle(
-                List.of(worldStyle(id("urbex", "standard"), Optional.empty())));
+        WorldStyle resolved = new WorldStyle(id("urbex", "standard"), List.of(worldStyle(Optional.empty())));
 
         assertEquals("urbex:standard", resolved.getDisplayName(),
                 "every world style written before this field existed must keep reading as its id");
@@ -72,8 +69,7 @@ class StyleDisplayNameTest {
 
     @Test
     void aWorldStyleShowsTheNameItDeclares() {
-        WorldStyle resolved = new WorldStyle(
-                List.of(worldStyle(id("urbex", "standard"), Optional.of("Standard"))));
+        WorldStyle resolved = new WorldStyle(id("urbex", "standard"), List.of(worldStyle(Optional.of("Standard"))));
 
         assertEquals("Standard", resolved.getDisplayName());
     }
@@ -85,9 +81,9 @@ class StyleDisplayNameTest {
      */
     @Test
     void aWorldStyleWithoutANameInheritsItsParents() {
-        WorldStyle resolved = new WorldStyle(List.of(
-                worldStyle(id("urbex", "standard"), Optional.of("Standard")),
-                worldStyle(id("urbexza", "zombie_apocalypse"), Optional.empty())));
+        WorldStyle resolved = new WorldStyle(id("urbexza", "zombie_apocalypse"), List.of(
+                worldStyle(Optional.of("Standard")),
+                worldStyle(Optional.empty())));
 
         assertEquals("Standard", resolved.getDisplayName(),
                 "the inheritance is why every shipped world style restates its own name");
@@ -95,17 +91,16 @@ class StyleDisplayNameTest {
 
     @Test
     void aWorldStylesOwnNameWinsOverTheOneItExtends() {
-        WorldStyle resolved = new WorldStyle(List.of(
-                worldStyle(id("urbex", "standard"), Optional.of("Standard")),
-                worldStyle(id("urbexza", "zombie_apocalypse"), Optional.of("Zombie Apocalypse"))));
+        WorldStyle resolved = new WorldStyle(id("urbexza", "zombie_apocalypse"), List.of(
+                worldStyle(Optional.of("Standard")),
+                worldStyle(Optional.of("Zombie Apocalypse"))));
 
         assertEquals("Zombie Apocalypse", resolved.getDisplayName());
     }
 
     @Test
     void anEmptyWorldStyleNameIsTreatedAsNoneRatherThanAsABlankLabel() {
-        WorldStyle resolved = new WorldStyle(
-                List.of(worldStyle(id("urbex", "standard"), Optional.of(""))));
+        WorldStyle resolved = new WorldStyle(id("urbex", "standard"), List.of(worldStyle(Optional.of(""))));
 
         assertEquals("urbex:standard", resolved.getDisplayName());
     }
@@ -119,28 +114,26 @@ class StyleDisplayNameTest {
     void theStaticFoldTheGuiUsesMatchesWhatTheConstructorResolves() {
         Identifier leaf = id("urbexmt", "moderntweaks");
         List<WorldStyleRE> chain = List.of(
-                worldStyle(id("urbex", "standard"), Optional.of("Standard")),
-                worldStyle(leaf, Optional.of("Modern Tweaks")));
+                worldStyle(Optional.of("Standard")),
+                worldStyle(Optional.of("Modern Tweaks")));
 
-        assertEquals(new WorldStyle(chain).getDisplayName(), WorldStyle.displayNameOf(chain, leaf));
+        assertEquals(new WorldStyle(leaf, chain).getDisplayName(), WorldStyle.displayNameOf(chain, leaf));
         assertEquals("urbexmt:moderntweaks",
-                WorldStyle.displayNameOf(List.of(worldStyle(leaf, Optional.empty())), leaf));
+                WorldStyle.displayNameOf(List.of(worldStyle(Optional.empty())), leaf));
     }
 
     // ---------------------------------------------------------------- city styles
 
     @Test
     void aCityStyleDeclaringNoNameIsLabelledByItsId() {
-        CityStyle resolved = new CityStyle(
-                List.of(cityStyle(id("urbex", "citystyle_standard"), Optional.empty())));
+        CityStyle resolved = new CityStyle(id("urbex", "citystyle_standard"), List.of(cityStyle(Optional.empty())));
 
         assertEquals("urbex:citystyle_standard", resolved.getDisplayName());
     }
 
     @Test
     void aCityStyleShowsTheNameItDeclares() {
-        CityStyle resolved = new CityStyle(
-                List.of(cityStyle(id("urbex", "citystyle_desert"), Optional.of("Desert"))));
+        CityStyle resolved = new CityStyle(id("urbex", "citystyle_desert"), List.of(cityStyle(Optional.of("Desert"))));
 
         assertEquals("Desert", resolved.getDisplayName());
     }
@@ -152,23 +145,23 @@ class StyleDisplayNameTest {
      */
     @Test
     void aCityStyleWithoutANameInheritsItsParents() {
-        CityStyle borrowed = new CityStyle(List.of(
-                cityStyle(id("urbex", "citystyle_common"), Optional.of("Common")),
-                cityStyle(id("mypack", "downtown"), Optional.empty())));
+        CityStyle borrowed = new CityStyle(id("mypack", "downtown"), List.of(
+                cityStyle(Optional.of("Common")),
+                cityStyle(Optional.empty())));
         assertEquals("Common", borrowed.getDisplayName());
 
-        CityStyle ownId = new CityStyle(List.of(
-                cityStyle(id("urbex", "citystyle_common"), Optional.empty()),
-                cityStyle(id("mypack", "downtown"), Optional.empty())));
+        CityStyle ownId = new CityStyle(id("mypack", "downtown"), List.of(
+                cityStyle(Optional.empty()),
+                cityStyle(Optional.empty())));
         assertEquals("mypack:downtown", ownId.getDisplayName(),
                 "an unnamed base is what lets an unnamed child keep its own identity");
     }
 
     @Test
     void aCityStylesOwnNameWinsOverTheOneItExtends() {
-        CityStyle resolved = new CityStyle(List.of(
-                cityStyle(id("urbex", "citystyle_common"), Optional.of("Common")),
-                cityStyle(id("urbexmt", "citystyle_desert"), Optional.of("Modern Desert"))));
+        CityStyle resolved = new CityStyle(id("urbexmt", "citystyle_desert"), List.of(
+                cityStyle(Optional.of("Common")),
+                cityStyle(Optional.of("Modern Desert"))));
 
         assertEquals("Modern Desert", resolved.getDisplayName());
     }
@@ -176,12 +169,10 @@ class StyleDisplayNameTest {
     /** {@code getName()} stays the id: worldgen, logs and conditions all key off it. */
     @Test
     void namingAStyleDoesNotChangeWhatGetNameReturns() {
-        CityStyle city = new CityStyle(
-                List.of(cityStyle(id("urbex", "citystyle_desert"), Optional.of("Desert"))));
+        CityStyle city = new CityStyle(id("urbex", "citystyle_desert"), List.of(cityStyle(Optional.of("Desert"))));
         assertEquals("urbex:citystyle_desert", city.getName());
 
-        WorldStyle world = new WorldStyle(
-                List.of(worldStyle(id("urbex", "standard"), Optional.of("Standard"))));
+        WorldStyle world = new WorldStyle(id("urbex", "standard"), List.of(worldStyle(Optional.of("Standard"))));
         assertEquals("urbex:standard", world.getName());
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/TestAssetId.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/TestAssetId.java
@@ -1,0 +1,26 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import net.minecraft.resources.Identifier;
+
+/**
+ * The registry id a test hands to a compiled asset it builds by hand.
+ * <p>
+ * A compiled asset takes its id as a constructor argument, because the compiler already has it -
+ * the decoded definition used to have it written into it by {@code IAsset.setRegistryName}, which
+ * made compilation mutate the authored model (issue #128). Tests build chains without a registry,
+ * so they have to supply one. {@link #ANY} is for the many tests where the id is not what is under
+ * test and only exists so an error message has something to name; {@link #of} is for the few that
+ * assert on it.
+ */
+public final class TestAssetId {
+
+    /** For a test that does not care what the asset is called. */
+    public static final Identifier ANY = Identifier.fromNamespaceAndPath("urbex", "test_asset");
+
+    private TestAssetId() {
+    }
+
+    public static Identifier of(String path) {
+        return Identifier.fromNamespaceAndPath("urbex", path);
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java
@@ -92,7 +92,7 @@ class WiringRequiredTest {
 
     @Test
     void aChildAppendsToTheStraightPartsItInheritsWhenItOptsIn() {
-        CityStyle resolved = new CityStyle(List.of(
+        CityStyle resolved = new CityStyle(TestAssetId.of("citystyle_parent"), List.of(
                 cityStyle("parent", TestWiring.streetParts("street")),
                 cityStyle("child", partsWith("straight",
                         new Mergeable<>(false, List.of("urbex:street_straight_alt"))))));
@@ -106,7 +106,7 @@ class WiringRequiredTest {
 
     @Test
     void aChildsBareArrayReplacesTheStraightPartsItInherits() {
-        CityStyle resolved = new CityStyle(List.of(
+        CityStyle resolved = new CityStyle(TestAssetId.of("citystyle_parent"), List.of(
                 cityStyle("parent", TestWiring.streetParts("street")),
                 cityStyle("child", partsWith("straight",
                         new Mergeable<>(true, List.of("urbex:street_straight_alt"))))));
@@ -125,13 +125,13 @@ class WiringRequiredTest {
                         Optional.empty(), Optional.empty(), Optional.empty())),
                 Optional.empty()));
 
-        HighwayParts resolved = new WorldStyle(List.of(parent, child)).getPartSelector().highwayParts();
+        HighwayParts resolved = new WorldStyle(TestAssetId.of("test_world"), List.of(parent, child)).getPartSelector().highwayParts();
 
         assertEquals(List.of("urbex:test_highway_tunnel", "urbex:highway_tunnel_alt"), resolved.tunnel());
         assertEquals(List.of("urbex:test_highway_open"), resolved.open(),
                 "a field the child never mentions is inherited unchanged");
         assertEquals(List.of("urbex:test_rails_bend"),
-                new WorldStyle(List.of(parent, child)).getPartSelector().railwayParts().railsBend(),
+                new WorldStyle(TestAssetId.of("test_world"), List.of(parent, child)).getPartSelector().railwayParts().railsBend(),
                 "and so is the group it never mentions");
     }
 
@@ -140,7 +140,7 @@ class WiringRequiredTest {
     @Test
     void aCityStyleWithNoStreetPartsAnywhereInTheChainIsALoadError() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new CityStyle(List.of(cityStyle("bare", null))));
+                () -> new CityStyle(TestAssetId.of("citystyle_bare"), List.of(cityStyle("bare", null))));
 
         assertTrue(e.getMessage().contains("streetblocks.parts"), e.getMessage());
         assertTrue(e.getMessage().contains("urbex:citystyle_bare"), e.getMessage());
@@ -149,7 +149,7 @@ class WiringRequiredTest {
     @Test
     void aCityStyleThatDeclaresHalfAFamilyIsALoadErrorNamingTheMissingComponent() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new CityStyle(List.of(cityStyle("half",
+                () -> new CityStyle(TestAssetId.of("citystyle_half"), List.of(cityStyle("half",
                         partsWith("straight", new Mergeable<>(true, List.of("urbex:street_straight")))))));
 
         assertTrue(e.getMessage().contains("streetblocks.parts.end"), e.getMessage());
@@ -158,7 +158,7 @@ class WiringRequiredTest {
 
     @Test
     void aChildThatDeclaresOneComponentStillLoadsWhenAnAncestorCoversTheRest() {
-        CityStyle resolved = new CityStyle(List.of(
+        CityStyle resolved = new CityStyle(TestAssetId.of("citystyle_parent"), List.of(
                 cityStyle("parent", TestWiring.streetParts("street")),
                 cityStyle("child", partsWith("all",
                         new Mergeable<>(true, List.of("urbex:street_all_alt"))))));
@@ -177,14 +177,14 @@ class WiringRequiredTest {
                 Optional.empty());
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new CityStyle(List.of(cityStyleRE("halflarge", settings))));
+                () -> new CityStyle(TestAssetId.of("citystyle_halflarge"), List.of(cityStyleRE("halflarge", settings))));
 
         assertTrue(e.getMessage().contains("streetblocks.largeparts.end"), e.getMessage());
     }
 
     @Test
     void theLargeAndTertiaryFamiliesFallBackToTheSecondaryOneWhenNothingDeclaresThem() {
-        CityStyle resolved = new CityStyle(List.of(cityStyle("plain", TestWiring.streetParts("street"))));
+        CityStyle resolved = new CityStyle(TestAssetId.of("citystyle_plain"), List.of(cityStyle("plain", TestWiring.streetParts("street"))));
 
         assertSame(resolved.getStreetParts(), resolved.getLargeStreetParts(),
                 "primary roads draw from the pack's own secondary parts, not from Java's");
@@ -194,7 +194,7 @@ class WiringRequiredTest {
     @Test
     void aWorldStyleWithNoPartsBlockAnywhereInTheChainIsALoadError() {
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new WorldStyle(List.of(worldStyle("bare", null))));
+                () -> new WorldStyle(TestAssetId.of("bare"), List.of(worldStyle("bare", null))));
 
         assertTrue(e.getMessage().contains("'parts'"), e.getMessage());
         assertTrue(e.getMessage().contains("urbex:bare"), e.getMessage());
@@ -206,7 +206,7 @@ class WiringRequiredTest {
                 TestWiring.partSelector().highways(), Optional.empty());
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new WorldStyle(List.of(worldStyle("nrail", highwaysOnly))));
+                () -> new WorldStyle(TestAssetId.of("nrail"), List.of(worldStyle("nrail", highwaysOnly))));
 
         assertTrue(e.getMessage().contains("parts.railways"), e.getMessage());
         assertTrue(e.getMessage().contains("urbex:nrail"), e.getMessage());
@@ -224,7 +224,7 @@ class WiringRequiredTest {
                         Optional.empty(), Optional.empty(), Optional.empty())));
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new WorldStyle(List.of(worldStyle("halfrail", halfRail))));
+                () -> new WorldStyle(TestAssetId.of("halfrail"), List.of(worldStyle("halfrail", halfRail))));
 
         assertTrue(e.getMessage().contains("parts.railways.stationopen"), e.getMessage());
     }
@@ -254,14 +254,12 @@ class WiringRequiredTest {
         return new CityStyleRE(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.empty(), Optional.ofNullable(settings), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", "citystyle_" + name));
+                Optional.empty(), Optional.empty(), Optional.ofNullable(settings), Optional.empty());
     }
 
     private static WorldStyleRE worldStyle(String name, PartSelector.Decl parts) {
         return new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.ofNullable(parts),
-                Optional.of(new Mergeable<>(true, List.of())), Optional.empty(), Optional.empty())
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", name));
+                Optional.of(new Mergeable<>(true, List.of())), Optional.empty(), Optional.empty());
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java
@@ -47,13 +47,12 @@ class WorldStyleRotatableTagTest {
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
                         List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
-                Optional.empty(), rotatable)
-                .setRegistryName(Identifier.fromNamespaceAndPath("urbex", name));
+                Optional.empty(), rotatable);
     }
 
     @Test
     void aChainDeclaringNothingResolvesToUrbexRotatable() {
-        WorldStyle resolved = new WorldStyle(List.of(worldStyle("standard", Optional.empty())));
+        WorldStyle resolved = new WorldStyle(TestAssetId.ANY, List.of(worldStyle("standard", Optional.empty())));
 
         assertEquals(tag("urbex", "rotatable"), resolved.getRotatableTag(),
                 "every asset written before this field existed must keep the old behaviour");
@@ -61,7 +60,7 @@ class WorldStyleRotatableTagTest {
 
     @Test
     void whatTheChildDeclaresWins() {
-        WorldStyle resolved = new WorldStyle(List.of(
+        WorldStyle resolved = new WorldStyle(TestAssetId.ANY, List.of(
                 worldStyle("standard", Optional.empty()),
                 worldStyle("zombie", Optional.of(tag("urbexza", "rotatable")))));
 
@@ -70,7 +69,7 @@ class WorldStyleRotatableTagTest {
 
     @Test
     void aChildThatOmitsItInheritsRatherThanRevertingToTheDefault() {
-        WorldStyle resolved = new WorldStyle(List.of(
+        WorldStyle resolved = new WorldStyle(TestAssetId.ANY, List.of(
                 worldStyle("standard", Optional.of(tag("urbexza", "rotatable"))),
                 worldStyle("child", Optional.empty())));
 


### PR DESCRIPTION
**128d**, first half — retiring `IAsset.setRegistryName`. Phase 2 step 4 of epic #134.

> Stacked on #146 → #145 → #144. This diff is against #146.

The `*RE` → `*Definition` rename is the *second* half and lands separately, so the rename noise
cannot hide this. Same reason this is not folded into #145.

## What was wrong

Resolving an `extends` chain wrote each link's registry id **onto the decoded object**:

```java
R entry = registry.getValue(ResourceKey.create(registryKey, key));
if (entry instanceof IAsset asset) {
    asset.setRegistryName(key);      // <- compilation mutating the authored model
}
```

…so that the compiled asset could read its own id back off the last link:

```java
name = chainRootFirst.get(chainRootFirst.size() - 1).getRegistryName();
```

Two things wrong with that, and only one of them is tidiness:

- **A registry entry's identity depended on something having walked a chain that reached it.** An
  entry nothing extended and nothing compiled had a null name. Identity is not a fact the entry
  carried; it was a side effect of compilation order.
- **Two compilations of the same registry wrote to the same decoded objects.** Harmless today,
  because they write the same value — but it is the last of the "compilation mutates registry-held
  definitions" acceptance criteria in #128, and the one that made the definitions un-shareable in
  principle.

## What changed

The compiler already has the id — `AssetStage.compileAll` passes it to the compile lambda, which was
ignoring it. It is a constructor argument now:

```java
(id, chain) -> new Variant(id, blockLookup, chain)
```

`IAsset`, `setRegistryName`, `getRegistryName` and the `name` field are deleted from all thirteen
definition types, and the chain walk writes nothing back.

`StuffSettingsRE.resolve` takes the id for the same reason: the fold it builds is a **synthetic entry
no registry holds**, and writing an id into it just so `requireResolved` could name the asset in an
error is precisely what `setRegistryName` existed for.

## The test churn, and why it is not just churn

Tests build chains by hand, with no registry, so they now supply the id themselves. That is the
change made visible: it used to be smuggled in by a setter on the definition.

- **`TestAssetId.ANY`** for the many tests where the id is not under test and only exists so an error
  message has something to name.
- **`TestAssetId.of(...)` and literal ids** for the ones that genuinely assert on it — the stuff sort
  order (an RNG address, so the ids are the *point*), the display-name fold, `BuildingPart`'s
  geometry errors, and `DatapackGuideExamplesTest`, which checks the guide quotes the exact messages
  the code produces, ids included.

Two test helpers had a `registryName`/`path` parameter that no longer feeds anything. `StyleDisplayNameTest`'s
lost it outright; `BuildingPartExtendsTest.part` keeps its `path` with a comment saying where the id
went, because every call site reads better naming the part it is building.

## Verification

```
./gradlew test               # pass, 551 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK
```

**Both digest goldens are unchanged.** Every asset ends up with the same id it had; only the
direction it travels changed.
