### PR TITLE
refactor: rename *RE to *Definition (#128, 128d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **The authored asset types are named `*Definition`, not `*RE`.** Thirteen classes and every
+  reference to them; a `PaletteRE` is a `PaletteDefinition`, `Preset.toRE()` is
+  `Preset.toDefinition()`. Mechanical only — no behaviour, no logic, nothing else in the same change
+  (issue #128).
+
 - **Compilation no longer writes registry ids into the definitions it reads.** A compiled asset takes
   its id as a constructor argument, from the compiler that already has it, instead of reading it off
   a definition that `IAsset.setRegistryName` had written it into on the way past. The interface, the

--- a/docs/superpowers/specs/2026-08-12-asset-snapshot-design.md
+++ b/docs/superpowers/specs/2026-08-12-asset-snapshot-design.md
@@ -121,6 +121,17 @@ required and both digest runs confirmed by logging no warning.
 never hides a semantic change. Also retires `IAsset.setRegistryName`: identity travels beside the
 decoded value instead of being written into it.
 
+*Landed as two PRs, logic first.* `setRegistryName` goes in its own PR — a compiled asset takes its
+id as a constructor argument from the compiler that already has it — and the rename follows as a pure
+mechanical change on top.
+
+*No `*Patch`.* Every `*RE` became `*Definition`. The `*Patch` half of the name was for a type that is
+only ever an overlay onto something already resolved, and there isn't one: each of the thirteen is a
+registry entry that may also be a link in an `extends` chain, which is what `Mergeable` and the chain
+fold handle. `PresetDefinition` is the closest — it doubles as the customization-overrides payload
+`Presets.applyOverrides` takes — but splitting that one type's two roles is a semantic change, not a
+rename, so it does not belong in a mechanical PR.
+
 **Then #56's remainder** becomes possible — the palette-character / slice-size / dangling-reference
 walk, which needs the compile-time palette merge 128a introduces. See the sequencing comment on #56.
 

--- a/src/main/java/dev/krona/urbex/commands/CommandExportPart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandExportPart.java
@@ -17,8 +17,8 @@ import dev.krona.urbex.worldgen.lost.BuildingInfo;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import dev.krona.urbex.worldgen.lost.cityassets.CompiledPalette;
 import dev.krona.urbex.worldgen.lost.cityassets.Palette;
-import dev.krona.urbex.worldgen.lost.regassets.BuildingPartRE;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import net.fabricmc.loader.api.FabricLoader;
@@ -140,8 +140,8 @@ public class CommandExportPart implements Command<CommandSourceStack> {
                         Optional.empty(),
                         Optional.empty()));
             }
-            PaletteRE paletteRE = new PaletteRE(Optional.empty(), Optional.of(entries));
-            DataResult<JsonElement> result = PaletteRE.CODEC.encodeStart(JsonOps.INSTANCE, paletteRE);
+            PaletteDefinition paletteDefinition = new PaletteDefinition(Optional.empty(), Optional.of(entries));
+            DataResult<JsonElement> result = PaletteDefinition.CODEC.encodeStart(JsonOps.INSTANCE, paletteDefinition);
             root.add("__comment__", new JsonPrimitive("'missingpalette' represents all blockstates that it couldn't find in the palette. These have to be put in a palette. " +
                     "'exportedpart' is the actual exported part"));
             root.add("missingpalette", result.result().get());
@@ -149,10 +149,10 @@ public class CommandExportPart implements Command<CommandSourceStack> {
             root.add("__comment__", new JsonPrimitive("'exportedpart' is the actual exported part"));
         }
 
-        BuildingPartRE buildingPartRE = new BuildingPartRE(Optional.empty(),
+        BuildingPartDefinition buildingPartRE = new BuildingPartDefinition(Optional.empty(),
                 Optional.of(part.getXSize()), Optional.of(part.getZSize()), Optional.of(slices),
                 Optional.ofNullable(part.getRefPaletteName()), Optional.empty(), Optional.empty());
-        DataResult<JsonElement> result = BuildingPartRE.CODEC.encodeStart(JsonOps.INSTANCE, buildingPartRE);
+        DataResult<JsonElement> result = BuildingPartDefinition.CODEC.encodeStart(JsonOps.INSTANCE, buildingPartRE);
         root.add("exportedpart", result.result().get());
 
         String json = gson.toJson(root);

--- a/src/main/java/dev/krona/urbex/commands/CommandSavePreset.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandSavePreset.java
@@ -10,7 +10,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.JsonOps;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.worldgen.IDimensionInfo;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
@@ -43,7 +43,7 @@ public class CommandSavePreset implements Command<CommandSourceStack> {
             return 0;
         }
         Preset preset = dimInfo.getProfile();
-        JsonElement json = PresetRE.CODEC.encodeStart(JsonOps.INSTANCE, preset.toRE()).getOrThrow();
+        JsonElement json = PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, preset.toDefinition()).getOrThrow();
         Path out = FabricLoader.getInstance().getGameDir().resolve("urbex-export");
         Path target = out.resolve(preset.getId().getPath() + ".json");
         try {

--- a/src/main/java/dev/krona/urbex/config/Preset.java
+++ b/src/main/java/dev/krona/urbex/config/Preset.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.config;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.setup.ModSetup;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.AtmosphereSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.BuildingSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.CitySettings;
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 /**
  * A fully-resolved preset: the runtime settings used by worldgen, produced by walking a
- * {@link PresetRE}'s extends chain onto these code defaults (see {@code Presets.resolve}).
+ * {@link PresetDefinition}'s extends chain onto these code defaults (see {@code Presets.resolve}).
  * <p>
  * Public field names match the runtime-generated profile format this class replaced (same names,
  * same types) so that the worldgen consumers migrated by a pure type rename. Exceptions: there is
@@ -184,7 +184,7 @@ public class Preset {
     /**
      * The authored display name, or {@code ""} when nothing in the {@code extends} chain declared
      * one. Callers rendering a label want {@link #getDisplayName()}, which fills that gap in; this
-     * raw form exists so {@link #toRE()} round-trips "no name was authored" as an empty string
+     * raw form exists so {@link #toDefinition()} round-trips "no name was authored" as an empty string
      * rather than inventing the id as an authored value.
      */
     public String getName() {
@@ -432,10 +432,10 @@ public class Preset {
     }
 
     /**
-     * Encodes this preset as a {@link PresetRE} with every field present (fully-populated
+     * Encodes this preset as a {@link PresetDefinition} with every field present (fully-populated
      * sections). Used for round-trip tests, saved-data overrides, and the export command.
      */
-    public PresetRE toRE() {
+    public PresetDefinition toDefinition() {
         TerrainSettings terrain =
                 new TerrainSettings(
                 Optional.of(LANDSCAPE_TYPE),
@@ -583,7 +583,7 @@ public class Preset {
                 Optional.of(EDITMODE),
                 Optional.of(GENERATE_NETHER));
 
-        return new PresetRE(
+        return new PresetDefinition(
                 Optional.empty(),
                 Optional.of(name),
                 Optional.of(description),

--- a/src/main/java/dev/krona/urbex/config/Presets.java
+++ b/src/main/java/dev/krona/urbex/config/Presets.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.config;
 
 import dev.krona.urbex.setup.CustomRegistries;
 import dev.krona.urbex.worldgen.lost.cityassets.ExtendsChain;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
@@ -18,12 +18,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
- * Resolves {@link PresetRE} {@code extends} chains into runtime {@link Preset}s, and lists the
+ * Resolves {@link PresetDefinition} {@code extends} chains into runtime {@link Preset}s, and lists the
  * presets a UI should offer to browse.
  */
 public class Presets {
 
-    public static final TagKey<PresetRE> TAG_BROWSABLE =
+    public static final TagKey<PresetDefinition> TAG_BROWSABLE =
             TagKey.create(CustomRegistries.PRESET_REGISTRY_KEY, Identifier.fromNamespaceAndPath("urbex", "presets"));
 
     private static final Identifier DEFAULT_PRESET_ID = Identifier.fromNamespaceAndPath("urbex", "default");
@@ -44,10 +44,10 @@ public class Presets {
      * @throws IllegalStateException if the extends chain cycles, or a referenced id is unknown to
      *                                {@code lookup}.
      */
-    public static Preset resolve(Identifier id, Function<Identifier, PresetRE> lookup) {
-        List<PresetRE> chain = ExtendsChain.resolve(id, lookup, PresetRE::getExtends);
+    public static Preset resolve(Identifier id, Function<Identifier, PresetDefinition> lookup) {
+        List<PresetDefinition> chain = ExtendsChain.resolve(id, lookup, PresetDefinition::getExtends);
         Preset p = new Preset(id);
-        for (PresetRE re : chain) {
+        for (PresetDefinition re : chain) {
             re.applyTo(p);
         }
         return p;
@@ -59,14 +59,14 @@ public class Presets {
         if (cached != null) {
             return cached;
         }
-        Registry<PresetRE> registry = access.lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY);
+        Registry<PresetDefinition> registry = access.lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY);
         Preset resolved = resolve(id, registry::getValue);
         Preset raced = CACHE.putIfAbsent(id, resolved);
         return raced != null ? raced : resolved;
     }
 
     /** Clones {@code base} and applies {@code overrides}'s present sections on top of the clone. */
-    public static Preset applyOverrides(Preset base, PresetRE overrides) {
+    public static Preset applyOverrides(Preset base, PresetDefinition overrides) {
         Preset p = base.copy();
         overrides.applyTo(p);
         return p;
@@ -82,9 +82,9 @@ public class Presets {
      * use.
      */
     public static List<Identifier> listBrowsable(RegistryAccess access) {
-        Registry<PresetRE> registry = access.lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY);
+        Registry<PresetDefinition> registry = access.lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY);
         List<Identifier> ids = new ArrayList<>();
-        for (Holder<PresetRE> holder : registry.getTagOrEmpty(TAG_BROWSABLE)) {
+        for (Holder<PresetDefinition> holder : registry.getTagOrEmpty(TAG_BROWSABLE)) {
             holder.unwrapKey().ifPresent(key -> ids.add(key.identifier()));
         }
         if (ids.isEmpty()) {

--- a/src/main/java/dev/krona/urbex/gui/CitiesTab.java
+++ b/src/main/java/dev/krona/urbex/gui/CitiesTab.java
@@ -8,8 +8,8 @@ import dev.krona.urbex.setup.CustomRegistries;
 import dev.krona.urbex.setup.WorldStyleMix;
 import dev.krona.urbex.worldgen.lost.cityassets.ExtendsChain;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
@@ -404,7 +404,7 @@ public class CitiesTab extends GridLayoutTab {
      */
     private static Map<String, String> registeredWorldStyles(CreateWorldScreen screen) {
         RegistryAccess access = screen.getUiState().getSettings().worldgenLoadContext();
-        Optional<Registry<WorldStyleRE>> registry = access.lookup(CustomRegistries.WORLDSTYLES_REGISTRY_KEY);
+        Optional<Registry<WorldStyleDefinition>> registry = access.lookup(CustomRegistries.WORLDSTYLES_REGISTRY_KEY);
         if (registry.isEmpty()) {
             return Map.of();
         }
@@ -427,10 +427,10 @@ public class CitiesTab extends GridLayoutTab {
      * cause, and a dropdown that throws out of its own constructor would take the create-world
      * screen down before the player ever got that message.
      */
-    private static String worldStyleDisplayName(Registry<WorldStyleRE> registry, Identifier id) {
+    private static String worldStyleDisplayName(Registry<WorldStyleDefinition> registry, Identifier id) {
         try {
             return WorldStyle.displayNameOf(
-                    ExtendsChain.resolve(id, registry::getValue, WorldStyleRE::getExtends), id);
+                    ExtendsChain.resolve(id, registry::getValue, WorldStyleDefinition::getExtends), id);
         } catch (RuntimeException e) {
             return id.toString();
         }
@@ -453,7 +453,7 @@ public class CitiesTab extends GridLayoutTab {
      */
     private static List<PresetSelection.Entry> registeredPresets(CreateWorldScreen screen) {
         RegistryAccess access = screen.getUiState().getSettings().worldgenLoadContext();
-        Optional<Registry<PresetRE>> registry = access.lookup(CustomRegistries.PRESET_REGISTRY_KEY);
+        Optional<Registry<PresetDefinition>> registry = access.lookup(CustomRegistries.PRESET_REGISTRY_KEY);
         if (registry.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/dev/krona/urbex/gui/CustomizeScreen.java
+++ b/src/main/java/dev/krona/urbex/gui/CustomizeScreen.java
@@ -316,7 +316,7 @@ public class CustomizeScreen extends Screen {
     /**
      * Publishes the edited copy as a world-saved-data overrides overlay (spec §9) - not a file:
      * {@link PresetSelection#applyCustomized} keeps it purely in memory, and {@link PresetSelection#publish()}
-     * encodes it as a {@code PresetRE} overlay over its base preset id ({@code copy.getId()}, unchanged
+     * encodes it as a {@code PresetDefinition} overlay over its base preset id ({@code copy.getId()}, unchanged
      * by {@link Preset#copy()}).
      */
     private void done() {

--- a/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
@@ -16,7 +16,7 @@ import dev.krona.urbex.worldgen.lost.cityassets.AssetCompiler;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetDiagnostics;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
@@ -181,7 +181,7 @@ public class NullDimensionInfo implements IDimensionInfo {
      * {@code outsidestyle}, {@code citystyles} and the whole of {@code parts}, down to each of the
      * twenty-two wiring components {@code PartSelector.requireComplete} checks. Anything left absent
      * is an {@link IllegalStateException} out of the constructor rather than a decode failure, and
-     * this is the one place in {@code src/main} that builds a {@code WorldStyleRE} by hand instead
+     * this is the one place in {@code src/main} that builds a {@code WorldStyleDefinition} by hand instead
      * of decoding one, so no datapack test covers it; {@code NullDimensionInfoPlaceholderTest} does.
      * <p>
      * The lists are declared and empty rather than absent because the preview draws no parts: it
@@ -193,8 +193,8 @@ public class NullDimensionInfo implements IDimensionInfo {
      * is handed to the {@link WorldStyle} constructor beside this, which is where a load error looking
      * for a name will find it (issue #128).
      */
-    private static WorldStyleRE placeholderStyle() {
-        return new WorldStyleRE(
+    private static WorldStyleDefinition placeholderStyle() {
+        return new WorldStyleDefinition(
                 Optional.empty(),
                 // No display name: this style is never offered in the picker, so nothing would read
                 // one, and inventing a label here would put a name on screen if that ever changed.

--- a/src/main/java/dev/krona/urbex/gui/PresetSelection.java
+++ b/src/main/java/dev/krona/urbex/gui/PresetSelection.java
@@ -8,7 +8,7 @@ import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.Presets;
 import dev.krona.urbex.setup.Config;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
@@ -225,7 +225,7 @@ public final class PresetSelection {
      *
      * @param preset       the saved preset id ({@code namespace:path}); empty means nothing to restore.
      * @param worldStyle   the saved worldStyle id, or empty for {@link Config#DEFAULT_WORLD_STYLE}.
-     * @param overridesJson the saved {@code PresetRE} overrides JSON, or empty for a plain preset.
+     * @param overridesJson the saved {@code PresetDefinition} overrides JSON, or empty for a plain preset.
      */
     public void restore(String preset, String worldStyle, String overridesJson) {
         if (preset == null || preset.isEmpty()) {
@@ -267,7 +267,7 @@ public final class PresetSelection {
     }
 
     /**
-     * Validates a saved-data overrides string against {@link PresetRE#CODEC} before it is allowed
+     * Validates a saved-data overrides string against {@link PresetDefinition#CODEC} before it is allowed
      * anywhere near {@link Config#overridesFromClient} - that field is read on a worldgen worker
      * thread the instant a chunk generates ({@code DimensionRuntime.create}), so a string that
      * fails to parse must never be published in the first place. Returns {@code null} - "plain
@@ -280,7 +280,7 @@ public final class PresetSelection {
             return null;
         }
         try {
-            PresetRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(overridesJson)).getOrThrow();
+            PresetDefinition.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(overridesJson)).getOrThrow();
             return overridesJson;
         } catch (Exception e) {
             Urbex.getLogger().warn("Re-created world '{}' had malformed Urbex preset overrides; " +
@@ -312,7 +312,7 @@ public final class PresetSelection {
             return;
         }
         try {
-            PresetRE re = PresetRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(pending.overridesJson())).getOrThrow();
+            PresetDefinition re = PresetDefinition.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(pending.overridesJson())).getOrThrow();
             applyCustomized(Presets.applyOverrides(base.preset(), re));
         } catch (Exception e) {
             Urbex.getLogger().warn("Could not rebuild the restored customized preset '{}'; showing it plain.",
@@ -355,7 +355,7 @@ public final class PresetSelection {
      *   <li>A plain built-in entry: its own id, the effective worldStyle, no overrides.</li>
      *   <li>The transient customized entry: the <em>base</em> preset id it was customized from
      *       (carried, unchanged, in {@code Preset.getId()} through every {@link Preset#copy()}), the
-     *       effective worldStyle, and the full edited preset encoded as a {@link PresetRE} overlay -
+     *       effective worldStyle, and the full edited preset encoded as a {@link PresetDefinition} overlay -
      *       so the server rebuilds exactly what the editor showed, not an approximation.</li>
      * </ul>
      */
@@ -378,8 +378,8 @@ public final class PresetSelection {
         if (CUSTOMIZED_ID.equals(entry.id())) {
             Preset preset = entry.preset();
             Config.presetFromClient = preset.getId();
-            PresetRE re = preset.toRE();
-            JsonElement json = PresetRE.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
+            PresetDefinition re = preset.toDefinition();
+            JsonElement json = PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
             Config.overridesFromClient = GSON.toJson(json);
         } else {
             Config.presetFromClient = entry.id();

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -15,7 +15,7 @@ import dev.krona.urbex.worldgen.lost.City;
 import dev.krona.urbex.worldgen.lost.Highway;
 import dev.krona.urbex.worldgen.lost.RailChunkType;
 import dev.krona.urbex.worldgen.lost.Railway;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
@@ -142,14 +142,14 @@ public class CityPreview implements AutoCloseable {
     }
 
     /**
-     * A content hash of every field {@link Preset#toRE()} would encode, used as the cache key's
+     * A content hash of every field {@link Preset#toDefinition()} would encode, used as the cache key's
      * stand-in for "did the preset actually change" (the Customize editor mutates one {@link Preset}
-     * instance in place, so identity alone can't tell). {@code toRE()}/the {@code PresetRE} codec are
+     * instance in place, so identity alone can't tell). {@code toDefinition()}/the {@code PresetDefinition} codec are
      * pure value encoding - no registry lookups - so this needs no {@link RegistryAccess}.
      */
     private static int presetHash(Preset preset) {
-        PresetRE re = preset.toRE();
-        JsonElement json = PresetRE.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
+        PresetDefinition re = preset.toDefinition();
+        JsonElement json = PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
         return json.toString().hashCode();
     }
 

--- a/src/main/java/dev/krona/urbex/gui/settings/Settings.java
+++ b/src/main/java/dev/krona/urbex/gui/settings/Settings.java
@@ -419,7 +419,7 @@ public final class Settings {
 
         // Public on Preset since Task 3 (the runtime-generated profile format these replaced kept
         // both private and so never reachable from any editor) - datapack presets can already
-        // override them via the PresetRE terrain section, so the in-game editor gets parity rather
+        // override them via the PresetDefinition terrain section, so the in-game editor gets parity rather
         // than a silent gap.
         r.section("blocks");
         r.text("LIQUID_BLOCK", SettingCategory.TERRAIN,

--- a/src/main/java/dev/krona/urbex/setup/Config.java
+++ b/src/main/java/dev/krona/urbex/setup/Config.java
@@ -10,7 +10,7 @@ import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.Presets;
 import dev.krona.urbex.config.UrbexConfig;
 import dev.krona.urbex.data.UrbexData;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
@@ -359,9 +359,9 @@ public class Config {
 
         if (selectedPreset != null) {
             RegistryAccess access = level.registryAccess();
-            Registry<dev.krona.urbex.worldgen.lost.regassets.PresetRE> presets =
+            Registry<dev.krona.urbex.worldgen.lost.regassets.PresetDefinition> presets =
                     access.lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY);
-            Registry<dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE> worldStyles =
+            Registry<dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition> worldStyles =
                     access.lookupOrThrow(CustomRegistries.WORLDSTYLES_REGISTRY_KEY);
             if (presets.get(selectedPreset).isEmpty()) {
                 Urbex.getLogger().error("Unknown Urbex preset '{}' selected for the overworld; ignoring. Valid presets: {}",
@@ -399,7 +399,7 @@ public class Config {
             // override that flips GENERATE_NETHER (on or off) would silently not count here.
             if (overworldChoice.overridesJson().isPresent()) {
                 try {
-                    PresetRE re = PresetRE.CODEC.parse(JsonOps.INSTANCE,
+                    PresetDefinition re = PresetDefinition.CODEC.parse(JsonOps.INSTANCE,
                             JsonParser.parseString(overworldChoice.overridesJson().get())).getOrThrow();
                     overworldPreset = Presets.applyOverrides(overworldPreset, re);
                 } catch (Exception e) {
@@ -424,9 +424,9 @@ public class Config {
      * Must run after {@link #applyWorldOverrides} so the world's selectedPreset is in effect.
      */
     public static void validateSelectedPresets(MinecraftServer server) {
-        Registry<dev.krona.urbex.worldgen.lost.regassets.PresetRE> presets =
+        Registry<dev.krona.urbex.worldgen.lost.regassets.PresetDefinition> presets =
                 server.registryAccess().lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY);
-        Registry<dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE> worldStyles =
+        Registry<dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition> worldStyles =
                 server.registryAccess().lookupOrThrow(CustomRegistries.WORLDSTYLES_REGISTRY_KEY);
 
         String selected = SELECTED_PRESET.get();
@@ -450,14 +450,14 @@ public class Config {
         }
     }
 
-    private static void requirePreset(Registry<dev.krona.urbex.worldgen.lost.regassets.PresetRE> presets, Identifier id, String context) {
+    private static void requirePreset(Registry<dev.krona.urbex.worldgen.lost.regassets.PresetDefinition> presets, Identifier id, String context) {
         if (presets.get(id).isEmpty()) {
             throw new IllegalStateException("Unknown Urbex preset '" + id + "' (" + context + "). Valid presets: "
                     + String.join(", ", sortedIds(presets)));
         }
     }
 
-    private static void requireWorldStyle(Registry<dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE> worldStyles, Identifier id, String context) {
+    private static void requireWorldStyle(Registry<dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition> worldStyles, Identifier id, String context) {
         if (worldStyles.get(id).isEmpty()) {
             throw new IllegalStateException("Unknown Urbex worldstyle '" + id + "' (" + context + "). Valid worldstyles: "
                     + String.join(", ", sortedIds(worldStyles)));

--- a/src/main/java/dev/krona/urbex/setup/CustomRegistries.java
+++ b/src/main/java/dev/krona/urbex/setup/CustomRegistries.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.setup;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.worldgen.lost.regassets.*;
-import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsRE;
+import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsDefinition;
 import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -10,48 +10,48 @@ import net.minecraft.resources.Identifier;
 
 public class CustomRegistries {
 
-    public static final ResourceKey<Registry<BuildingRE>> BUILDING_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "buildings"));
+    public static final ResourceKey<Registry<BuildingDefinition>> BUILDING_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "buildings"));
 
-    public static final ResourceKey<Registry<PaletteRE>> PALETTE_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "palettes"));
+    public static final ResourceKey<Registry<PaletteDefinition>> PALETTE_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "palettes"));
 
-    public static final ResourceKey<Registry<BuildingPartRE>> PART_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "parts"));
+    public static final ResourceKey<Registry<BuildingPartDefinition>> PART_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "parts"));
 
-    public static final ResourceKey<Registry<StyleRE>> STYLE_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "styles"));
+    public static final ResourceKey<Registry<StyleDefinition>> STYLE_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "styles"));
 
-    public static final ResourceKey<Registry<ConditionRE>> CONDITIONS_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "conditions"));
+    public static final ResourceKey<Registry<ConditionDefinition>> CONDITIONS_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "conditions"));
 
-    public static final ResourceKey<Registry<CityStyleRE>> CITYSTYLES_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "citystyles"));
+    public static final ResourceKey<Registry<CityStyleDefinition>> CITYSTYLES_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "citystyles"));
 
-    public static final ResourceKey<Registry<MultiBuildingRE>> MULTIBUILDINGS_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "multibuildings"));
+    public static final ResourceKey<Registry<MultiBuildingDefinition>> MULTIBUILDINGS_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "multibuildings"));
 
-    public static final ResourceKey<Registry<VariantRE>> VARIANTS_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "variants"));
+    public static final ResourceKey<Registry<VariantDefinition>> VARIANTS_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "variants"));
 
-    public static final ResourceKey<Registry<WorldStyleRE>> WORLDSTYLES_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "worldstyles"));
+    public static final ResourceKey<Registry<WorldStyleDefinition>> WORLDSTYLES_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "worldstyles"));
 
-    public static final ResourceKey<Registry<PredefinedCityRE>> PREDEFINEDCITIES_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "predefinedcities"));
+    public static final ResourceKey<Registry<PredefinedCityDefinition>> PREDEFINEDCITIES_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "predefinedcities"));
 
-    public static final ResourceKey<Registry<ScatteredRE>> SCATTERED_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "scattered"));
+    public static final ResourceKey<Registry<ScatteredDefinition>> SCATTERED_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "scattered"));
 
-    public static final ResourceKey<Registry<StuffSettingsRE>> STUFF_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "stuff"));
+    public static final ResourceKey<Registry<StuffSettingsDefinition>> STUFF_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "stuff"));
 
-    public static final ResourceKey<Registry<PresetRE>> PRESET_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "presets"));
+    public static final ResourceKey<Registry<PresetDefinition>> PRESET_REGISTRY_KEY = ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(Urbex.MODID, "presets"));
 
     public static void init() {
         // Fabric: register the datapack ("dynamic") registries. These are server-side only
         // (not synced to clients), matching the NeoForge DataPackRegistryEvent behavior
         // (no network codec was provided there either).
-        DynamicRegistries.register(BUILDING_REGISTRY_KEY, BuildingRE.CODEC);
-        DynamicRegistries.register(PALETTE_REGISTRY_KEY, PaletteRE.CODEC);
-        DynamicRegistries.register(PART_REGISTRY_KEY, BuildingPartRE.CODEC);
-        DynamicRegistries.register(STYLE_REGISTRY_KEY, StyleRE.CODEC);
-        DynamicRegistries.register(CONDITIONS_REGISTRY_KEY, ConditionRE.CODEC);
-        DynamicRegistries.register(CITYSTYLES_REGISTRY_KEY, CityStyleRE.CODEC);
-        DynamicRegistries.register(MULTIBUILDINGS_REGISTRY_KEY, MultiBuildingRE.CODEC);
-        DynamicRegistries.register(VARIANTS_REGISTRY_KEY, VariantRE.CODEC);
-        DynamicRegistries.register(WORLDSTYLES_REGISTRY_KEY, WorldStyleRE.CODEC);
-        DynamicRegistries.register(PREDEFINEDCITIES_REGISTRY_KEY, PredefinedCityRE.CODEC);
-        DynamicRegistries.register(SCATTERED_REGISTRY_KEY, ScatteredRE.CODEC);
-        DynamicRegistries.register(STUFF_REGISTRY_KEY, StuffSettingsRE.CODEC);
-        DynamicRegistries.register(PRESET_REGISTRY_KEY, PresetRE.CODEC);
+        DynamicRegistries.register(BUILDING_REGISTRY_KEY, BuildingDefinition.CODEC);
+        DynamicRegistries.register(PALETTE_REGISTRY_KEY, PaletteDefinition.CODEC);
+        DynamicRegistries.register(PART_REGISTRY_KEY, BuildingPartDefinition.CODEC);
+        DynamicRegistries.register(STYLE_REGISTRY_KEY, StyleDefinition.CODEC);
+        DynamicRegistries.register(CONDITIONS_REGISTRY_KEY, ConditionDefinition.CODEC);
+        DynamicRegistries.register(CITYSTYLES_REGISTRY_KEY, CityStyleDefinition.CODEC);
+        DynamicRegistries.register(MULTIBUILDINGS_REGISTRY_KEY, MultiBuildingDefinition.CODEC);
+        DynamicRegistries.register(VARIANTS_REGISTRY_KEY, VariantDefinition.CODEC);
+        DynamicRegistries.register(WORLDSTYLES_REGISTRY_KEY, WorldStyleDefinition.CODEC);
+        DynamicRegistries.register(PREDEFINEDCITIES_REGISTRY_KEY, PredefinedCityDefinition.CODEC);
+        DynamicRegistries.register(SCATTERED_REGISTRY_KEY, ScatteredDefinition.CODEC);
+        DynamicRegistries.register(STUFF_REGISTRY_KEY, StuffSettingsDefinition.CODEC);
+        DynamicRegistries.register(PRESET_REGISTRY_KEY, PresetDefinition.CODEC);
     }
 }

--- a/src/main/java/dev/krona/urbex/setup/PresetChoice.java
+++ b/src/main/java/dev/krona/urbex/setup/PresetChoice.java
@@ -6,9 +6,9 @@ import java.util.Optional;
 
 /**
  * A resolved dimension selection: which preset generates it, which world styles it draws from, and
- * an optional {@code PresetRE} JSON overlay applied on top of the resolved preset (a
+ * an optional {@code PresetDefinition} JSON overlay applied on top of the resolved preset (a
  * client-published customization, or a saved-world one). {@code overridesJson}, when present, is
- * parsed with {@code PresetRE.CODEC} and applied via {@code Presets.applyOverrides}.
+ * parsed with {@code PresetDefinition.CODEC} and applied via {@code Presets.applyOverrides}.
  * <p>
  * {@code worldStyles} is a {@link WorldStyleMix} rather than a single id: with
  * {@code experimentalMultiWorldStyles} on it can carry several weighted styles, and every other

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
@@ -9,7 +9,7 @@ import dev.krona.urbex.setup.Config;
 import dev.krona.urbex.setup.PresetChoice;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
 import dev.krona.urbex.worldgen.lost.cityassets.CityStyle;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
@@ -112,7 +112,7 @@ public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo plann
             // level. PresetSelection.restore() already validates before publishing, so this guard is
             // a backstop against corrupted saved data reaching this far, not the primary defense.
             try {
-                PresetRE re = PresetRE.CODEC.parse(JsonOps.INSTANCE,
+                PresetDefinition re = PresetDefinition.CODEC.parse(JsonOps.INSTANCE,
                         JsonParser.parseString(choice.overridesJson().get())).getOrThrow();
                 preset = Presets.applyOverrides(preset, re);
             } catch (Exception e) {

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
@@ -10,7 +10,7 @@ import dev.krona.urbex.worldgen.lost.BiomeInfo;
 import dev.krona.urbex.worldgen.lost.BuildingInfo;
 import dev.krona.urbex.worldgen.lost.cityassets.CompiledPalette;
 import dev.krona.urbex.worldgen.lost.cityassets.StuffObject;
-import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsRE;
+import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockMatcher;
 import dev.krona.urbex.worldgen.lost.regassets.data.IdentifierMatcher;
 import net.minecraft.core.BlockPos;
@@ -53,7 +53,7 @@ public class Stuff {
             List<StuffObject> stuffs = feature.provider.assets().stuffFor(tag);
             {
                 for (StuffObject stuff : stuffs) {
-                    StuffSettingsRE settings = stuff.getSettings();
+                    StuffSettingsDefinition settings = stuff.getSettings();
                     // Never null: 'inbuilding' is required of the resolved chain, precisely because
                     // the null branch this used to carry made the stuff object silently inert.
                     boolean inBuilding = settings.isInBuilding();
@@ -129,7 +129,7 @@ public class Stuff {
     }
 
     private static void actuallyGenerateStuff(ChunkGenContext ctx, CityGenerator feature, BuildingInfo info, StuffObject stuff, CompiledPalette palette, int stuffOrdinal, boolean inBuilding) {
-        StuffSettingsRE settings = stuff.getSettings();
+        StuffSettingsDefinition settings = stuff.getSettings();
         String blocks = settings.getColumn();
         if (!columnResolves(stuff, blocks, palette)) {
             return;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
@@ -2,8 +2,8 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.setup.CustomRegistries;
-import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityRE;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.CitySettings;
 import net.minecraft.core.Holder;
@@ -139,12 +139,12 @@ public final class AssetCompiler {
                 reachable.add(DataTools.fromName(selector.getRight().getRight()));
             }
         }
-        for (PresetRE preset : access.lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY)) {
+        for (PresetDefinition preset : access.lookupOrThrow(CustomRegistries.PRESET_REGISTRY_KEY)) {
             preset.cities().flatMap(CitySettings::cityStyleAlternative)
                     .filter(name -> !name.isBlank())
                     .ifPresent(name -> reachable.add(DataTools.fromName(name)));
         }
-        for (PredefinedCityRE city : access.lookupOrThrow(CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY)) {
+        for (PredefinedCityDefinition city : access.lookupOrThrow(CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY)) {
             if (city.getCityStyle() != null && !city.getCityStyle().isBlank()) {
                 reachable.add(DataTools.fromName(city.getCityStyle()));
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
@@ -1,7 +1,7 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.BuildingRE;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
 import net.minecraft.core.HolderLookup;
@@ -57,15 +57,15 @@ public class Building {
      * documented fallbacks - {@code -1} for "take the level's limit" - not markers for "undeclared".
      */
     public Building(Identifier id, HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
-                        AssetIndex<Palette> palettes, List<BuildingRE> chainRootFirst) {
+                        AssetIndex<Palette> palettes, List<BuildingDefinition> chainRootFirst) {
         name = id;
         List<PartRef> partRefs = new ArrayList<>();
         boolean anyParts = false;
         List<PartRef> partRefs2 = new ArrayList<>();
-        List<PaletteRE> inlinePalettes = new ArrayList<>();
+        List<PaletteDefinition> inlinePalettes = new ArrayList<>();
         String refPalette = null;
         Character filler = null;
-        for (BuildingRE object : chainRootFirst) {
+        for (BuildingDefinition object : chainRootFirst) {
             if (object.getMinFloors() != null) {
                 minFloors = object.getMinFloors();
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPart.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPart.java
@@ -1,8 +1,8 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.worldgen.lost.BuildingInfo;
-import dev.krona.urbex.worldgen.lost.regassets.BuildingPartRE;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartMeta;
 import net.minecraft.core.HolderLookup;
@@ -62,17 +62,17 @@ public class BuildingPart implements IBuildingPart {
      * slices actually in force is a load error rather than a silent truncation.
      */
     public BuildingPart(Identifier id, HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
-                        AssetIndex<Palette> palettes, List<BuildingPartRE> chainRootFirst) {
-        BuildingPartRE leaf = chainRootFirst.get(chainRootFirst.size() - 1);
+                        AssetIndex<Palette> palettes, List<BuildingPartDefinition> chainRootFirst) {
+        BuildingPartDefinition leaf = chainRootFirst.get(chainRootFirst.size() - 1);
         name = id;
 
         Integer declaredXSize = null;
         Integer declaredZSize = null;
         String[] declaredSlices = null;
-        List<PaletteRE> inlinePalettes = new ArrayList<>();
+        List<PaletteDefinition> inlinePalettes = new ArrayList<>();
         String refPalette = null;
         List<PartMeta> meta = new ArrayList<>();
-        for (BuildingPartRE re : chainRootFirst) {
+        for (BuildingPartDefinition re : chainRootFirst) {
             if (re.getxSize() != null) {
                 declaredXSize = re.getxSize();
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyle.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyle.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Tools;
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.ObjectSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.StreetParts;
@@ -100,11 +100,11 @@ public class CityStyle {
      * {@link #declare}). Nothing mutates after this returns, so worldgen worker threads share one
      * immutable instance with no locking.
      */
-    public CityStyle(Identifier id, List<CityStyleRE> chainRootFirst) {
-        CityStyleRE leaf = chainRootFirst.get(chainRootFirst.size() - 1);
+    public CityStyle(Identifier id, List<CityStyleDefinition> chainRootFirst) {
+        CityStyleDefinition leaf = chainRootFirst.get(chainRootFirst.size() - 1);
         name = id;
         stuffTags.add("all");
-        for (CityStyleRE re : chainRootFirst) {
+        for (CityStyleDefinition re : chainRootFirst) {
             applyFrom(re);
         }
         Resolved.require(streetParts, name, "streetblocks.parts")
@@ -127,7 +127,7 @@ public class CityStyle {
      * Every scalar assignment is conditional on the incoming value being present, so a chain entry
      * that omits a field does not blank out what an earlier entry set.
      */
-    private void applyFrom(CityStyleRE object) {
+    private void applyFrom(CityStyleDefinition object) {
         if (object.getDisplayName() != null) {
             displayName = object.getDisplayName();
         }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Condition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Condition.java
@@ -1,7 +1,7 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.varia.Tools;
-import dev.krona.urbex.worldgen.lost.regassets.ConditionRE;
+import dev.krona.urbex.worldgen.lost.regassets.ConditionDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.ConditionPart;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import net.minecraft.resources.Identifier;
@@ -24,11 +24,11 @@ public class Condition {
      * inherits it unchanged. A chain where nothing declares {@code values} is a load error, since
      * the condition would silently hand back null for every draw.
      */
-    public Condition(Identifier id, List<ConditionRE> chainRootFirst) {
+    public Condition(Identifier id, List<ConditionDefinition> chainRootFirst) {
         name = id;
         List<ConditionPart> values = new ArrayList<>();
         boolean anyValues = false;
-        for (ConditionRE object : chainRootFirst) {
+        for (ConditionDefinition object : chainRootFirst) {
             if (object.getValues() != null) {
                 Mergeable.apply(values, object.getValues());
                 anyValues = true;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ConditionContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ConditionContext.java
@@ -32,7 +32,7 @@ public abstract class ConditionContext {
      * comparison and in all nine places one is written. Three fields take one -
      * {@code belowpart}, {@code inpart} and {@code inbuilding} - and three blocks declare all
      * three: a building's {@code parts[]} and {@code parts2[]} (both are {@code PartRef}, bound
-     * twice by {@code BuildingRE}) and a condition's own {@code values[]}
+     * twice by {@code BuildingDefinition}) and a condition's own {@code values[]}
      * ({@code ConditionPart}). {@code inbiome} is the fourth field of both records and is
      * deliberately not in this list: it is a biome id, not an asset name.
      * {@code DatapackReferenceIntegrityTest} walks the same nine.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/MultiBuilding.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/MultiBuilding.java
@@ -1,6 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingRE;
+import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingDefinition;
 import net.minecraft.resources.Identifier;
 
 import java.util.HashSet;
@@ -21,12 +21,12 @@ public class MultiBuilding {
      * or restate a grid at the size it inherits. The grid replaces its ancestor's wholesale rather
      * than merging, because a half-inherited grid would contradict {@code dimx}/{@code dimz}.
      */
-    public MultiBuilding(Identifier id, List<MultiBuildingRE> chainRootFirst) {
+    public MultiBuilding(Identifier id, List<MultiBuildingDefinition> chainRootFirst) {
         name = id;
         Integer declaredDimX = null;
         Integer declaredDimZ = null;
         List<List<String>> declaredBuildings = null;
-        for (MultiBuildingRE object : chainRootFirst) {
+        for (MultiBuildingDefinition object : chainRootFirst) {
             if (object.getDimX() != null) {
                 declaredDimX = object.getDimX();
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Palette.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.varia.Tools;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import net.minecraft.core.HolderLookup;
@@ -49,7 +49,7 @@ public class Palette {
      *                    static server (issue #60) or compiling one on the spot (issue #128).
      */
     public Palette(Identifier id, HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
-                   List<PaletteRE> chainRootFirst) {
+                   List<PaletteDefinition> chainRootFirst) {
         name = id;
         compile(blockLookup, variants, mergeByCharacter(chainRootFirst, name));
     }
@@ -73,9 +73,9 @@ public class Palette {
      * @param chainRootFirst the inline blocks along the owner's chain, root first
      */
     public static Palette inline(HolderLookup<Block> blockLookup, @Nullable AssetIndex<Variant> variants,
-                                 Identifier owner, List<PaletteRE> chainRootFirst) {
-        for (PaletteRE re : chainRootFirst) {
-            // The codec accepts 'extends' wherever a PaletteRE is embedded, but an inline block is
+                                 Identifier owner, List<PaletteDefinition> chainRootFirst) {
+        for (PaletteDefinition re : chainRootFirst) {
+            // The codec accepts 'extends' wherever a PaletteDefinition is embedded, but an inline block is
             // not a registry entry, so nothing can resolve it. Rejecting is the honest option:
             // silently dropping a key the codec accepted is how a datapack quietly means something
             // other than what it says.
@@ -101,11 +101,11 @@ public class Palette {
      * declares {@code extends} inherits its ancestor's markers; a chain where nothing declares one
      * is a load error rather than a palette that silently maps no characters at all.
      */
-    private static Collection<PaletteEntry> mergeByCharacter(List<PaletteRE> chainRootFirst,
+    private static Collection<PaletteEntry> mergeByCharacter(List<PaletteDefinition> chainRootFirst,
                                                              Identifier owner) {
         Map<Character, PaletteEntry> merged = new LinkedHashMap<>();
         boolean anyEntries = false;
-        for (PaletteRE re : chainRootFirst) {
+        for (PaletteDefinition re : chainRootFirst) {
             if (re.getPaletteEntries() == null) {
                 continue;
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PredefinedCity.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PredefinedCity.java
@@ -1,6 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityRE;
+import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedStreet;
@@ -31,14 +31,14 @@ public class PredefinedCity {
      * and street lists go through {@link Mergeable} so a declared list replaces unless it opts into
      * appending.
      */
-    public PredefinedCity(Identifier id, List<PredefinedCityRE> chainRootFirst) {
+    public PredefinedCity(Identifier id, List<PredefinedCityDefinition> chainRootFirst) {
         name = id;
         String declaredDimension = null;
         Integer declaredChunkX = null;
         Integer declaredChunkZ = null;
         Integer declaredRadius = null;
         String declaredCityStyle = null;
-        for (PredefinedCityRE object : chainRootFirst) {
+        for (PredefinedCityDefinition object : chainRootFirst) {
             if (object.getDimension() != null) {
                 declaredDimension = object.getDimension();
             }
@@ -61,7 +61,7 @@ public class PredefinedCity {
         chunkZ = Resolved.require(declaredChunkZ, name, "chunkz");
         radius = Resolved.require(declaredRadius, name, "radius");
         cityStyle = Resolved.require(declaredCityStyle, name, "citystyle");
-        for (PredefinedCityRE object : chainRootFirst) {
+        for (PredefinedCityDefinition object : chainRootFirst) {
             if (object.getPredefinedBuildings() != null) {
                 Mergeable.apply(predefinedBuildings, object.getPredefinedBuildings());
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ScatteredBuilding.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ScatteredBuilding.java
@@ -1,6 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.ScatteredRE;
+import dev.krona.urbex.worldgen.lost.regassets.ScatteredDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.StringRepresentable;
@@ -31,7 +31,7 @@ public class ScatteredBuilding {
      * {@link Resolved#require} cannot state. Left unchecked, a chain declaring neither loaded and
      * then threw from {@code Scattered.generate} the first time the entry was placed.
      */
-    public ScatteredBuilding(Identifier id, List<ScatteredRE> chainRootFirst) {
+    public ScatteredBuilding(Identifier id, List<ScatteredDefinition> chainRootFirst) {
         name = id;
         List<String> declaredBuildings = new ArrayList<>();
         boolean anyBuildings = false;
@@ -39,7 +39,7 @@ public class ScatteredBuilding {
         int heightoffset = 0;
         TerrainHeight terrainheight = null;
         TerrainFix terrainfix = null;
-        for (ScatteredRE object : chainRootFirst) {
+        for (ScatteredDefinition object : chainRootFirst) {
             if (object.getBuildings() != null) {
                 Mergeable.apply(declaredBuildings, object.getBuildings());
                 anyBuildings = true;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/StuffObject.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/StuffObject.java
@@ -1,6 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsRE;
+import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsDefinition;
 import net.minecraft.resources.Identifier;
 
 import java.util.List;
@@ -8,15 +8,15 @@ import java.util.List;
 public class StuffObject {
 
     private final Identifier name;
-    private final StuffSettingsRE settings;
+    private final StuffSettingsDefinition settings;
 
     /**
      * Builds a fully resolved stuff object from its {@code extends} chain, root first. The fold
-     * lives on {@link StuffSettingsRE#resolve} so generation keeps reading one settings object and
+     * lives on {@link StuffSettingsDefinition#resolve} so generation keeps reading one settings object and
      * never has to know a chain was involved.
      */
-    public StuffObject(Identifier id, List<StuffSettingsRE> chainRootFirst) {
-        this.settings = StuffSettingsRE.resolve(id, chainRootFirst);
+    public StuffObject(Identifier id, List<StuffSettingsDefinition> chainRootFirst) {
+        this.settings = StuffSettingsDefinition.resolve(id, chainRootFirst);
         this.name = id;
     }
 
@@ -29,7 +29,7 @@ public class StuffObject {
         return name;
     }
 
-    public StuffSettingsRE getSettings() {
+    public StuffSettingsDefinition getSettings() {
         return settings;
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Style.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Style.java
@@ -1,6 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.StyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.StyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteSelector;
 import net.minecraft.resources.Identifier;
@@ -27,11 +27,11 @@ public class Style {
      *                 {@link #getRandomPalette}, from a worldgen worker, which is why that method took
      *                 an {@code IDimensionInfo} it otherwise had no use for (issue #128).
      */
-    public Style(Identifier id, AssetIndex<Palette> palettes, List<StyleRE> chainRootFirst) {
+    public Style(Identifier id, AssetIndex<Palette> palettes, List<StyleDefinition> chainRootFirst) {
         name = id;
         List<List<PaletteSelector>> groups = new ArrayList<>();
         boolean anyGroups = false;
-        for (StyleRE object : chainRootFirst) {
+        for (StyleDefinition object : chainRootFirst) {
             if (object.getRandomPaletteChoices() != null) {
                 Mergeable.apply(groups, object.getRandomPaletteChoices());
                 anyGroups = true;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Variant.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Variant.java
@@ -1,7 +1,7 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.varia.Tools;
-import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
+import dev.krona.urbex.worldgen.lost.regassets.VariantDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import net.minecraft.core.HolderLookup;
@@ -30,11 +30,11 @@ public class Variant {
      *               registries. Taken rather than fetched: resolution used to reach a static server
      *               reference from wherever it happened to run (issues #60, #128).
      */
-    public Variant(Identifier id, HolderLookup<Block> blockLookup, List<VariantRE> chainRootFirst) {
+    public Variant(Identifier id, HolderLookup<Block> blockLookup, List<VariantDefinition> chainRootFirst) {
         name = id;
         List<BlockEntry> entries = new ArrayList<>();
         boolean anyBlocks = false;
-        for (VariantRE object : chainRootFirst) {
+        for (VariantDefinition object : chainRootFirst) {
             if (object.getBlocks() != null) {
                 Mergeable.apply(entries, object.getBlocks());
                 anyBlocks = true;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
@@ -5,7 +5,7 @@ import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.UrbexTags;
 import dev.krona.urbex.worldgen.lost.BiomeInfo;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.*;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.Identifier;
@@ -48,7 +48,7 @@ public class WorldStyle {
      * nothing, which is how a third-party pack could generate parts it never mentioned. It is
      * folded field by field, so a child can append one tunnel variant without restating the group.
      */
-    public WorldStyle(Identifier id, List<WorldStyleRE> chainRootFirst) {
+    public WorldStyle(Identifier id, List<WorldStyleDefinition> chainRootFirst) {
         name = id;
         String outside = null;
         ScatteredSettings scattered = null;
@@ -59,7 +59,7 @@ public class WorldStyle {
         List<CityStyleSelector> selectors = new ArrayList<>();
         boolean anySelectors = false;
         List<CityBiomeMultiplier> multipliers = new ArrayList<>();
-        for (WorldStyleRE object : chainRootFirst) {
+        for (WorldStyleDefinition object : chainRootFirst) {
             if (object.getOutsideStyle() != null) {
                 outside = object.getOutsideStyle();
             }
@@ -120,9 +120,9 @@ public class WorldStyle {
      * (that would require the chain to be complete, which is worldgen's check to make, not a
      * dropdown's).
      */
-    public static String displayNameOf(List<WorldStyleRE> chainRootFirst, Identifier id) {
+    public static String displayNameOf(List<WorldStyleDefinition> chainRootFirst, Identifier id) {
         String display = null;
-        for (WorldStyleRE object : chainRootFirst) {
+        for (WorldStyleDefinition object : chainRootFirst) {
             if (object.getDisplayName() != null) {
                 display = object.getDisplayName();
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/BuildingDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/BuildingDefinition.java
@@ -21,13 +21,13 @@ import java.util.Optional;
  * are values a file may legitimately mean, and under a sentinel a child could not override an
  * inherited {@code 0.8} back down to {@code 0.0}.
  */
-public class BuildingRE implements Extendable {
+public class BuildingDefinition implements Extendable {
 
-    private static final Codec<BuildingRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<BuildingDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Codec.STRING.optionalFieldOf("refpalette").forGetter(l -> Optional.ofNullable(l.refPaletteName)),
-                    PaletteRE.CODEC.optionalFieldOf("palette").forGetter(l -> Optional.ofNullable(l.localPalette)),
+                    PaletteDefinition.CODEC.optionalFieldOf("palette").forGetter(l -> Optional.ofNullable(l.localPalette)),
                     DataTools.PALETTE_CHAR.optionalFieldOf("filler").forGetter(l -> Optional.ofNullable(l.fillerBlock)),
                     DataTools.PALETTE_CHAR.optionalFieldOf("rubble").forGetter(l -> Optional.ofNullable(l.rubbleBlock)),
                     Codec.INT.optionalFieldOf("mincellars").forGetter(l -> Optional.ofNullable(l.minCellars)),
@@ -40,10 +40,10 @@ public class BuildingRE implements Extendable {
                     Codec.FLOAT.optionalFieldOf("preferslonely").forGetter(l -> Optional.ofNullable(l.prefersLonely)),
                     Mergeable.codec(PartRef.CODEC).optionalFieldOf("parts").forGetter(l -> Optional.ofNullable(l.parts)),
                     Mergeable.codec(PartRef.CODEC).optionalFieldOf("parts2").forGetter(l -> Optional.ofNullable(l.parts2))
-            ).apply(instance, BuildingRE::new));
+            ).apply(instance, BuildingDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<BuildingRE> CODEC = RetiredKeys.reject(RAW, "building");
+    public static final Codec<BuildingDefinition> CODEC = RetiredKeys.reject(RAW, "building");
 
 
 
@@ -61,14 +61,14 @@ public class BuildingRE implements Extendable {
     private final Character rubbleBlock;   // Block used for destroyed building rubble
     private final Float prefersLonely;  // The chance this this building is alone. If 1.0f this building wants to be alone all the time
 
-    private PaletteRE localPalette = null;
+    private PaletteDefinition localPalette = null;
     private final String refPaletteName;
 
     private final Mergeable<PartRef> parts;
     private final Mergeable<PartRef> parts2;
 
-    public BuildingRE(Optional<Identifier> extendsId,
-                      Optional<String> refpalette, Optional<PaletteRE> locpalette, Optional<Character> filler, Optional<Character> rubble,
+    public BuildingDefinition(Optional<Identifier> extendsId,
+                      Optional<String> refpalette, Optional<PaletteDefinition> locpalette, Optional<Character> filler, Optional<Character> rubble,
                       Optional<Integer> minCellars, Optional<Integer> minFloors, Optional<Integer> maxCellars, Optional<Integer> maxFloors,
                       Optional<Boolean> allowDoors, Optional<Boolean> allowFillers, Optional<Boolean> overrideFloors,
                       Optional<Float> prefersLonely, Optional<Mergeable<PartRef>> partRefs, Optional<Mergeable<PartRef>> partRefs2) {
@@ -146,7 +146,7 @@ public class BuildingRE implements Extendable {
         return prefersLonely;
     }
 
-    public PaletteRE getLocalPalette() {
+    public PaletteDefinition getLocalPalette() {
         return localPalette;
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/BuildingPartDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/BuildingPartDefinition.java
@@ -21,21 +21,21 @@ import java.util.Optional;
  * geometry. Requiredness is checked after the chain is resolved, in
  * {@link dev.krona.urbex.worldgen.lost.cityassets.BuildingPart}.
  */
-public class BuildingPartRE implements Extendable {
+public class BuildingPartDefinition implements Extendable {
 
-    private static final Codec<BuildingPartRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<BuildingPartDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Codec.INT.optionalFieldOf("xsize").forGetter(l -> Optional.ofNullable(l.xSize)),
                     Codec.INT.optionalFieldOf("zsize").forGetter(l -> Optional.ofNullable(l.zSize)),
-                    Codec.list(Codec.list(Codec.STRING)).optionalFieldOf("slices").forGetter(BuildingPartRE::createSlices),
+                    Codec.list(Codec.list(Codec.STRING)).optionalFieldOf("slices").forGetter(BuildingPartDefinition::createSlices),
                     Codec.STRING.optionalFieldOf("refpalette").forGetter(l -> Optional.ofNullable(l.refPaletteName)),
-                    PaletteRE.CODEC.optionalFieldOf("palette").forGetter(l -> Optional.ofNullable(l.localPalette)),
+                    PaletteDefinition.CODEC.optionalFieldOf("palette").forGetter(l -> Optional.ofNullable(l.localPalette)),
                     Mergeable.codec(PartMeta.CODEC).optionalFieldOf("meta").forGetter(l -> Optional.ofNullable(l.metadata))
-            ).apply(instance, BuildingPartRE::new));
+            ).apply(instance, BuildingPartDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<BuildingPartRE> CODEC = RetiredKeys.reject(RAW, "part");
+    public static final Codec<BuildingPartDefinition> CODEC = RetiredKeys.reject(RAW, "part");
 
 
     private final Optional<Identifier> extendsId;
@@ -48,16 +48,16 @@ public class BuildingPartRE implements Extendable {
     private final Integer xSize;
     private final Integer zSize;
 
-    private PaletteRE localPalette = null;
+    private PaletteDefinition localPalette = null;
     private final String refPaletteName;
 
     private final Mergeable<PartMeta> metadata;
 
-    public BuildingPartRE(Optional<Identifier> extendsId, Optional<Integer> xSize, Optional<Integer> zSize,
+    public BuildingPartDefinition(Optional<Identifier> extendsId, Optional<Integer> xSize, Optional<Integer> zSize,
                           Optional<List<List<String>>> slices, Optional<String> refpalette,
-                          Optional<PaletteRE> locpalette, Optional<Mergeable<PartMeta>> metadata) {
+                          Optional<PaletteDefinition> locpalette, Optional<Mergeable<PartMeta>> metadata) {
         this.extendsId = extendsId;
-        this.slices = slices.map(BuildingPartRE::flatten).orElse(null);
+        this.slices = slices.map(BuildingPartDefinition::flatten).orElse(null);
         this.xSize = xSize.orElse(null);
         this.zSize = zSize.orElse(null);
         this.refPaletteName = refpalette.map(String::intern).orElse(null);
@@ -119,7 +119,7 @@ public class BuildingPartRE implements Extendable {
         return zSize;
     }
 
-    public PaletteRE getLocalPalette() {
+    public PaletteDefinition getLocalPalette() {
         return localPalette;
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/CityStyleDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/CityStyleDefinition.java
@@ -9,13 +9,13 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Optional;
 
-public class CityStyleRE implements Extendable {
+public class CityStyleDefinition implements Extendable {
 
-    private static final Codec<CityStyleRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<CityStyleDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     Codec.FLOAT.optionalFieldOf("explosionchance").forGetter(l -> Optional.ofNullable(l.explosionChance)),
                     Codec.STRING.optionalFieldOf("style").forGetter(l -> Optional.ofNullable(l.style)),
-                    DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(CityStyleRE::getExtends),
+                    DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(CityStyleDefinition::getExtends),
                     Codec.STRING.optionalFieldOf("name").forGetter(l -> Optional.ofNullable(l.displayName)),
                     Codec.STRING.listOf().optionalFieldOf("stuff_tags").forGetter(l -> Optional.ofNullable(l.stuffTags)),
                     GeneralSettings.CODEC.optionalFieldOf("generalblocks").forGetter(l -> Optional.ofNullable(l.generalSettings)),
@@ -25,10 +25,10 @@ public class CityStyleRE implements Extendable {
                     RailSettings.CODEC.optionalFieldOf("railblocks").forGetter(l -> Optional.ofNullable(l.railSettings)),
                     StreetSettings.CODEC.optionalFieldOf("streetblocks").forGetter(l -> Optional.ofNullable(l.streetSettings)),
                     Selectors.CODEC.optionalFieldOf("selectors").forGetter(l -> Optional.ofNullable(l.selectors))
-            ).apply(instance, CityStyleRE::new));
+            ).apply(instance, CityStyleDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<CityStyleRE> CODEC = RetiredKeys.reject(RAW, "citystyle");
+    public static final Codec<CityStyleDefinition> CODEC = RetiredKeys.reject(RAW, "citystyle");
 
 
     private final Float explosionChance;
@@ -50,7 +50,7 @@ public class CityStyleRE implements Extendable {
 
     private final Selectors selectors;
 
-    public CityStyleRE(
+    public CityStyleDefinition(
             Optional<Float> explosionChance,
             Optional<String> style,
             Optional<Identifier> extendsId,

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/ConditionDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/ConditionDefinition.java
@@ -19,21 +19,21 @@ import java.util.Optional;
  * Absent means "inherit unchanged", which is what {@code {"replace": false, "values": []}} was
  * being used for.
  */
-public class ConditionRE implements Extendable {
+public class ConditionDefinition implements Extendable {
 
-    private static final Codec<ConditionRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<ConditionDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Mergeable.codec(ConditionPart.CODEC).optionalFieldOf("values").forGetter(l -> Optional.ofNullable(l.values))
-            ).apply(instance, ConditionRE::new));
+            ).apply(instance, ConditionDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<ConditionRE> CODEC = RetiredKeys.reject(RAW, "condition");
+    public static final Codec<ConditionDefinition> CODEC = RetiredKeys.reject(RAW, "condition");
 
     private final Optional<Identifier> extendsId;
     private final Mergeable<ConditionPart> values;   // null when this entry declares none
 
-    public ConditionRE(Optional<Identifier> extendsId, Optional<Mergeable<ConditionPart>> values) {
+    public ConditionDefinition(Optional<Identifier> extendsId, Optional<Mergeable<ConditionPart>> values) {
         this.extendsId = extendsId;
         this.values = values.orElse(null);
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/MultiBuildingDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/MultiBuildingDefinition.java
@@ -18,9 +18,9 @@ import java.util.Optional;
  * Until that change this registry's every field was required, which made {@code extends} on it
  * purely decorative: a child had to restate the whole grid to decode at all.
  */
-public class MultiBuildingRE implements Extendable {
+public class MultiBuildingDefinition implements Extendable {
 
-    private static final Codec<MultiBuildingRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<MultiBuildingDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Codec.INT.optionalFieldOf("dimx").forGetter(l -> Optional.ofNullable(l.dimX)),
@@ -28,17 +28,17 @@ public class MultiBuildingRE implements Extendable {
                     // A grid, not an ordered list: appending rows would contradict dimx/dimz, so a
                     // declared grid replaces the inherited one wholesale, and an absent one inherits.
                     Codec.list(Codec.list(Codec.STRING)).optionalFieldOf("buildings").forGetter(l -> Optional.ofNullable(l.buildings))
-            ).apply(instance, MultiBuildingRE::new));
+            ).apply(instance, MultiBuildingDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<MultiBuildingRE> CODEC = RetiredKeys.reject(RAW, "multibuilding");
+    public static final Codec<MultiBuildingDefinition> CODEC = RetiredKeys.reject(RAW, "multibuilding");
 
     private final Optional<Identifier> extendsId;
     private final Integer dimX;                 // null when this entry declares none and takes its ancestor's
     private final Integer dimZ;                 // null when this entry declares none and takes its ancestor's
     private final List<List<String>> buildings; // null when this entry declares none and takes its ancestor's
 
-    public MultiBuildingRE(Optional<Identifier> extendsId, Optional<Integer> dimX, Optional<Integer> dimZ,
+    public MultiBuildingDefinition(Optional<Identifier> extendsId, Optional<Integer> dimX, Optional<Integer> dimZ,
                            Optional<List<List<String>>> buildings) {
         this.extendsId = extendsId;
         this.dimX = dimX.orElse(null);

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PaletteDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PaletteDefinition.java
@@ -17,22 +17,22 @@ import java.util.Optional;
  * {@code palette} is optional here rather than required, because requiredness is checked after the
  * {@code extends} chain is resolved, in {@link dev.krona.urbex.worldgen.lost.cityassets.Palette}.
  */
-public class PaletteRE implements Extendable {
+public class PaletteDefinition implements Extendable {
 
-    private static final Codec<PaletteRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<PaletteDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Codec.list(PaletteEntry.CODEC).optionalFieldOf("palette").forGetter(l -> Optional.ofNullable(l.paletteEntries))
-            ).apply(instance, PaletteRE::new));
+            ).apply(instance, PaletteDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<PaletteRE> CODEC = RetiredKeys.reject(RAW, "palette");
+    public static final Codec<PaletteDefinition> CODEC = RetiredKeys.reject(RAW, "palette");
 
     private final Optional<Identifier> extendsId;
     // Null when this entry declares no palette of its own and takes its ancestor's.
     private final List<PaletteEntry> paletteEntries;
 
-    public PaletteRE(Optional<Identifier> extendsId, Optional<List<PaletteEntry>> entries) {
+    public PaletteDefinition(Optional<Identifier> extendsId, Optional<List<PaletteEntry>> entries) {
         this.extendsId = extendsId;
         this.paletteEntries = entries.map(List::copyOf).orElse(null);
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PredefinedCityDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PredefinedCityDefinition.java
@@ -20,9 +20,9 @@ import java.util.Optional;
  * {@link dev.krona.urbex.worldgen.lost.cityassets.PredefinedCity} - so a sibling city can be
  * "the same city, elsewhere" by declaring nothing but {@code extends} and its two chunk coordinates.
  */
-public class PredefinedCityRE implements Extendable {
+public class PredefinedCityDefinition implements Extendable {
 
-    private static final Codec<PredefinedCityRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<PredefinedCityDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Codec.STRING.optionalFieldOf("dimension").forGetter(l -> Optional.ofNullable(l.dimension)),
@@ -32,10 +32,10 @@ public class PredefinedCityRE implements Extendable {
                     Codec.STRING.optionalFieldOf("citystyle").forGetter(l -> Optional.ofNullable(l.cityStyle)),
                     Mergeable.codec(PredefinedBuilding.CODEC).optionalFieldOf("buildings").forGetter(l -> Optional.ofNullable(l.predefinedBuildings)),
                     Mergeable.codec(PredefinedStreet.CODEC).optionalFieldOf("streets").forGetter(l -> Optional.ofNullable(l.predefinedStreets))
-            ).apply(instance, PredefinedCityRE::new));
+            ).apply(instance, PredefinedCityDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<PredefinedCityRE> CODEC = RetiredKeys.reject(RAW, "predefined city");
+    public static final Codec<PredefinedCityDefinition> CODEC = RetiredKeys.reject(RAW, "predefined city");
 
 
     private final Optional<Identifier> extendsId;
@@ -48,7 +48,7 @@ public class PredefinedCityRE implements Extendable {
     private final Mergeable<PredefinedBuilding> predefinedBuildings;
     private final Mergeable<PredefinedStreet> predefinedStreets;
 
-    public PredefinedCityRE(
+    public PredefinedCityDefinition(
             Optional<Identifier> extendsId,
             Optional<String> dimension,
             Optional<Integer> chunkX, Optional<Integer> chunkZ, Optional<Integer> radius,

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PresetDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/PresetDefinition.java
@@ -26,9 +26,9 @@ import java.util.Set;
 /**
  * The datapack-facing preset format: every field is optional, and only the fields actually
  * present in the JSON are applied on top of an {@code extends} chain (see {@code Presets.resolve}).
- * Mirrors the {@code WorldStyleRE} registry-entry idiom.
+ * Mirrors the {@code WorldStyleDefinition} registry-entry idiom.
  */
-public class PresetRE implements Extendable {
+public class PresetDefinition implements Extendable {
 
     public static final Set<String> KEYS = Set.of("extends", "name", "description", "extraDescription", "warning",
             "icon", "terrain", "cities", "buildings", "roads", "highways", "railways", "destruction", "decoration",
@@ -61,21 +61,21 @@ public class PresetRE implements Extendable {
                     Codec.STRING.optionalFieldOf("icon").forGetter(Meta::icon)
             ).apply(instance, Meta::new));
 
-    private static final Codec<PresetRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<PresetDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
-                    META.forGetter(PresetRE::meta),
-                    TerrainSettings.CODEC.optionalFieldOf("terrain").forGetter(PresetRE::terrain),
-                    CitySettings.CODEC.optionalFieldOf("cities").forGetter(PresetRE::cities),
-                    BuildingSettings.CODEC.optionalFieldOf("buildings").forGetter(PresetRE::buildings),
-                    RoadSettings.CODEC.optionalFieldOf("roads").forGetter(PresetRE::roads),
-                    HighwaySettings.CODEC.optionalFieldOf("highways").forGetter(PresetRE::highways),
-                    RailwaySettings.CODEC.optionalFieldOf("railways").forGetter(PresetRE::railways),
-                    DestructionSettings.CODEC.optionalFieldOf("destruction").forGetter(PresetRE::destruction),
-                    DecorationSettings.CODEC.optionalFieldOf("decoration").forGetter(PresetRE::decoration),
-                    SpawnSettings.CODEC.optionalFieldOf("spawn").forGetter(PresetRE::spawn),
-                    AtmosphereSettings.CODEC.optionalFieldOf("atmosphere").forGetter(PresetRE::atmosphere),
-                    MiscSettings.CODEC.optionalFieldOf("misc").forGetter(PresetRE::misc)
-            ).apply(instance, PresetRE::new));
+                    META.forGetter(PresetDefinition::meta),
+                    TerrainSettings.CODEC.optionalFieldOf("terrain").forGetter(PresetDefinition::terrain),
+                    CitySettings.CODEC.optionalFieldOf("cities").forGetter(PresetDefinition::cities),
+                    BuildingSettings.CODEC.optionalFieldOf("buildings").forGetter(PresetDefinition::buildings),
+                    RoadSettings.CODEC.optionalFieldOf("roads").forGetter(PresetDefinition::roads),
+                    HighwaySettings.CODEC.optionalFieldOf("highways").forGetter(PresetDefinition::highways),
+                    RailwaySettings.CODEC.optionalFieldOf("railways").forGetter(PresetDefinition::railways),
+                    DestructionSettings.CODEC.optionalFieldOf("destruction").forGetter(PresetDefinition::destruction),
+                    DecorationSettings.CODEC.optionalFieldOf("decoration").forGetter(PresetDefinition::decoration),
+                    SpawnSettings.CODEC.optionalFieldOf("spawn").forGetter(PresetDefinition::spawn),
+                    AtmosphereSettings.CODEC.optionalFieldOf("atmosphere").forGetter(PresetDefinition::atmosphere),
+                    MiscSettings.CODEC.optionalFieldOf("misc").forGetter(PresetDefinition::misc)
+            ).apply(instance, PresetDefinition::new));
 
     /**
      * Retired-key rejection outside the unknown-key warning, so {@code inherit}/{@code parent} fail
@@ -83,7 +83,7 @@ public class PresetRE implements Extendable {
      * where an unknown key is even mentioned - the other twelve drop it silently - which is exactly
      * why the retired keys cannot be left to that path. See {@link RetiredKeys}.
      */
-    public static final Codec<PresetRE> CODEC = RetiredKeys.reject(
+    public static final Codec<PresetDefinition> CODEC = RetiredKeys.reject(
             dev.krona.urbex.worldgen.lost.regassets.data.preset.UnknownKeys.warning(RAW, KEYS, "preset"),
             "preset");
 
@@ -106,7 +106,7 @@ public class PresetRE implements Extendable {
     private final Optional<AtmosphereSettings> atmosphere;
     private final Optional<MiscSettings> misc;
 
-    public PresetRE(Optional<Identifier> extendsId,
+    public PresetDefinition(Optional<Identifier> extendsId,
                      Optional<String> displayName,
                      Optional<String> description,
                      Optional<String> extraDescription,
@@ -129,7 +129,7 @@ public class PresetRE implements Extendable {
     }
 
     /** The codec's own constructor; see {@link Meta} for why the metadata arrives bundled. */
-    private PresetRE(Meta meta,
+    private PresetDefinition(Meta meta,
                      Optional<TerrainSettings> terrain,
                      Optional<CitySettings> cities,
                      Optional<BuildingSettings> buildings,

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/ScatteredDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/ScatteredDefinition.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  * resolved chain must leave at least one - neither is required on its own, so neither can be
  * required here. Declaring both is allowed; {@code Scattered.generate} takes the multibuilding.
  */
-public class ScatteredRE implements Extendable {
+public class ScatteredDefinition implements Extendable {
 
     /**
      * {@code rotatable} was decoded and then thrown away: {@link ScatteredBuilding} never copied it
@@ -42,7 +42,7 @@ public class ScatteredRE implements Extendable {
                     + "Urbex does not implement: a scattered building always generates unrotated. "
                     + "The key used to be parsed and silently ignored; remove it."));
 
-    private static final Codec<ScatteredRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<ScatteredDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Mergeable.codec(Codec.STRING).optionalFieldOf("buildings").forGetter(l -> Optional.ofNullable(l.buildings)),
@@ -51,10 +51,10 @@ public class ScatteredRE implements Extendable {
                     StringRepresentable.fromEnum(ScatteredBuilding.TerrainHeight::values).optionalFieldOf("terrainheight").forGetter(l -> Optional.ofNullable(l.terrainheight)),
                     StringRepresentable.fromEnum(ScatteredBuilding.TerrainFix::values).optionalFieldOf("terrainfix").forGetter(l -> Optional.ofNullable(l.terrainfix)),
                     Codec.INT.optionalFieldOf("heightoffset").forGetter(l -> Optional.ofNullable(l.heightoffset))
-            ).apply(instance, ScatteredRE::new));
+            ).apply(instance, ScatteredDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<ScatteredRE> CODEC = RetiredKeys.reject(RAW, "scattered building");
+    public static final Codec<ScatteredDefinition> CODEC = RetiredKeys.reject(RAW, "scattered building");
 
     private final Optional<Identifier> extendsId;
     private final ScatteredBuilding.TerrainHeight terrainheight;
@@ -63,7 +63,7 @@ public class ScatteredRE implements Extendable {
     private final Mergeable<String> buildings;
     private final String multibuilding;
 
-    public ScatteredRE(Optional<Identifier> extendsId,
+    public ScatteredDefinition(Optional<Identifier> extendsId,
                        Optional<Mergeable<String>> buildings, Optional<String> multibuilding,
                        // Always empty: UNSUPPORTED_ROTATABLE fails the decode if the key is there
                        // at all, so this parameter exists only to keep the group's arity.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/StuffSettingsDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/StuffSettingsDefinition.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * than required, because a rarer variant of an existing decoration should not have to restate them.
  * Requiredness is checked after the chain is resolved, in {@link #resolve}.
  */
-public class StuffSettingsRE implements Extendable {
+public class StuffSettingsDefinition implements Extendable {
 
     /**
      * The widest {@code attempts} the RNG slot address can hold, and one more than the widest
@@ -42,7 +42,7 @@ public class StuffSettingsRE implements Extendable {
      */
     public static final int SLOT_FIELD_SIZE = 4096;
 
-    private static final Codec<StuffSettingsRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<StuffSettingsDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Mergeable.codec(Codec.STRING).optionalFieldOf("tags").forGetter(l -> Optional.ofNullable(l.tags)),
@@ -58,10 +58,10 @@ public class StuffSettingsRE implements Extendable {
                     BlockMatcher.CODEC.optionalFieldOf("blocks").forGetter(l -> Optional.ofNullable(l.blockMatcher)),
                     BlockMatcher.CODEC.optionalFieldOf("upperblocks").forGetter(l -> Optional.ofNullable(l.upperBlockMatcher)),
                     IdentifierMatcher.CODEC.optionalFieldOf("buildings").forGetter(l -> Optional.ofNullable(l.buildingMatcher))
-            ).apply(instance, StuffSettingsRE::new));
+            ).apply(instance, StuffSettingsDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<StuffSettingsRE> CODEC = RetiredKeys.reject(RAW, "stuff entry");
+    public static final Codec<StuffSettingsDefinition> CODEC = RetiredKeys.reject(RAW, "stuff entry");
 
     private final Optional<Identifier> extendsId;
     private final Mergeable<String> tags;
@@ -79,7 +79,7 @@ public class StuffSettingsRE implements Extendable {
     private final BlockMatcher upperBlockMatcher;
     private final IdentifierMatcher buildingMatcher;
 
-    public StuffSettingsRE(Optional<Identifier> extendsId,
+    public StuffSettingsDefinition(Optional<Identifier> extendsId,
                            Optional<Mergeable<String>> tags,
                            Optional<String> column,
                            Optional<Integer> minheight, Optional<Integer> maxheight,
@@ -114,8 +114,8 @@ public class StuffSettingsRE implements Extendable {
      * file, so a child inherits them, and a chain where nothing declares one is a load error naming
      * the asset and the field rather than an NPE during generation.
      */
-    public static StuffSettingsRE resolve(Identifier id, List<StuffSettingsRE> chainRootFirst) {
-        StuffSettingsRE leaf = chainRootFirst.get(chainRootFirst.size() - 1);
+    public static StuffSettingsDefinition resolve(Identifier id, List<StuffSettingsDefinition> chainRootFirst) {
+        StuffSettingsDefinition leaf = chainRootFirst.get(chainRootFirst.size() - 1);
         if (chainRootFirst.size() == 1) {
             return leaf.requireResolved(id);
         }
@@ -133,7 +133,7 @@ public class StuffSettingsRE implements Extendable {
         BlockMatcher blockMatcher = null;
         BlockMatcher upperBlockMatcher = null;
         IdentifierMatcher buildingMatcher = null;
-        for (StuffSettingsRE re : chainRootFirst) {
+        for (StuffSettingsDefinition re : chainRootFirst) {
             if (re.tags != null) {
                 Mergeable.apply(tags, re.tags);
                 anyTags = true;
@@ -175,7 +175,7 @@ public class StuffSettingsRE implements Extendable {
                 buildingMatcher = re.buildingMatcher;
             }
         }
-        return new StuffSettingsRE(Optional.empty(),
+        return new StuffSettingsDefinition(Optional.empty(),
                 anyTags ? Optional.of(new Mergeable<>(true, List.copyOf(tags))) : Optional.empty(),
                 Optional.ofNullable(column),
                 Optional.ofNullable(minheight), Optional.ofNullable(maxheight),
@@ -194,7 +194,7 @@ public class StuffSettingsRE implements Extendable {
      *             fold is a synthetic entry no registry holds, and writing an id into it just so an
      *             error could name it is what {@code IAsset.setRegistryName} was for (issue #128).
      */
-    private StuffSettingsRE requireResolved(Identifier name) {
+    private StuffSettingsDefinition requireResolved(Identifier name) {
         Resolved.require(column, name, "column");
         Resolved.require(mincount, name, "mincount");
         Resolved.require(maxcount, name, "maxcount");

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/StyleDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/StyleDefinition.java
@@ -19,22 +19,22 @@ import java.util.Optional;
  * after the {@code extends} chain is resolved, in
  * {@link dev.krona.urbex.worldgen.lost.cityassets.Style}.
  */
-public class StyleRE implements Extendable {
+public class StyleDefinition implements Extendable {
 
-    private static final Codec<StyleRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<StyleDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Mergeable.codec(Codec.list(PaletteSelector.CODEC)).optionalFieldOf("randompalettes").forGetter(l -> Optional.ofNullable(l.randomPaletteChoices))
-            ).apply(instance, StyleRE::new));
+            ).apply(instance, StyleDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<StyleRE> CODEC = RetiredKeys.reject(RAW, "style");
+    public static final Codec<StyleDefinition> CODEC = RetiredKeys.reject(RAW, "style");
 
 
     private final Optional<Identifier> extendsId;
     private final Mergeable<List<PaletteSelector>> randomPaletteChoices;   // null when undeclared
 
-    public StyleRE(Optional<Identifier> extendsId, Optional<Mergeable<List<PaletteSelector>>> randomPaletteChoices) {
+    public StyleDefinition(Optional<Identifier> extendsId, Optional<Mergeable<List<PaletteSelector>>> randomPaletteChoices) {
         this.extendsId = extendsId;
         this.randomPaletteChoices = randomPaletteChoices.orElse(null);
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/VariantDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/VariantDefinition.java
@@ -17,21 +17,21 @@ import java.util.Optional;
  * {@code blocks} is optional here rather than required, because requiredness is checked after the
  * {@code extends} chain is resolved, in {@link dev.krona.urbex.worldgen.lost.cityassets.Variant}.
  */
-public class VariantRE implements Extendable {
+public class VariantDefinition implements Extendable {
 
-    private static final Codec<VariantRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<VariantDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Mergeable.codec(BlockEntry.CODEC).optionalFieldOf("blocks").forGetter(l -> Optional.ofNullable(l.blocks))
-            ).apply(instance, VariantRE::new));
+            ).apply(instance, VariantDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<VariantRE> CODEC = RetiredKeys.reject(RAW, "variant");
+    public static final Codec<VariantDefinition> CODEC = RetiredKeys.reject(RAW, "variant");
 
     private final Optional<Identifier> extendsId;
     private final Mergeable<BlockEntry> blocks;   // null when this entry declares none
 
-    public VariantRE(Optional<Identifier> extendsId, Optional<Mergeable<BlockEntry>> entries) {
+    public VariantDefinition(Optional<Identifier> extendsId, Optional<Mergeable<BlockEntry>> entries) {
         this.extendsId = extendsId;
         this.blocks = entries.orElse(null);
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleDefinition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/WorldStyleDefinition.java
@@ -18,9 +18,9 @@ import java.util.Optional;
  * is checked after the chain is resolved, in
  * {@link dev.krona.urbex.worldgen.lost.cityassets.WorldStyle}.
  */
-public class WorldStyleRE implements Extendable {
+public class WorldStyleDefinition implements Extendable {
 
-    private static final Codec<WorldStyleRE> RAW = RecordCodecBuilder.create(instance ->
+    private static final Codec<WorldStyleDefinition> RAW = RecordCodecBuilder.create(instance ->
             instance.group(
                     DataTools.STRICT_IDENTIFIER_CODEC.optionalFieldOf("extends").forGetter(l -> l.extendsId),
                     Codec.STRING.optionalFieldOf("name").forGetter(l -> Optional.ofNullable(l.displayName)),
@@ -32,10 +32,10 @@ public class WorldStyleRE implements Extendable {
                     Mergeable.codec(CityStyleSelector.CODEC).optionalFieldOf("citystyles").forGetter(l -> Optional.ofNullable(l.cityStyleSelectors)),
                     Mergeable.codec(CityBiomeMultiplier.CODEC).optionalFieldOf("citybiomemultipliers").forGetter(l -> Optional.ofNullable(l.cityBiomeMultipliers)),
                     DataTools.BLOCK_TAG_CODEC.optionalFieldOf("rotatable").forGetter(l -> Optional.ofNullable(l.rotatable))
-            ).apply(instance, WorldStyleRE::new));
+            ).apply(instance, WorldStyleDefinition::new));
 
     /** Retired-key rejection wraps every registry's codec; see {@link RetiredKeys}. */
-    public static final Codec<WorldStyleRE> CODEC = RetiredKeys.reject(RAW, "worldstyle");
+    public static final Codec<WorldStyleDefinition> CODEC = RetiredKeys.reject(RAW, "worldstyle");
 
     private final Optional<Identifier> extendsId;
     // The human-readable label the world-style picker shows instead of the id. Null means "not
@@ -55,7 +55,7 @@ public class WorldStyleRE implements Extendable {
     // before this field existed.
     private final TagKey<Block> rotatable;
 
-    public WorldStyleRE(Optional<Identifier> extendsId,
+    public WorldStyleDefinition(Optional<Identifier> extendsId,
                         Optional<String> displayName,
                         Optional<String> outsideStyle,
                         Optional<MultiSettings> multiSettings,

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/ObjectSelector.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/ObjectSelector.java
@@ -15,7 +15,7 @@ public record ObjectSelector(float factor, String value, int minSpawnDistance, i
                     // Real getters, not the constants this used to encode. The decode side has
                     // always been correct, so the tuning survived a round trip only by accident of
                     // never being encoded: `urbex savepreset` and the create-world screen's
-                    // overrides overlay both go through PresetRE.CODEC, and a selector re-encoded
+                    // overrides overlay both go through PresetDefinition.CODEC, and a selector re-encoded
                     // with v -> 0 would have silently reset every distance and feather it carried.
                     Codec.INT.optionalFieldOf("minSpawnDistance", 0).forGetter(ObjectSelector::minSpawnDistance),
                     Codec.INT.optionalFieldOf("maxSpawnDistance", Integer.MAX_VALUE).forGetter(ObjectSelector::maxSpawnDistance),

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/RetiredKeys.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/RetiredKeys.java
@@ -73,8 +73,8 @@ public final class RetiredKeys {
 
     /**
      * Wraps a codec so a retired key fails the decode. Encode is delegated untouched - these keys
-     * can never be produced by an encoder, and {@code PaletteRE}/{@code BuildingPartRE}/
-     * {@code PresetRE} encode on live command and GUI paths that inspect the {@link DataResult}
+     * can never be produced by an encoder, and {@code PaletteDefinition}/{@code BuildingPartDefinition}/
+     * {@code PresetDefinition} encode on live command and GUI paths that inspect the {@link DataResult}
      * themselves.
      */
     public static <A> Codec<A> reject(Codec<A> base, String context) {

--- a/src/test/java/dev/krona/urbex/config/DisplayNameTest.java
+++ b/src/test/java/dev/krona/urbex/config/DisplayNameTest.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.config;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import net.minecraft.resources.Identifier;
 import org.junit.jupiter.api.Test;
 
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class DisplayNameTest {
 
-    private static PresetRE decode(String json) {
+    private static PresetDefinition decode(String json) {
         JsonElement element = JsonParser.parseString(json);
-        return PresetRE.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
+        return PresetDefinition.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
     }
 
     private static Identifier id(String path) {
@@ -36,7 +36,7 @@ class DisplayNameTest {
     @Test
     void anAuthoredNameIsWhatTheUiShows() {
         Identifier presetId = id("tallbuildings");
-        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{\"name\": \"Tall Buildings\"}"));
+        Map<Identifier, PresetDefinition> lookup = Map.of(presetId, decode("{\"name\": \"Tall Buildings\"}"));
 
         Preset p = Presets.resolve(presetId, lookup::get);
 
@@ -47,7 +47,7 @@ class DisplayNameTest {
     @Test
     void noNameAnywhereFallsBackToTheFullyQualifiedId() {
         Identifier presetId = id("tallbuildings");
-        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{}"));
+        Map<Identifier, PresetDefinition> lookup = Map.of(presetId, decode("{}"));
 
         Preset p = Presets.resolve(presetId, lookup::get);
 
@@ -59,7 +59,7 @@ class DisplayNameTest {
     @Test
     void anEmptyStringIsTreatedAsNoNameRatherThanAsABlankLabel() {
         Identifier presetId = id("blank");
-        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{\"name\": \"\"}"));
+        Map<Identifier, PresetDefinition> lookup = Map.of(presetId, decode("{\"name\": \"\"}"));
 
         assertEquals("urbex:blank", Presets.resolve(presetId, lookup::get).getDisplayName());
     }
@@ -73,7 +73,7 @@ class DisplayNameTest {
     void aChildInheritsItsParentsNameWhenItDeclaresNone() {
         Identifier parent = id("default");
         Identifier child = id("largecities");
-        Map<Identifier, PresetRE> lookup = Map.of(
+        Map<Identifier, PresetDefinition> lookup = Map.of(
                 parent, decode("{\"name\": \"Default\"}"),
                 child, decode("{\"extends\": \"urbex:default\"}"));
 
@@ -84,7 +84,7 @@ class DisplayNameTest {
     void aChildsOwnNameWinsOverTheOneItExtends() {
         Identifier parent = id("default");
         Identifier child = id("largecities");
-        Map<Identifier, PresetRE> lookup = Map.of(
+        Map<Identifier, PresetDefinition> lookup = Map.of(
                 parent, decode("{\"name\": \"Default\"}"),
                 child, decode("{\"extends\": \"urbex:default\", \"name\": \"Large Cities\"}"));
 
@@ -93,18 +93,18 @@ class DisplayNameTest {
 
     /**
      * The customized-preset path: the Cities tab's "Customize this preset…" entry is published as a
-     * {@code PresetRE} overlay built by {@code toRE()}, and rebuilt from it on a Re-Create. A name
+     * {@code PresetDefinition} overlay built by {@code toDefinition()}, and rebuilt from it on a Re-Create. A name
      * dropped anywhere along that round trip would rename the row on reload.
      */
     @Test
     void theNameSurvivesCopyAndTheToReRoundTrip() {
         Identifier presetId = id("wasteland");
-        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{\"name\": \"Wasteland\"}"));
+        Map<Identifier, PresetDefinition> lookup = Map.of(presetId, decode("{\"name\": \"Wasteland\"}"));
         Preset resolved = Presets.resolve(presetId, lookup::get);
 
         assertEquals("Wasteland", resolved.copy().getDisplayName());
 
-        Preset rebuilt = Presets.applyOverrides(new Preset(presetId), resolved.toRE());
+        Preset rebuilt = Presets.applyOverrides(new Preset(presetId), resolved.toDefinition());
         assertEquals("Wasteland", rebuilt.getDisplayName());
     }
 
@@ -112,7 +112,7 @@ class DisplayNameTest {
     @Test
     void aNameNeedsNoNamespaceAndMayContainSpacesAndPunctuation() {
         Identifier presetId = id("fancy");
-        Map<Identifier, PresetRE> lookup =
+        Map<Identifier, PresetDefinition> lookup =
                 Map.of(presetId, decode("{\"name\": \"Cities & Ruins (heavy)\"}"));
 
         assertEquals("Cities & Ruins (heavy)", Presets.resolve(presetId, lookup::get).getDisplayName());
@@ -123,9 +123,9 @@ class DisplayNameTest {
         Preset p = new Preset(id("x"));
         p.setName("Example");
 
-        JsonElement json = PresetRE.CODEC.encodeStart(JsonOps.INSTANCE, p.toRE()).getOrThrow();
+        JsonElement json = PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, p.toDefinition()).getOrThrow();
 
-        assertTrue(json.getAsJsonObject().has("name"), "toRE() must carry the name");
+        assertTrue(json.getAsJsonObject().has("name"), "toDefinition() must carry the name");
         assertEquals("Example", json.getAsJsonObject().get("name").getAsString());
         // The metadata block is a MapCodec purely to buy a seventeenth field back from
         // RecordCodecBuilder's sixteen-field limit; it must stay flattened into the file's own

--- a/src/test/java/dev/krona/urbex/config/PresetCodecTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetCodecTest.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.BuildingSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.CitySettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.TerrainSettings;
@@ -19,19 +19,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Headless: PresetRE and its sections hold only primitives/strings/lists, so decoding needs no MC
+ * Headless: PresetDefinition and its sections hold only primitives/strings/lists, so decoding needs no MC
  * bootstrap.
  */
 class PresetCodecTest {
 
-    private static PresetRE decode(String json) {
+    private static PresetDefinition decode(String json) {
         JsonElement element = JsonParser.parseString(json);
-        return PresetRE.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
+        return PresetDefinition.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
     }
 
     @Test
     void minimalFileParses() {
-        PresetRE re = decode("{\"description\":\"x\",\"cities\":{\"cityChance\":0.001}}");
+        PresetDefinition re = decode("{\"description\":\"x\",\"cities\":{\"cityChance\":0.001}}");
 
         assertEquals("x", re.description().orElseThrow());
         assertTrue(re.cities().isPresent());
@@ -61,14 +61,14 @@ class PresetCodecTest {
 
         JsonObject root = JsonParser.parseString(json).getAsJsonObject();
         Dynamic<JsonElement> dyn = new Dynamic<>(JsonOps.INSTANCE, root);
-        assertEquals(List.of("citiez"), UnknownKeys.check(dyn, PresetRE.KEYS));
+        assertEquals(List.of("citiez"), UnknownKeys.check(dyn, PresetDefinition.KEYS));
     }
 
     @Test
     void unknownSectionKeyParsesButWarns() {
         String json = "{\"cities\":{\"cityChanse\":0.1}}";
 
-        PresetRE re = decode(json);
+        PresetDefinition re = decode(json);
         assertTrue(re.cities().isPresent());
 
         JsonObject citiesObj = JsonParser.parseString(json).getAsJsonObject().getAsJsonObject("cities");
@@ -80,12 +80,12 @@ class PresetCodecTest {
     void underscoreKeysAreSilentlyAllowed() {
         String json = "{\"_comment\":\"x\",\"cities\":{\"_note\":\"y\"}}";
 
-        PresetRE re = decode(json);
+        PresetDefinition re = decode(json);
         assertTrue(re.cities().isPresent());
 
         JsonObject root = JsonParser.parseString(json).getAsJsonObject();
         Dynamic<JsonElement> rootDyn = new Dynamic<>(JsonOps.INSTANCE, root);
-        assertEquals(List.of(), UnknownKeys.check(rootDyn, PresetRE.KEYS));
+        assertEquals(List.of(), UnknownKeys.check(rootDyn, PresetDefinition.KEYS));
 
         JsonObject citiesObj = root.getAsJsonObject("cities");
         Dynamic<JsonElement> citiesDyn = new Dynamic<>(JsonOps.INSTANCE, citiesObj);
@@ -94,7 +94,7 @@ class PresetCodecTest {
 
     @Test
     void enumValuesParse() {
-        PresetRE re = decode("{\"terrain\":{\"landscapeType\":\"cavern\"},"
+        PresetDefinition re = decode("{\"terrain\":{\"landscapeType\":\"cavern\"},"
                 + "\"buildings\":{\"multiBuildingStreetConflict\":\"override_all\"}}");
 
         TerrainSettings terrain = re.terrain().orElseThrow();

--- a/src/test/java/dev/krona/urbex/config/PresetOverrideCacheTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetOverrideCacheTest.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.config;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import net.minecraft.SharedConstants;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.Bootstrap;
@@ -34,9 +34,9 @@ class PresetOverrideCacheTest {
         Bootstrap.bootStrap();
     }
 
-    private static PresetRE decode(String json) {
+    private static PresetDefinition decode(String json) {
         JsonElement element = JsonParser.parseString(json);
-        return PresetRE.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
+        return PresetDefinition.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
     }
 
     @Test
@@ -47,7 +47,7 @@ class PresetOverrideCacheTest {
         assertEquals(Blocks.WATER.defaultBlockState(), base.getLiquidBlock());
         assertEquals(Blocks.STONE.defaultBlockState(), base.getBaseBlock());
 
-        PresetRE overrides = decode("{\"terrain\":{\"liquidBlock\":\"minecraft:lava\","
+        PresetDefinition overrides = decode("{\"terrain\":{\"liquidBlock\":\"minecraft:lava\","
                 + "\"baseBlock\":\"minecraft:granite\"}}");
 
         Preset overridden = Presets.applyOverrides(base, overrides);

--- a/src/test/java/dev/krona/urbex/config/PresetResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetResolutionTest.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.config;
 
 import com.google.gson.JsonElement;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import net.minecraft.resources.Identifier;
 import org.junit.jupiter.api.Test;
 
@@ -17,18 +17,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /** Headless: {@code Presets.resolve(Identifier, Function)} needs no registry or level. */
 class PresetResolutionTest {
 
-    private static PresetRE decode(String json) {
+    private static PresetDefinition decode(String json) {
         JsonElement element = com.google.gson.JsonParser.parseString(json);
-        return PresetRE.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
+        return PresetDefinition.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
     }
 
     private static Identifier id(String path) {
         return Identifier.fromNamespaceAndPath("urbex", path);
     }
 
-    /** Builds a {@code PresetRE} with only the {@code extends} field set. */
-    private static PresetRE presetWithExtends(Identifier extendsId) {
-        return new PresetRE(Optional.of(extendsId), Optional.empty(), Optional.empty(), Optional.empty(),
+    /** Builds a {@code PresetDefinition} with only the {@code extends} field set. */
+    private static PresetDefinition presetWithExtends(Identifier extendsId) {
+        return new PresetDefinition(Optional.of(extendsId), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty());
@@ -37,7 +37,7 @@ class PresetResolutionTest {
     @Test
     void extendslessPresetGetsCodeDefaults() {
         Identifier presetId = id("leaf");
-        Map<Identifier, PresetRE> lookup = Map.of(presetId, decode("{}"));
+        Map<Identifier, PresetDefinition> lookup = Map.of(presetId, decode("{}"));
 
         Preset p = Presets.resolve(presetId, lookup::get);
 
@@ -51,7 +51,7 @@ class PresetResolutionTest {
         Identifier parentId = id("parent");
         Identifier childId = id("child");
 
-        Map<Identifier, PresetRE> lookup = new HashMap<>();
+        Map<Identifier, PresetDefinition> lookup = new HashMap<>();
         lookup.put(parentId, decode("{\"cities\":{\"cityChance\":0.5}}"));
         lookup.put(childId, decode("{\"extends\":\"urbex:parent\",\"destruction\":{\"ruinChance\":0.9}}"));
 
@@ -70,7 +70,7 @@ class PresetResolutionTest {
         Identifier middleId = id("middle");
         Identifier leafId = id("leaf");
 
-        Map<Identifier, PresetRE> lookup = new HashMap<>();
+        Map<Identifier, PresetDefinition> lookup = new HashMap<>();
         lookup.put(rootId, decode("{\"cities\":{\"cityChance\":0.1}}"));
         lookup.put(middleId, decode("{\"extends\":\"urbex:root\","
                 + "\"cities\":{\"cityChance\":0.2},\"buildings\":{\"buildingChance\":0.3}}"));
@@ -87,7 +87,7 @@ class PresetResolutionTest {
         Identifier aId = id("a");
         Identifier bId = id("b");
 
-        Map<Identifier, PresetRE> lookup = new HashMap<>();
+        Map<Identifier, PresetDefinition> lookup = new HashMap<>();
         lookup.put(aId, decode("{\"extends\":\"urbex:b\"}"));
         lookup.put(bId, decode("{\"extends\":\"urbex:a\"}"));
 
@@ -100,7 +100,7 @@ class PresetResolutionTest {
     @Test
     void danglingExtendsIsError() {
         Identifier leafId = id("leaf");
-        Map<Identifier, PresetRE> lookup = Map.of(leafId, decode("{\"extends\":\"urbex:ghost\"}"));
+        Map<Identifier, PresetDefinition> lookup = Map.of(leafId, decode("{\"extends\":\"urbex:ghost\"}"));
 
         IllegalStateException ex = assertThrows(IllegalStateException.class,
                 () -> Presets.resolve(leafId, lookup::get));
@@ -134,7 +134,7 @@ class PresetResolutionTest {
     @Test
     void pureResolveReflectsALookupChangeBetweenCalls() {
         Identifier presetId = id("mutable");
-        Map<Identifier, PresetRE> lookup = new HashMap<>();
+        Map<Identifier, PresetDefinition> lookup = new HashMap<>();
         lookup.put(presetId, decode("{\"cities\":{\"cityChance\":0.1}}"));
 
         Preset first = Presets.resolve(presetId, lookup::get);

--- a/src/test/java/dev/krona/urbex/config/PresetRoundTripTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetRoundTripTest.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.config;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.AtmosphereSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.BuildingSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.CitySettings;
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@code toReEncodesEveryKey} is the drift guard's engine: it pins each section's declared
- * {@code KEYS} constant to what {@code toRE()} actually encodes, so a field added to a section
+ * {@code KEYS} constant to what {@code toDefinition()} actually encodes, so a field added to a section
  * record without updating {@code KEYS} (or vice versa) fails a test instead of silently warning
  * at runtime.
  */
@@ -53,9 +53,9 @@ class PresetRoundTripTest {
 
     @Test
     void toReEncodesEveryKey() {
-        PresetRE re = new Preset(ID).toRE();
+        PresetDefinition re = new Preset(ID).toDefinition();
 
-        JsonElement encoded = PresetRE.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
+        JsonElement encoded = PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
         JsonObject root = encoded.getAsJsonObject();
 
         for (Map.Entry<String, Set<String>> entry : EXPECTED_SECTION_KEYS.entrySet()) {
@@ -82,9 +82,9 @@ class PresetRoundTripTest {
         p.HORIZON = 100f;
         p.EDITMODE = true;
 
-        PresetRE re = p.toRE();
-        JsonElement encoded = PresetRE.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
-        PresetRE decoded = PresetRE.CODEC.parse(JsonOps.INSTANCE, encoded).getOrThrow();
+        PresetDefinition re = p.toDefinition();
+        JsonElement encoded = PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
+        PresetDefinition decoded = PresetDefinition.CODEC.parse(JsonOps.INSTANCE, encoded).getOrThrow();
 
         Preset resolved = Presets.resolve(ID, i -> i.equals(ID) ? decoded : null);
 

--- a/src/test/java/dev/krona/urbex/config/PresetSchemaTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetSchemaTest.java
@@ -6,7 +6,7 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.AtmosphereSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.BuildingSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.preset.CitySettings;
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Drift-guards {@code docs/schema/preset.schema.json} (hand-written, since the section records are
  * plain DFU codecs with no schema-generation library wired up) against the same two sources of
  * truth {@link PresetRoundTripTest} pins the codecs to: each section's {@code KEYS} constant, and
- * the full key universe {@code toRE()} actually encodes. A field added to a section record without
+ * the full key universe {@code toDefinition()} actually encodes. A field added to a section record without
  * a matching schema edit (or vice versa) fails here instead of silently going undocumented.
  */
 class PresetSchemaTest {
@@ -95,8 +95,8 @@ class PresetSchemaTest {
     void schemaCoversExactlyTheCodecKeys() throws IOException {
         JsonNode schema = readSchemaNode();
 
-        assertEquals(PresetRE.KEYS, propertyNames(schema),
-                "top-level schema properties should exactly match PresetRE.KEYS");
+        assertEquals(PresetDefinition.KEYS, propertyNames(schema),
+                "top-level schema properties should exactly match PresetDefinition.KEYS");
         assertClosedAndBlessesUnderscoreKeys(schema, "root");
 
         JsonNode properties = schema.get("properties");

--- a/src/test/java/dev/krona/urbex/config/ShippedPresetsTest.java
+++ b/src/test/java/dev/krona/urbex/config/ShippedPresetsTest.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.config;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import net.minecraft.resources.Identifier;
 import org.junit.jupiter.api.Test;
 
@@ -25,8 +25,8 @@ class ShippedPresetsTest {
     private static final Path PRESETS_DIR = Path.of("src/main/resources/data/urbex/urbex/presets");
     private static final Path TAG_FILE = Path.of("src/main/resources/data/urbex/tags/urbex/presets/presets.json");
 
-    private Map<Identifier, PresetRE> loadShippedPresets() throws Exception {
-        Map<Identifier, PresetRE> presets = new HashMap<>();
+    private Map<Identifier, PresetDefinition> loadShippedPresets() throws Exception {
+        Map<Identifier, PresetDefinition> presets = new HashMap<>();
 
         try (var stream = Files.list(PRESETS_DIR)) {
             stream.filter(p -> p.toString().endsWith(".json"))
@@ -38,7 +38,7 @@ class ShippedPresetsTest {
 
                             String json = Files.readString(p);
                             JsonElement element = JsonParser.parseString(json);
-                            PresetRE preset = PresetRE.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
+                            PresetDefinition preset = PresetDefinition.CODEC.parse(JsonOps.INSTANCE, element).getOrThrow();
                             presets.put(id, preset);
                         } catch (Exception e) {
                             throw new RuntimeException(e);
@@ -51,7 +51,7 @@ class ShippedPresetsTest {
 
     @Test
     void allShippedPresetsParseAndResolve() throws Exception {
-        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        Map<Identifier, PresetDefinition> presets = loadShippedPresets();
         assertFalse(presets.isEmpty(), "No preset files found");
 
         for (Identifier id : presets.keySet()) {
@@ -62,12 +62,12 @@ class ShippedPresetsTest {
 
     @Test
     void everyShippedPresetHasExplicitLightingDensity() throws Exception {
-        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        Map<Identifier, PresetDefinition> presets = loadShippedPresets();
         assertFalse(presets.isEmpty(), "No preset files found");
 
         for (var entry : presets.entrySet()) {
             Identifier id = entry.getKey();
-            PresetRE preset = entry.getValue();
+            PresetDefinition preset = entry.getValue();
             assertTrue(preset.decoration().isPresent() && preset.decoration().get().lightingDensity().isPresent(),
                     "Preset " + id + " does not have explicit decoration.lightingDensity");
         }
@@ -75,7 +75,7 @@ class ShippedPresetsTest {
 
     @Test
     void avgHeightmapOnEverywhere() throws Exception {
-        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        Map<Identifier, PresetDefinition> presets = loadShippedPresets();
         assertFalse(presets.isEmpty(), "No preset files found");
 
         for (var entry : presets.entrySet()) {
@@ -88,12 +88,12 @@ class ShippedPresetsTest {
 
     @Test
     void nonDefaultPresetsExtendDefault() throws Exception {
-        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        Map<Identifier, PresetDefinition> presets = loadShippedPresets();
         assertFalse(presets.isEmpty(), "No preset files found");
 
         for (var entry : presets.entrySet()) {
             Identifier id = entry.getKey();
-            PresetRE preset = entry.getValue();
+            PresetDefinition preset = entry.getValue();
 
             if (id.getPath().equals("default")) {
                 // Default preset should not extend anything
@@ -111,7 +111,7 @@ class ShippedPresetsTest {
 
     @Test
     void tagListsExactlyTheShippedPresets() throws Exception {
-        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        Map<Identifier, PresetDefinition> presets = loadShippedPresets();
         assertFalse(presets.isEmpty(), "No preset files found");
 
         String tagJson = Files.readString(TAG_FILE);
@@ -136,7 +136,7 @@ class ShippedPresetsTest {
      */
     @Test
     void everyShippedPresetDeclaresItsOwnUniqueName() throws Exception {
-        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        Map<Identifier, PresetDefinition> presets = loadShippedPresets();
         assertFalse(presets.isEmpty(), "No preset files found");
 
         Map<String, Identifier> byName = new HashMap<>();
@@ -164,7 +164,7 @@ class ShippedPresetsTest {
      */
     @Test
     void everyShippedPresetDeclaresItsOwnDescription() throws Exception {
-        Map<Identifier, PresetRE> presets = loadShippedPresets();
+        Map<Identifier, PresetDefinition> presets = loadShippedPresets();
         assertFalse(presets.isEmpty(), "No preset files found");
 
         for (var entry : presets.entrySet()) {

--- a/src/test/java/dev/krona/urbex/data/DatapackGuideExamplesTest.java
+++ b/src/test/java/dev/krona/urbex/data/DatapackGuideExamplesTest.java
@@ -14,19 +14,19 @@ import dev.krona.urbex.worldgen.lost.cityassets.Palette;
 import dev.krona.urbex.worldgen.lost.cityassets.Resolved;
 import dev.krona.urbex.worldgen.lost.cityassets.Style;
 import dev.krona.urbex.worldgen.lost.cityassets.StuffObject;
-import dev.krona.urbex.worldgen.lost.regassets.BuildingPartRE;
-import dev.krona.urbex.worldgen.lost.regassets.BuildingRE;
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
-import dev.krona.urbex.worldgen.lost.regassets.ConditionRE;
-import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingRE;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
-import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityRE;
-import dev.krona.urbex.worldgen.lost.regassets.PresetRE;
-import dev.krona.urbex.worldgen.lost.regassets.ScatteredRE;
-import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsRE;
-import dev.krona.urbex.worldgen.lost.regassets.StyleRE;
-import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.ConditionDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.ScatteredDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.StyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.VariantDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
@@ -76,25 +76,25 @@ class DatapackGuideExamplesTest {
     /**
      * The thirteen registries, by the directory name the guide (and a datapack) spells them with.
      * <p>
-     * A method rather than a static field: touching any {@code *RE.CODEC} initialises Minecraft's
+     * A method rather than a static field: touching any {@code *Definition.CODEC} initialises Minecraft's
      * built-in registries, and a static field would do that during class initialisation, before
      * {@link #bootstrap()} has run.
      */
     private static Map<String, Codec<?>> codecs() {
         return Map.ofEntries(
-            Map.entry("worldstyles", WorldStyleRE.CODEC),
-            Map.entry("citystyles", CityStyleRE.CODEC),
-            Map.entry("buildings", BuildingRE.CODEC),
-            Map.entry("parts", BuildingPartRE.CODEC),
-            Map.entry("palettes", PaletteRE.CODEC),
-            Map.entry("styles", StyleRE.CODEC),
-            Map.entry("multibuildings", MultiBuildingRE.CODEC),
-            Map.entry("scattered", ScatteredRE.CODEC),
-            Map.entry("conditions", ConditionRE.CODEC),
-            Map.entry("variants", VariantRE.CODEC),
-            Map.entry("stuff", StuffSettingsRE.CODEC),
-            Map.entry("predefinedcities", PredefinedCityRE.CODEC),
-            Map.entry("presets", PresetRE.CODEC));
+            Map.entry("worldstyles", WorldStyleDefinition.CODEC),
+            Map.entry("citystyles", CityStyleDefinition.CODEC),
+            Map.entry("buildings", BuildingDefinition.CODEC),
+            Map.entry("parts", BuildingPartDefinition.CODEC),
+            Map.entry("palettes", PaletteDefinition.CODEC),
+            Map.entry("styles", StyleDefinition.CODEC),
+            Map.entry("multibuildings", MultiBuildingDefinition.CODEC),
+            Map.entry("scattered", ScatteredDefinition.CODEC),
+            Map.entry("conditions", ConditionDefinition.CODEC),
+            Map.entry("variants", VariantDefinition.CODEC),
+            Map.entry("stuff", StuffSettingsDefinition.CODEC),
+            Map.entry("predefinedcities", PredefinedCityDefinition.CODEC),
+            Map.entry("presets", PresetDefinition.CODEC));
     }
 
     @BeforeAll
@@ -198,7 +198,7 @@ class DatapackGuideExamplesTest {
                 namedPart(tower, 8, null, null))));
 
         // 'extends' inside an inline palette block.
-        expect(guide, missing, () -> Palette.inline(BuiltInRegistries.BLOCK, null, tower, List.of(new PaletteRE(
+        expect(guide, missing, () -> Palette.inline(BuiltInRegistries.BLOCK, null, tower, List.of(new PaletteDefinition(
                 Optional.of(Identifier.fromNamespaceAndPath("urbex", "common")), Optional.empty()))));
 
         // A palette entry that resolves to nothing at all.
@@ -206,12 +206,12 @@ class DatapackGuideExamplesTest {
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         expect(guide, missing, () -> new Palette(Identifier.fromNamespaceAndPath("urbex", "x"), BuiltInRegistries.BLOCK, null, List.of(
-                new PaletteRE(Optional.empty(), Optional.of(List.of(empty))))));
+                new PaletteDefinition(Optional.empty(), Optional.of(List.of(empty))))));
 
         // A 'randompalettes' group nothing could ever be drawn from, and a stuff entry whose two
         // count bounds contradict. Both are checked at the chain fold rather than per field.
         expect(guide, missing, () -> new Style(Identifier.fromNamespaceAndPath("urbexmt", "downtown"), NO_PALETTES, List.of(
-                new StyleRE(Optional.empty(), Optional.of(new Mergeable<>(true,
+                new StyleDefinition(Optional.empty(), Optional.of(new Mergeable<>(true,
                         List.of(List.of(new PaletteSelector(0f, "urbex:common")))))))));
         expect(guide, missing, () -> new StuffObject(downtown, List.of(
                 stuffCounts(downtown, 5, 2))));
@@ -224,7 +224,7 @@ class DatapackGuideExamplesTest {
         // The retired-key rejection, which is a DataResult error rather than a throw, so it cannot
         // go through expect(). Taken from the codec that ships, not from RetiredKeys.problem, so the
         // guide is pinned to what a pack author actually sees.
-        String retired = CityStyleRE.CODEC
+        String retired = CityStyleDefinition.CODEC
                 .parse(JsonOps.INSTANCE, JsonParser.parseString("{\"inherit\":\"urbex:citystyle_common\"}"))
                 .error().orElseThrow(() -> new AssertionError("expected 'inherit' to be rejected"))
                 .message();
@@ -238,8 +238,8 @@ class DatapackGuideExamplesTest {
     }
 
     /** A stuff entry declaring everything required, with the two count bounds the caller names. */
-    private static StuffSettingsRE stuffCounts(Identifier id, int mincount, int maxcount) {
-        return new StuffSettingsRE(Optional.empty(),
+    private static StuffSettingsDefinition stuffCounts(Identifier id, int mincount, int maxcount) {
+        return new StuffSettingsDefinition(Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of("rubble"))), Optional.of("AA"),
                 Optional.empty(), Optional.empty(),
                 Optional.of(mincount), Optional.of(maxcount), Optional.of(1),
@@ -279,9 +279,9 @@ class DatapackGuideExamplesTest {
      */
     private static final AssetIndex<Palette> NO_PALETTES = AssetIndex.empty("urbex:palettes");
 
-    private static BuildingPartRE namedPart(Identifier id, Integer xSize, Integer zSize,
+    private static BuildingPartDefinition namedPart(Identifier id, Integer xSize, Integer zSize,
                                             List<List<String>> slices) {
-        return new BuildingPartRE(Optional.empty(), Optional.ofNullable(xSize),
+        return new BuildingPartDefinition(Optional.empty(), Optional.ofNullable(xSize),
                 Optional.ofNullable(zSize), Optional.ofNullable(slices), Optional.empty(),
                 Optional.empty(), Optional.empty());
     }

--- a/src/test/java/dev/krona/urbex/data/WorldStyleCompletenessTest.java
+++ b/src/test/java/dev/krona/urbex/data/WorldStyleCompletenessTest.java
@@ -8,8 +8,8 @@ import com.mojang.serialization.JsonOps;
 import dev.krona.urbex.worldgen.lost.cityassets.CityStyle;
 import dev.krona.urbex.worldgen.lost.cityassets.Resolved;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.StreetParts;
@@ -95,9 +95,9 @@ class WorldStyleCompletenessTest {
         Set<String> cityStylesNamed = new LinkedHashSet<>();
         for (Path file : worldStyles) {
             List<Path> chain = chainRootFirst("worldstyles", file);
-            List<WorldStyleRE> entries = new ArrayList<>();
+            List<WorldStyleDefinition> entries = new ArrayList<>();
             for (Path link : chain) {
-                entries.add(WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, read(link)).getOrThrow());
+                entries.add(WorldStyleDefinition.CODEC.parse(JsonOps.INSTANCE, read(link)).getOrThrow());
                 cityStylesNamed.addAll(cityStyleRefs(link));
             }
             requireWorldStyleWiring(new WorldStyle(TestAssetId.ANY, entries));
@@ -110,9 +110,9 @@ class WorldStyleCompletenessTest {
         for (String name : cityStylesNamed) {
             Path file = fileFor("citystyles", name);
             assertTrue(Files.isRegularFile(file), name + " does not resolve to " + file);
-            List<CityStyleRE> entries = new ArrayList<>();
+            List<CityStyleDefinition> entries = new ArrayList<>();
             for (Path link : chainRootFirst("citystyles", file)) {
-                entries.add(CityStyleRE.CODEC.parse(JsonOps.INSTANCE, read(link)).getOrThrow());
+                entries.add(CityStyleDefinition.CODEC.parse(JsonOps.INSTANCE, read(link)).getOrThrow());
             }
             requireCityStyleWiring(new CityStyle(TestAssetId.ANY, entries));
         }

--- a/src/test/java/dev/krona/urbex/gui/NullDimensionInfoPlaceholderTest.java
+++ b/src/test/java/dev/krona/urbex/gui/NullDimensionInfoPlaceholderTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * null deliberately when the biome registry or the parent screen is absent) or because the lookup
  * failed, which is what a stale GUI world style no longer shipped by any datapack looks like. The
  * placeholder is therefore a live user-facing path, not a theoretical one, and it is built from a
- * hand-written {@code WorldStyleRE} rather than from JSON - so nothing about it is checked by the
+ * hand-written {@code WorldStyleDefinition} rather than from JSON - so nothing about it is checked by the
  * datapack tests.
  * <p>
  * That is exactly how it broke: {@code parts} became required of a resolved chain after the

--- a/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
+++ b/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
@@ -187,11 +187,11 @@ class PresetSelectionTest {
         assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, Config.worldStyleMixFromClient);
         assertNotNull(Config.overridesFromClient);
 
-        // The published JSON is a real, parseable PresetRE overlay (not a stringified profile).
-        com.mojang.serialization.DataResult<dev.krona.urbex.worldgen.lost.regassets.PresetRE> parsed =
-                dev.krona.urbex.worldgen.lost.regassets.PresetRE.CODEC.parse(com.mojang.serialization.JsonOps.INSTANCE,
+        // The published JSON is a real, parseable PresetDefinition overlay (not a stringified profile).
+        com.mojang.serialization.DataResult<dev.krona.urbex.worldgen.lost.regassets.PresetDefinition> parsed =
+                dev.krona.urbex.worldgen.lost.regassets.PresetDefinition.CODEC.parse(com.mojang.serialization.JsonOps.INSTANCE,
                         com.google.gson.JsonParser.parseString(Config.overridesFromClient));
-        assertTrue(parsed.isSuccess(), "overridesFromClient must decode as a PresetRE: " + parsed);
+        assertTrue(parsed.isSuccess(), "overridesFromClient must decode as a PresetDefinition: " + parsed);
         assertEquals(0.5, parsed.getOrThrow().cities().orElseThrow().cityChance().orElseThrow(), 1e-9);
     }
 
@@ -264,7 +264,7 @@ class PresetSelectionTest {
     /**
      * Regression: an unparseable overridesJson must never reach {@code Config.overridesFromClient} -
      * that field is read when a level loads and its runtime is built
-     * ({@code DimensionRuntime.create}'s {@code PresetRE.CODEC.parse(...).getOrThrow()}), so a
+     * ({@code DimensionRuntime.create}'s {@code PresetDefinition.CODEC.parse(...).getOrThrow()}), so a
      * corrupted/hand-edited save's garbage JSON must be rejected before publish, not after.
      */
     @Test

--- a/src/test/java/dev/krona/urbex/worldgen/TagSnapshotTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/TagSnapshotTest.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.worldgen;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetIndex;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
@@ -105,7 +105,7 @@ class TagSnapshotTest {
     }
 
     private static WorldStyle worldStyle(String name, Optional<TagKey<Block>> rotatable) {
-        return new WorldStyle(Identifier.fromNamespaceAndPath("urbex", name), List.of(new WorldStyleRE(
+        return new WorldStyle(Identifier.fromNamespaceAndPath("urbex", name), List.of(new WorldStyleDefinition(
                 Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.of(TestWiring.partSelector()),

--- a/src/test/java/dev/krona/urbex/worldgen/WorldStyleFieldTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/WorldStyleFieldTest.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
@@ -45,11 +45,11 @@ class WorldStyleFieldTest {
     /**
      * A minimal resolvable world style, built by hand rather than from a registry - the same shape
      * {@code NullDimensionInfo}'s preview placeholder uses, which is the only other place in the
-     * tree that constructs a {@code WorldStyleRE} directly. Declares everything
+     * tree that constructs a {@code WorldStyleDefinition} directly. Declares everything
      * {@code WorldStyle} requires after resolution and nothing else.
      */
     private static WorldStyle style(String path) {
-        WorldStyleRE re = new WorldStyleRE(
+        WorldStyleDefinition re = new WorldStyleDefinition(
                 Optional.empty(),
                 // No display name: these exist to be told apart by id, and getName() is what the
                 // field's primary tie-break and this test's assertions read.

--- a/src/test/java/dev/krona/urbex/worldgen/lost/TestProfiles.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/TestProfiles.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.worldgen.lost;
 
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.worldgen.lost.cityassets.CityStyle;
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
 import net.minecraft.resources.Identifier;
 
@@ -37,7 +37,7 @@ final class TestProfiles {
      * {@code urbex:test_street_*} ids that no test here places.
      */
     static CityStyle cityStyle() {
-        return new CityStyle(Identifier.fromNamespaceAndPath("urbex", "test_citystyle"), List.of(new CityStyleRE(
+        return new CityStyle(Identifier.fromNamespaceAndPath("urbex", "test_citystyle"), List.of(new CityStyleDefinition(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.of(TestWiring.streetSettings()),

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompilerTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompilerTest.java
@@ -2,10 +2,10 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import com.mojang.serialization.Lifecycle;
 import dev.krona.urbex.setup.CustomRegistries;
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
-import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsRE;
-import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.VariantDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
@@ -96,7 +96,7 @@ class AssetCompilerTest {
     void stuffSharingATagIsOrderedByIdRatherThanByHash() {
         AssetDiagnostics diagnostics = new AssetDiagnostics();
         RegistryAccess access = registries();
-        MappedRegistry<StuffSettingsRE> stuff = new MappedRegistry<>(
+        MappedRegistry<StuffSettingsDefinition> stuff = new MappedRegistry<>(
                 CustomRegistries.STUFF_REGISTRY_KEY, Lifecycle.stable());
         // Registered in reverse order on purpose: if the index leaked registration or hash order,
         // this is what would show it.
@@ -163,30 +163,30 @@ class AssetCompilerTest {
 
     private record Entry<T>(ResourceKey<Registry<T>> key, Identifier id, T value) { }
 
-    private static Entry<VariantRE> variant(String path, String block) {
+    private static Entry<VariantDefinition> variant(String path, String block) {
         return new Entry<>(CustomRegistries.VARIANTS_REGISTRY_KEY, id(path),
-                new VariantRE(Optional.empty(),
+                new VariantDefinition(Optional.empty(),
                         Optional.of(new Mergeable<>(true, List.of(new BlockEntry(1, block))))));
     }
 
-    private static Entry<PaletteRE> paletteNamingVariant(String path, char marker, String variant) {
+    private static Entry<PaletteDefinition> paletteNamingVariant(String path, char marker, String variant) {
         PaletteEntry entry = new PaletteEntry(Character.toString(marker), Optional.empty(),
                 Optional.of(variant), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         return new Entry<>(CustomRegistries.PALETTE_REGISTRY_KEY, id(path),
-                new PaletteRE(Optional.empty(), Optional.of(List.of(entry))));
+                new PaletteDefinition(Optional.empty(), Optional.of(List.of(entry))));
     }
 
     /** A city style declaring nothing: complete only through a child that extends it. */
-    private static Entry<CityStyleRE> abstractBaseCityStyle(String path) {
+    private static Entry<CityStyleDefinition> abstractBaseCityStyle(String path) {
         return new Entry<>(CustomRegistries.CITYSTYLES_REGISTRY_KEY, id(path),
-                new CityStyleRE(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                new CityStyleDefinition(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
     }
 
-    private static StuffSettingsRE stuffTagged(String path, String tag) {
-        return new StuffSettingsRE(Optional.empty(),
+    private static StuffSettingsDefinition stuffTagged(String path, String tag) {
+        return new StuffSettingsDefinition(Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of(tag))),
                 Optional.of("\\"),
                 Optional.empty(), Optional.empty(),

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetValidationTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetValidationTest.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import com.mojang.serialization.Lifecycle;
 import dev.krona.urbex.setup.CustomRegistries;
-import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
+import dev.krona.urbex.worldgen.lost.regassets.VariantDefinition;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.RegistrationInfo;
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * asking for that diagnosis on a running world changes nothing.
  * <p>
  * Both properties are exercised through the {@code variants} registry, whose entries are the
- * cheapest asset to break: a {@code VariantRE} declaring no {@code blocks} anywhere in its chain is
+ * cheapest asset to break: a {@code VariantDefinition} declaring no {@code blocks} anywhere in its chain is
  * exactly the "a field nothing declares" failure {@link Resolved} raises, and it needs no other
  * registry to be populated to reach it.
  */
@@ -93,13 +93,13 @@ class AssetValidationTest {
      * {@code variants}, which holds one entry per name given - each declaring no {@code blocks}.
      */
     private static RegistryAccess registriesWithBrokenVariants(String... brokenPaths) {
-        MappedRegistry<VariantRE> variants = new MappedRegistry<>(
+        MappedRegistry<VariantDefinition> variants = new MappedRegistry<>(
                 CustomRegistries.VARIANTS_REGISTRY_KEY, Lifecycle.stable());
         for (String path : brokenPaths) {
             variants.register(
                     ResourceKey.create(CustomRegistries.VARIANTS_REGISTRY_KEY,
                             Identifier.fromNamespaceAndPath("urbex", path)),
-                    new VariantRE(Optional.empty(), Optional.empty()),
+                    new VariantDefinition(Optional.empty(), Optional.empty()),
                     RegistrationInfo.BUILT_IN);
         }
         return new RegistryAccess.ImmutableRegistryAccess(List.of(

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BelowPartConditionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BelowPartConditionTest.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import com.mojang.datafixers.util.Either;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.lost.regassets.BuildingRE;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.ConditionTest;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
@@ -95,7 +95,7 @@ public class BelowPartConditionTest {
     private static Building buildingWithParts2Condition(Set<String> belowPart, Set<String> inpart) {
         PartRef floor = partRef(FLOOR, null, null);
         PartRef second = partRef("urbex:second_part", belowPart, inpart);
-        return new Building(TestAssetId.ANY, BuiltInRegistries.BLOCK, null, AssetIndex.empty("urbex:palettes"), List.of(new BuildingRE(
+        return new Building(TestAssetId.ANY, BuiltInRegistries.BLOCK, null, AssetIndex.empty("urbex:palettes"), List.of(new BuildingDefinition(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.of('#'), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPartExtendsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/BuildingPartExtendsTest.java
@@ -1,7 +1,7 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.BuildingPartRE;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartMeta;
@@ -42,9 +42,9 @@ class BuildingPartExtendsTest {
 
     @Test
     void aPartThatOnlySwapsItsPaletteKeepsItsAncestorsGeometry() {
-        BuildingPartRE parent = part("radiotower", geometry(2, 2, TOWER)
+        BuildingPartDefinition parent = part("radiotower", geometry(2, 2, TOWER)
                 .refpalette("urbex:radiotower"));
-        BuildingPartRE child = part("radiotower_rusted", inherits("urbex:radiotower")
+        BuildingPartDefinition child = part("radiotower_rusted", inherits("urbex:radiotower")
                 .refpalette("urbexmt:radiotower_rusted"));
 
         BuildingPart resolved = new BuildingPart(TestAssetId.of("radiotower_rusted"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child));
@@ -60,8 +60,8 @@ class BuildingPartExtendsTest {
 
     @Test
     void declaringSlicesReplacesTheInheritedOnesWholesale() {
-        BuildingPartRE parent = part("tower", geometry(2, 2, TOWER));
-        BuildingPartRE child = part("tower_short", inherits("urbex:tower")
+        BuildingPartDefinition parent = part("tower", geometry(2, 2, TOWER));
+        BuildingPartDefinition child = part("tower_short", inherits("urbex:tower")
                 .slices(List.of(List.of("ij", "kl"))));
 
         BuildingPart resolved = new BuildingPart(TestAssetId.of("tower_short"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child));
@@ -74,8 +74,8 @@ class BuildingPartExtendsTest {
 
     @Test
     void anXSizeThatContradictsInheritedSlicesIsALoadError() {
-        BuildingPartRE parent = part("tower", geometry(2, 2, TOWER));
-        BuildingPartRE child = part("tower_wide", inherits("urbex:tower").xsize(3));
+        BuildingPartDefinition parent = part("tower", geometry(2, 2, TOWER));
+        BuildingPartDefinition child = part("tower_wide", inherits("urbex:tower").xsize(3));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
                 () -> new BuildingPart(TestAssetId.of("tower_wide"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
@@ -90,8 +90,8 @@ class BuildingPartExtendsTest {
 
     @Test
     void aZSizeThatContradictsInheritedSlicesIsALoadError() {
-        BuildingPartRE parent = part("tower", geometry(2, 2, TOWER));
-        BuildingPartRE child = part("tower_deep", inherits("urbex:tower").zsize(5));
+        BuildingPartDefinition parent = part("tower", geometry(2, 2, TOWER));
+        BuildingPartDefinition child = part("tower_deep", inherits("urbex:tower").zsize(5));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
                 () -> new BuildingPart(TestAssetId.of("tower_deep"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)));
@@ -102,8 +102,8 @@ class BuildingPartExtendsTest {
 
     @Test
     void aChainThatNeverDeclaresSlicesIsALoadError() {
-        BuildingPartRE parent = part("abstract_tower", new Builder().xsize(2).zsize(2));
-        BuildingPartRE child = part("tower_rusted", inherits("urbex:abstract_tower")
+        BuildingPartDefinition parent = part("abstract_tower", new Builder().xsize(2).zsize(2));
+        BuildingPartDefinition child = part("tower_rusted", inherits("urbex:abstract_tower")
                 .refpalette("urbex:rusted"));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
@@ -117,7 +117,7 @@ class BuildingPartExtendsTest {
 
     @Test
     void aChainThatNeverDeclaresDimensionsIsALoadError() {
-        BuildingPartRE parent = part("sliced_only", new Builder().slices(TOWER));
+        BuildingPartDefinition parent = part("sliced_only", new Builder().slices(TOWER));
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
                 () -> new BuildingPart(TestAssetId.of("sliced_only"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent)));
@@ -127,9 +127,9 @@ class BuildingPartExtendsTest {
 
     @Test
     void metadataFromTheChildReplacesTheParentsUnlessItOptsIntoAppending() {
-        BuildingPartRE parent = part("tower", geometry(2, 2, TOWER).meta(true, meta("support")));
-        BuildingPartRE replacing = part("tower_a", inherits("urbex:tower").meta(true, meta("nowater")));
-        BuildingPartRE appending = part("tower_b", inherits("urbex:tower").meta(false, meta("nowater")));
+        BuildingPartDefinition parent = part("tower", geometry(2, 2, TOWER).meta(true, meta("support")));
+        BuildingPartDefinition replacing = part("tower_a", inherits("urbex:tower").meta(true, meta("nowater")));
+        BuildingPartDefinition appending = part("tower_b", inherits("urbex:tower").meta(false, meta("nowater")));
 
         BuildingPart replaced = new BuildingPart(TestAssetId.of("tower_b"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, replacing));
         assertTrue(replaced.getMetaBoolean("nowater"));
@@ -145,11 +145,11 @@ class BuildingPartExtendsTest {
         // An inline palette is a keyed collection too. Replacing it wholesale would reproduce, one
         // level down, exactly the failure the keyed-collection rule exists to prevent: a child
         // repainting one marker would silently lose the other two.
-        BuildingPartRE parent = part("tower", geometry(2, 2, TOWER)
+        BuildingPartDefinition parent = part("tower", geometry(2, 2, TOWER)
                 .inlinePalette(entry('a', "minecraft:stone"),
                         entry('b', "minecraft:bricks"),
                         entry('c', "minecraft:glass")));
-        BuildingPartRE child = part("tower_rusted", inherits("urbex:tower")
+        BuildingPartDefinition child = part("tower_rusted", inherits("urbex:tower")
                 .inlinePalette(entry('a', "minecraft:deepslate")));
 
         Palette resolved = new BuildingPart(TestAssetId.of("tower_rusted"), BuiltInRegistries.BLOCK, null, PALETTES, List.of(parent, child)).getLocalPalette();
@@ -164,9 +164,9 @@ class BuildingPartExtendsTest {
     @Test
     void namingAPaletteWithRefpaletteDropsAnInheritedInlineOne() {
         // refpalette and an inline block are two ways to say the same thing, not two layers.
-        BuildingPartRE parent = part("tower", geometry(2, 2, TOWER)
+        BuildingPartDefinition parent = part("tower", geometry(2, 2, TOWER)
                 .inlinePalette(entry('a', "minecraft:stone")));
-        BuildingPartRE child = part("tower_ref", inherits("urbex:tower")
+        BuildingPartDefinition child = part("tower_ref", inherits("urbex:tower")
                 .refpalette("urbex:somewhere_else"));
 
         // The refpalette wins, and the inherited inline palette is gone - so the part cannot be
@@ -180,10 +180,10 @@ class BuildingPartExtendsTest {
 
     @Test
     void anExtendsInsideAnInlinePaletteIsRejectedRatherThanIgnored() {
-        // PaletteRE.CODEC accepts "extends" wherever it is embedded, but an inline block is not a
+        // PaletteDefinition.CODEC accepts "extends" wherever it is embedded, but an inline block is not a
         // registry entry, so nothing can resolve it. Silently dropping it is the one option that
         // lets a datapack mean something other than what it says.
-        BuildingPartRE part = part("tower", geometry(2, 2, TOWER)
+        BuildingPartDefinition part = part("tower", geometry(2, 2, TOWER)
                 .inlinePalette(Optional.of(Identifier.parse("urbex:common")),
                         entry('a', "minecraft:stone")));
 
@@ -233,7 +233,7 @@ class BuildingPartExtendsTest {
      * longer carries one (issue #128), so it is not written here - it is passed to
      * {@link BuildingPart}'s constructor at each call site, which is where the compiler passes it.
      */
-    private static BuildingPartRE part(String path, Builder builder) {
+    private static BuildingPartDefinition part(String path, Builder builder) {
         return builder.build();
     }
 
@@ -243,7 +243,7 @@ class BuildingPartExtendsTest {
         private Optional<Integer> zSize = Optional.empty();
         private Optional<List<List<String>>> slices = Optional.empty();
         private Optional<String> refpalette = Optional.empty();
-        private Optional<PaletteRE> inlinePalette = Optional.empty();
+        private Optional<PaletteDefinition> inlinePalette = Optional.empty();
         private Optional<Mergeable<PartMeta>> meta = Optional.empty();
 
         Builder extendsId(String id) {
@@ -276,7 +276,7 @@ class BuildingPartExtendsTest {
         }
 
         Builder inlinePalette(Optional<Identifier> paletteExtends, PaletteEntry... entries) {
-            this.inlinePalette = Optional.of(new PaletteRE(paletteExtends, Optional.of(List.of(entries))));
+            this.inlinePalette = Optional.of(new PaletteDefinition(paletteExtends, Optional.of(List.of(entries))));
             return this;
         }
 
@@ -285,8 +285,8 @@ class BuildingPartExtendsTest {
             return this;
         }
 
-        BuildingPartRE build() {
-            return new BuildingPartRE(extendsId, xSize, zSize, slices, refpalette, inlinePalette, meta);
+        BuildingPartDefinition build() {
+            return new BuildingPartDefinition(extendsId, xSize, zSize, slices, refpalette, inlinePalette, meta);
         }
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyleInheritSelectorsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CityStyleInheritSelectorsTest.java
@@ -1,6 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.ObjectSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.Selectors;
@@ -48,17 +48,17 @@ class CityStyleInheritSelectorsTest {
     }
 
     /** A registry entry declaring only {@code buildings} and {@code multibuildings}; null means undeclared. */
-    private static CityStyleRE re(List<ObjectSelector> buildings, List<ObjectSelector> multiBuildings,
+    private static CityStyleDefinition re(List<ObjectSelector> buildings, List<ObjectSelector> multiBuildings,
                                   List<ObjectSelector> parks) {
         return reSelectors(replacing(buildings), replacing(multiBuildings), replacing(parks));
     }
 
     /** A registry entry declaring only {@code buildings}, exactly as the JSON codec would decode it. */
-    private static CityStyleRE reBuildings(Optional<Mergeable<ObjectSelector>> buildings) {
+    private static CityStyleDefinition reBuildings(Optional<Mergeable<ObjectSelector>> buildings) {
         return reSelectors(buildings, Optional.empty(), Optional.empty());
     }
 
-    private static CityStyleRE reSelectors(Optional<Mergeable<ObjectSelector>> buildings,
+    private static CityStyleDefinition reSelectors(Optional<Mergeable<ObjectSelector>> buildings,
                                             Optional<Mergeable<ObjectSelector>> multiBuildings,
                                             Optional<Mergeable<ObjectSelector>> parks) {
         Selectors selectors = new Selectors(
@@ -74,7 +74,7 @@ class CityStyleInheritSelectorsTest {
         // The street wiring is boilerplate here, not part of what these tests assert: since the
         // code-side defaults were deleted, a city style whose chain declares no 'parts' family is a
         // load error, so every entry these tests build has to carry one.
-        return new CityStyleRE(
+        return new CityStyleDefinition(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.of(TestWiring.streetSettings()),
@@ -87,8 +87,8 @@ class CityStyleInheritSelectorsTest {
 
     @Test
     void declaredListReplacesInheritedOneInsteadOfAppending() {
-        CityStyleRE parent = re(sels("b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8"), null, null);
-        CityStyleRE child = re(sels("b1", "b2", "b3", "b4", "b5"), null, null);
+        CityStyleDefinition parent = re(sels("b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8"), null, null);
+        CityStyleDefinition child = re(sels("b1", "b2", "b3", "b4", "b5"), null, null);
 
         CityStyle merged = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 
@@ -98,8 +98,8 @@ class CityStyleInheritSelectorsTest {
 
     @Test
     void explicitlyEmptyListMeansEmpty() {
-        CityStyleRE parent = re(null, sels("m1", "m2", "m3"), null);
-        CityStyleRE child = re(null, List.of(), null);
+        CityStyleDefinition parent = re(null, sels("m1", "m2", "m3"), null);
+        CityStyleDefinition child = re(null, List.of(), null);
 
         CityStyle merged = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 
@@ -109,8 +109,8 @@ class CityStyleInheritSelectorsTest {
 
     @Test
     void undeclaredListStillInheritsWhole() {
-        CityStyleRE parent = re(null, null, sels("p1", "p2"));
-        CityStyleRE child = re(sels("b1"), null, null);
+        CityStyleDefinition parent = re(null, null, sels("p1", "p2"));
+        CityStyleDefinition child = re(sels("b1"), null, null);
 
         CityStyle merged = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 
@@ -120,8 +120,8 @@ class CityStyleInheritSelectorsTest {
 
     @Test
     void everySelectorKindIsCoveredByTheMerge() {
-        CityStyleRE parent = re(sels("b1"), sels("m1"), sels("p1"));
-        CityStyleRE child = re(null, null, null);
+        CityStyleDefinition parent = re(sels("b1"), sels("m1"), sels("p1"));
+        CityStyleDefinition child = re(null, null, null);
 
         CityStyle parentResolved = new CityStyle(TestAssetId.ANY, List.of(parent));
         CityStyle merged = new CityStyle(TestAssetId.ANY, List.of(parent, child));
@@ -134,8 +134,8 @@ class CityStyleInheritSelectorsTest {
 
     @Test
     void appendModeAddsToTheInheritedEntriesInParentOrder() {
-        CityStyleRE parent = reBuildings(replacing(sels("b1", "b2")));
-        CityStyleRE child = reBuildings(appending(sels("b3")));
+        CityStyleDefinition parent = reBuildings(replacing(sels("b1", "b2")));
+        CityStyleDefinition child = reBuildings(appending(sels("b3")));
 
         CityStyle resolved = new CityStyle(TestAssetId.ANY, List.of(parent, child));
 

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CommonPaletteLightingTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/CommonPaletteLightingTest.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.LightSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import net.minecraft.SharedConstants;
@@ -45,7 +45,7 @@ class CommonPaletteLightingTest {
 
     @Test
     void commonPaletteCompilesExactTypedLightPoolsWithoutRedstoneTorches() throws IOException {
-        PaletteRE common = decodeClasspathPalette(COMMON_PALETTE);
+        PaletteDefinition common = decodeClasspathPalette(COMMON_PALETTE);
         PaletteEntry torchMarker = entry(common, 'T');
         PaletteEntry freeMarker = entry(common, 'h');
         PaletteEntry redstoneTorch = entry(common, 'g');
@@ -98,7 +98,7 @@ class CommonPaletteLightingTest {
         try (Stream<Path> files = Files.walk(BUNDLED_PALETTES)) {
             for (Path path : files.filter(file -> file.toString().endsWith(".json"))
                     .sorted(Comparator.naturalOrder()).toList()) {
-                DataResult<PaletteRE> decoded = PaletteRE.CODEC.parse(JsonOps.INSTANCE,
+                DataResult<PaletteDefinition> decoded = PaletteDefinition.CODEC.parse(JsonOps.INSTANCE,
                         JsonParser.parseString(Files.readString(path)));
                 assertTrue(decoded.result().isPresent(),
                         () -> path + ": " + decoded.error().map(Object::toString).orElse("unknown decode error"));
@@ -106,10 +106,10 @@ class CommonPaletteLightingTest {
         }
     }
 
-    private static PaletteRE decodeClasspathPalette(String resource) throws IOException {
+    private static PaletteDefinition decodeClasspathPalette(String resource) throws IOException {
         try (InputStream stream = CommonPaletteLightingTest.class.getClassLoader().getResourceAsStream(resource)) {
             assertNotNull(stream, () -> "Missing classpath resource " + resource);
-            DataResult<PaletteRE> decoded = PaletteRE.CODEC.parse(JsonOps.INSTANCE,
+            DataResult<PaletteDefinition> decoded = PaletteDefinition.CODEC.parse(JsonOps.INSTANCE,
                     JsonParser.parseReader(new InputStreamReader(stream, StandardCharsets.UTF_8)));
             assertTrue(decoded.result().isPresent(),
                     () -> decoded.error().map(Object::toString).orElse("unknown decode error"));
@@ -117,7 +117,7 @@ class CommonPaletteLightingTest {
         }
     }
 
-    private static PaletteEntry entry(PaletteRE palette, char marker) {
+    private static PaletteEntry entry(PaletteDefinition palette, char marker) {
         return palette.getPaletteEntries().stream()
                 .filter(entry -> entry.getChr().equals(Character.toString(marker)))
                 .findFirst()

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/LightPoolTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/LightPoolTest.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.LightSettings;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -55,7 +55,7 @@ class LightPoolTest {
 
     @Test
     void paletteCompilationRejectsPoolWithoutCandidatesWithResourceAndMarkerContext() {
-        PaletteRE palette = decodePalette("""
+        PaletteDefinition palette = decodePalette("""
                 {"palette":[{"char":"L","light":{
                   "floor":[],"wall":[],"ceiling":[],"free":[]
                 }}]}
@@ -71,7 +71,7 @@ class LightPoolTest {
     @Test
     void paletteCompilationRejectsNonpositiveWeightWithFullCandidateContext() {
         for (int weight : List.of(0, -3)) {
-            PaletteRE palette = decodePalette("""
+            PaletteDefinition palette = decodePalette("""
                     {"palette":[{"char":"L","light":{
                       "floor":[{"weight":%d,"block":"minecraft:torch"}]
                     }}]}
@@ -235,7 +235,7 @@ class LightPoolTest {
 
     @Test
     void completeLegacyTorchEntryStillCompilesWithoutTypedPool() {
-        DataResult<PaletteRE> result = PaletteRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+        DataResult<PaletteDefinition> result = PaletteDefinition.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
                 {"palette":[{
                   "char":"L",
                   "block":"minecraft:wall_torch[facing=north]",
@@ -243,9 +243,9 @@ class LightPoolTest {
                 }]}
                 """));
         assertTrue(result.result().isPresent());
-        PaletteRE paletteRE = result.result().orElseThrow();
+        PaletteDefinition paletteDefinition = result.result().orElseThrow();
 
-        Palette.PE entry = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteRE)).getPalette().get('L');
+        Palette.PE entry = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteDefinition)).getPalette().get('L');
         assertInstanceOf(BlockState.class, entry.blocks());
         assertTrue(entry.info().isTorch());
         assertNull(entry.info().light());
@@ -253,7 +253,7 @@ class LightPoolTest {
 
     @Test
     void typedLightOnlyEntryUsesRepresentativeState() {
-        DataResult<PaletteRE> result = PaletteRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+        DataResult<PaletteDefinition> result = PaletteDefinition.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
                 {"palette":[{
                   "char":"L",
                   "light":{"wall":[
@@ -263,9 +263,9 @@ class LightPoolTest {
                 }]}
                 """));
         assertTrue(result.result().isPresent());
-        PaletteRE paletteRE = result.result().orElseThrow();
+        PaletteDefinition paletteDefinition = result.result().orElseThrow();
 
-        Palette.PE entry = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteRE)).getPalette().get('L');
+        Palette.PE entry = new Palette(PALETTE_ID, BuiltInRegistries.BLOCK, null, List.of(paletteDefinition)).getPalette().get('L');
         BlockState representative = assertInstanceOf(BlockState.class, entry.blocks());
         assertEquals(Blocks.SOUL_WALL_TORCH, representative.getBlock());
         assertTrue(entry.info().isSpecial());
@@ -296,8 +296,8 @@ class LightPoolTest {
         return LightSettings.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(json));
     }
 
-    private static PaletteRE decodePalette(String json) {
-        DataResult<PaletteRE> result = PaletteRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(json));
+    private static PaletteDefinition decodePalette(String json) {
+        DataResult<PaletteDefinition> result = PaletteDefinition.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(json));
         assertTrue(result.result().isPresent(), () -> result.error().map(Object::toString).orElse("unknown decode error"));
         return result.result().orElseThrow();
     }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/MissingBlocksAreSkippedTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/MissingBlocksAreSkippedTest.java
@@ -1,7 +1,7 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
-import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.VariantDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
@@ -152,12 +152,12 @@ class MissingBlocksAreSkippedTest {
         return (Pair<Integer, BlockState>[]) entry.blocks();
     }
 
-    private static VariantRE variantOf(BlockEntry... blocks) {
-        return new VariantRE(Optional.empty(), Optional.of(new Mergeable<>(true, List.of(blocks))));
+    private static VariantDefinition variantOf(BlockEntry... blocks) {
+        return new VariantDefinition(Optional.empty(), Optional.of(new Mergeable<>(true, List.of(blocks))));
     }
 
-    private static PaletteRE paletteOf(PaletteEntry... entries) {
-        return new PaletteRE(Optional.empty(), Optional.of(List.of(entries)));
+    private static PaletteDefinition paletteOf(PaletteEntry... entries) {
+        return new PaletteDefinition(Optional.empty(), Optional.of(List.of(entries)));
     }
 
     private static PaletteEntry single(char marker, String block) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteExtendsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteExtendsTest.java
@@ -1,6 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -34,11 +34,11 @@ class PaletteExtendsTest {
 
     @Test
     void childOverridesOnlyTheCharactersItDeclares() {
-        PaletteRE parent = palette("parent",
+        PaletteDefinition parent = palette("parent",
                 entry('S', "minecraft:stone"),
                 entry('b', "minecraft:bricks"),
                 entry('g', "minecraft:glass"));
-        PaletteRE child = palette("child", entry('S', "minecraft:deepslate"));
+        PaletteDefinition child = palette("child", entry('S', "minecraft:deepslate"));
 
         Palette resolved = new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
@@ -51,8 +51,8 @@ class PaletteExtendsTest {
 
     @Test
     void aCharacterTheChildAddsJoinsTheOnesItInherits() {
-        PaletteRE parent = palette("parent", entry('S', "minecraft:stone"));
-        PaletteRE child = palette("child", entry('w', "minecraft:oak_planks"));
+        PaletteDefinition parent = palette("parent", entry('S', "minecraft:stone"));
+        PaletteDefinition child = palette("child", entry('w', "minecraft:oak_planks"));
 
         Palette resolved = new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
@@ -63,9 +63,9 @@ class PaletteExtendsTest {
 
     @Test
     void theLastEntryInADeepChainWins() {
-        PaletteRE root = palette("root", entry('S', "minecraft:stone"));
-        PaletteRE middle = palette("middle", entry('S', "minecraft:andesite"));
-        PaletteRE leaf = palette("leaf", entry('S', "minecraft:deepslate"));
+        PaletteDefinition root = palette("root", entry('S', "minecraft:stone"));
+        PaletteDefinition middle = palette("middle", entry('S', "minecraft:andesite"));
+        PaletteDefinition leaf = palette("leaf", entry('S', "minecraft:deepslate"));
 
         assertEquals("minecraft:deepslate", blockOf(new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(root, middle, leaf)), 'S'));
         assertEquals("minecraft:andesite", blockOf(new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(root, middle)), 'S'));
@@ -75,8 +75,8 @@ class PaletteExtendsTest {
     void anOverriddenCharacterTakesItsDamagedMappingWithIt() {
         // The parent's 'S' is replaced wholesale, so its damaged-state mapping must go with it
         // rather than linger keyed on a block the resolved palette no longer places.
-        PaletteRE parent = palette("parent", damagedEntry('S', "minecraft:stone", "minecraft:cobblestone"));
-        PaletteRE child = palette("child", entry('S', "minecraft:deepslate"));
+        PaletteDefinition parent = palette("parent", damagedEntry('S', "minecraft:stone", "minecraft:cobblestone"));
+        PaletteDefinition child = palette("child", entry('S', "minecraft:deepslate"));
 
         Palette resolved = new Palette(LEAF_ID, BuiltInRegistries.BLOCK, null, List.of(parent, child));
 
@@ -100,8 +100,8 @@ class PaletteExtendsTest {
         return BuiltInRegistries.BLOCK.getKey(blockState.getBlock()).toString();
     }
 
-    private static PaletteRE palette(String path, PaletteEntry... entries) {
-        return new PaletteRE(Optional.empty(), Optional.of(List.of(entries)));
+    private static PaletteDefinition palette(String path, PaletteEntry... entries) {
+        return new PaletteDefinition(Optional.empty(), Optional.of(List.of(entries)));
     }
 
     private static PaletteEntry entry(char marker, String block) {

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteVariantResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteVariantResolutionTest.java
@@ -1,7 +1,7 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.PaletteRE;
-import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.VariantDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
@@ -99,17 +99,17 @@ class PaletteVariantResolutionTest {
         return BuiltInRegistries.BLOCK.getKey(state.getBlock()).toString();
     }
 
-    private static PaletteRE paletteNamingVariant() {
+    private static PaletteDefinition paletteNamingVariant() {
         PaletteEntry entry = new PaletteEntry("V", Optional.empty(), Optional.of("urbex:rubble"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        return new PaletteRE(Optional.empty(), Optional.of(List.of(entry)));
+        return new PaletteDefinition(Optional.empty(), Optional.of(List.of(entry)));
     }
 
     /** An index whose only {@code urbex:rubble} variant is one weighted block. */
     private static AssetIndex<Variant> variantsWith(String block) {
         Identifier id = Identifier.fromNamespaceAndPath("urbex", "rubble");
-        VariantRE definition = new VariantRE(Optional.empty(),
+        VariantDefinition definition = new VariantDefinition(Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of(new BlockEntry(1, block)))));
         return new AssetIndex<>("urbex:variants", Map.of(id, new Variant(id, BuiltInRegistries.BLOCK, List.of(definition))));
     }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RegistryChainResolutionTest.java
@@ -1,16 +1,16 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.lost.regassets.BuildingRE;
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
-import dev.krona.urbex.worldgen.lost.regassets.ConditionRE;
-import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingRE;
-import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityRE;
-import dev.krona.urbex.worldgen.lost.regassets.ScatteredRE;
-import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsRE;
-import dev.krona.urbex.worldgen.lost.regassets.StyleRE;
-import dev.krona.urbex.worldgen.lost.regassets.VariantRE;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.ConditionDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.ScatteredDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.StyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.VariantDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.BlockEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.ConditionPart;
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * <p>
  * The bundled datapack uses {@code extends} only in {@code citystyles} and {@code presets}, so
  * every other registry only ever resolves a chain of one in the digest runs and in gameplay -
- * {@link StuffSettingsRE#resolve} even short-circuits that case. Without these tests the fold
+ * {@link StuffSettingsDefinition#resolve} even short-circuits that case. Without these tests the fold
  * bodies would never execute anywhere.
  * <p>
  * {@code stuff} is the dangerous one: {@code AssetRegistries.load} files each {@link StuffObject}
@@ -99,16 +99,16 @@ class RegistryChainResolutionTest {
     void stuffInheritsEveryOptionalScalarTheChildOmits() {
         IdentifierMatcher onlyLibraries = new IdentifierMatcher(
                 Optional.of(List.of("urbex:library")), Optional.empty());
-        StuffSettingsRE parent = stuff("torches")
+        StuffSettingsDefinition parent = stuff("torches")
                 .tags(true, "all")
                 .minheight(40).maxheight(90)
                 .inbuilding(true).seesky(false)
                 .buildings(onlyLibraries)
                 .build();
-        StuffSettingsRE child = stuff("torches_rare").column("XX").counts(2, 9, 7)
+        StuffSettingsDefinition child = stuff("torches_rare").column("XX").counts(2, 9, 7)
                 .undeclaredInbuilding().build();
 
-        StuffSettingsRE resolved = new StuffObject(TestAssetId.ANY, List.of(parent, child)).getSettings();
+        StuffSettingsDefinition resolved = new StuffObject(TestAssetId.ANY, List.of(parent, child)).getSettings();
 
         assertNotSame(child, resolved, "a two-entry chain must actually fold, not hand back the leaf");
         assertEquals(40, resolved.getMinheight(), "minheight is inherited");
@@ -125,7 +125,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void stuffRequiredScalarsComeFromTheLeaf() {
-        StuffSettingsRE resolved = new StuffObject(TestAssetId.ANY, List.of(
+        StuffSettingsDefinition resolved = new StuffObject(TestAssetId.ANY, List.of(
                 stuff("torches").column("AB").counts(1, 2, 3).build(),
                 stuff("torches_rare").column("CD").counts(4, 5, 6).build())).getSettings();
 
@@ -137,7 +137,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void stuffResolvedFromAChainOfOneIsTheEntryItself() {
-        StuffSettingsRE only = stuff("torches").tags(true, "all").build();
+        StuffSettingsDefinition only = stuff("torches").tags(true, "all").build();
 
         assertSame(only, new StuffObject(TestAssetId.ANY, List.of(only)).getSettings());
     }
@@ -214,8 +214,8 @@ class RegistryChainResolutionTest {
                 "'all' is added by the constructor and sorts in with the rest");
     }
 
-    private static CityStyleRE cityStyleWithTags(String... tags) {
-        return new CityStyleRE(
+    private static CityStyleDefinition cityStyleWithTags(String... tags) {
+        return new CityStyleDefinition(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(List.of(tags)),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.of(TestWiring.streetSettings()), Optional.empty());
@@ -225,7 +225,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void conditionValuesReplaceByDefaultAndAppendWhenTheChildOptsIn() {
-        ConditionRE parent = condition("loot", true, "urbex:common_loot", "urbex:rare_loot");
+        ConditionDefinition parent = condition("loot", true, "urbex:common_loot", "urbex:rare_loot");
 
         assertEquals(Set.of("urbex:barrel_loot"),
                 valuesOf(new Condition(TestAssetId.ANY, List.of(parent, condition("loot_barrel", true, "urbex:barrel_loot")))),
@@ -239,7 +239,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void variantBlocksReplaceByDefaultAndAppendWhenTheChildOptsIn() {
-        VariantRE parent = variant("stones", true,
+        VariantDefinition parent = variant("stones", true,
                 new BlockEntry(1, "minecraft:stone"), new BlockEntry(2, "minecraft:andesite"));
 
         Variant replaced = new Variant(TestAssetId.ANY, BuiltInRegistries.BLOCK, List.of(parent,
@@ -267,7 +267,7 @@ class RegistryChainResolutionTest {
 
     @Test
     void stylePalettesReplaceByDefaultAndAppendWhenTheChildOptsIn() {
-        StyleRE parent = style("nordic", group("urbex:common"));
+        StyleDefinition parent = style("nordic", group("urbex:common"));
 
         assertEquals(List.of(List.of("urbex:snowy")),
                 paletteNamesOf(new Style(TestAssetId.ANY, PALETTES, List.of(parent, style("nordic_snow", group("urbex:snowy"))))),
@@ -281,13 +281,13 @@ class RegistryChainResolutionTest {
 
     @Test
     void scatteredChildInheritsTheTerrainHandlingItDoesNotDeclare() {
-        ScatteredRE parent = new ScatteredRE(Optional.empty(),
+        ScatteredDefinition parent = new ScatteredDefinition(Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of("urbex:oilrig"))), Optional.empty(),
                 Optional.empty(),
                 Optional.of(ScatteredBuilding.TerrainHeight.OCEAN),
                 Optional.of(ScatteredBuilding.TerrainFix.CLEAR),
                 Optional.of(3));
-        ScatteredRE child = new ScatteredRE(Optional.empty(),
+        ScatteredDefinition child = new ScatteredDefinition(Optional.empty(),
                 Optional.of(new Mergeable<>(true, List.of("urbex:oilrig_burnt"))), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
 
@@ -304,13 +304,13 @@ class RegistryChainResolutionTest {
 
     @Test
     void predefinedCityChildInheritsEverythingButThePositionItMoves() {
-        PredefinedCityRE parent = new PredefinedCityRE(Optional.empty(),
+        PredefinedCityDefinition parent = new PredefinedCityDefinition(Optional.empty(),
                 Optional.of("minecraft:overworld"), Optional.of(10), Optional.of(20), Optional.of(7),
                 Optional.of("urbex:citystyle_common"),
                 Optional.of(new Mergeable<>(true,
                         List.of(new PredefinedBuilding("urbex:townhall", 0, 0, false, false)))),
                 Optional.empty());
-        PredefinedCityRE child = new PredefinedCityRE(Optional.empty(),
+        PredefinedCityDefinition child = new PredefinedCityDefinition(Optional.empty(),
                 Optional.empty(), Optional.of(100), Optional.of(200), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty());
 
@@ -331,13 +331,13 @@ class RegistryChainResolutionTest {
     @Test
     void worldStyleChildInheritsTheSelectorsAndSettingsItDoesNotDeclare() {
         ScatteredSettings scattered = new ScatteredSettings(24, 0.25f, 4, List.of());
-        WorldStyleRE parent = new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:standard"),
+        WorldStyleDefinition parent = new WorldStyleDefinition(Optional.empty(), Optional.empty(), Optional.of("urbex:standard"),
                 Optional.empty(), Optional.empty(), Optional.of(scattered),
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
                         List.of(new CityStyleSelector(1.0f, "urbex:citystyle_common", null)))),
                 Optional.empty(), Optional.empty());
-        WorldStyleRE child = new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:bleak"),
+        WorldStyleDefinition child = new WorldStyleDefinition(Optional.empty(), Optional.empty(), Optional.of("urbex:bleak"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty());
 
@@ -353,10 +353,10 @@ class RegistryChainResolutionTest {
 
     @Test
     void multiBuildingChildInheritsTheGridItDoesNotDeclare() {
-        MultiBuildingRE parent = new MultiBuildingRE(Optional.empty(),
+        MultiBuildingDefinition parent = new MultiBuildingDefinition(Optional.empty(),
                 Optional.of(1), Optional.of(2),
                 Optional.of(List.of(List.of("urbex:oilrig00", "urbex:oilrig01"))));
-        MultiBuildingRE child = new MultiBuildingRE(Optional.empty(),
+        MultiBuildingDefinition child = new MultiBuildingDefinition(Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty());
 
         MultiBuilding resolved = new MultiBuilding(TestAssetId.ANY, List.of(parent, child));
@@ -427,15 +427,15 @@ class RegistryChainResolutionTest {
     }
 
     @SafeVarargs
-    private static StyleRE style(String path, List<PaletteSelector>... groups) {
-        return new StyleRE(Optional.empty(), groups.length == 0
+    private static StyleDefinition style(String path, List<PaletteSelector>... groups) {
+        return new StyleDefinition(Optional.empty(), groups.length == 0
                 ? Optional.empty()
                 : Optional.of(new Mergeable<>(true, List.of(groups))));
     }
 
     @SafeVarargs
-    private static StyleRE styleAppending(String path, List<PaletteSelector>... groups) {
-        return new StyleRE(Optional.empty(), Optional.of(new Mergeable<>(false, List.of(groups))));
+    private static StyleDefinition styleAppending(String path, List<PaletteSelector>... groups) {
+        return new StyleDefinition(Optional.empty(), Optional.of(new Mergeable<>(false, List.of(groups))));
     }
 
     private static BuildingBuilder building(String path) {
@@ -488,8 +488,8 @@ class RegistryChainResolutionTest {
                     Optional.empty());
         }
 
-        BuildingRE build() {
-            return new BuildingRE(Optional.empty(), Optional.empty(), Optional.empty(),
+        BuildingDefinition build() {
+            return new BuildingDefinition(Optional.empty(), Optional.empty(), Optional.empty(),
                     filler, rubble,
                     Optional.empty(), minFloors, Optional.empty(), Optional.empty(),
                     Optional.empty(), Optional.empty(), Optional.empty(),
@@ -535,18 +535,18 @@ class RegistryChainResolutionTest {
         };
     }
 
-    private static ConditionRE condition(String path, boolean replace, String... values) {
+    private static ConditionDefinition condition(String path, boolean replace, String... values) {
         List<ConditionPart> parts = List.of(values).stream()
                 .map(value -> new ConditionPart(1.0f, value,
                         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
                 .toList();
-        return new ConditionRE(Optional.empty(), Optional.of(new Mergeable<>(replace, parts)));
+        return new ConditionDefinition(Optional.empty(), Optional.of(new Mergeable<>(replace, parts)));
     }
 
-    private static VariantRE variant(String path, boolean replace, BlockEntry... blocks) {
-        return new VariantRE(Optional.empty(), Optional.of(new Mergeable<>(replace, List.of(blocks))));
+    private static VariantDefinition variant(String path, boolean replace, BlockEntry... blocks) {
+        return new VariantDefinition(Optional.empty(), Optional.of(new Mergeable<>(replace, List.of(blocks))));
     }
 
     private static StuffBuilder stuff(String path) {
@@ -627,8 +627,8 @@ class RegistryChainResolutionTest {
             return this;
         }
 
-        StuffSettingsRE build() {
-            return new StuffSettingsRE(Optional.empty(), tags, column, minheight, maxheight,
+        StuffSettingsDefinition build() {
+            return new StuffSettingsDefinition(Optional.empty(), tags, column, minheight, maxheight,
                     mincount, maxcount, attempts, inbuilding, seesky,
                     Optional.empty(), Optional.empty(), Optional.empty(), buildings);
         }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/RequiredAfterResolutionTest.java
@@ -1,9 +1,9 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingRE;
-import dev.krona.urbex.worldgen.lost.regassets.ScatteredRE;
-import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsRE;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.ScatteredDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.StuffSettingsDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.ScatteredSettings;
@@ -54,8 +54,8 @@ class RequiredAfterResolutionTest {
 
     @Test
     void stuffChildInheritsRequiredScalarsItDoesNotDeclare() {
-        StuffSettingsRE parent = stuff().column("y").counts(2, 5, 10).inbuilding(true).tags("rubble").build();
-        StuffSettingsRE child = stuff().tags("debris").build();
+        StuffSettingsDefinition parent = stuff().column("y").counts(2, 5, 10).inbuilding(true).tags("rubble").build();
+        StuffSettingsDefinition child = stuff().tags("debris").build();
 
         StuffObject resolved = new StuffObject(TestAssetId.of("test_stuff"), List.of(parent, child));
 
@@ -93,11 +93,11 @@ class RequiredAfterResolutionTest {
 
     @Test
     void stuffChildThatDeclaresOnlySomeOfTheChainStillLoadsWhenAnAncestorCoversTheRest() {
-        StuffSettingsRE root = stuff().column("y").counts(2, 5, 10).inbuilding(false).build();
-        StuffSettingsRE middle = stuff().counts(3, 6, 11).build();
-        StuffSettingsRE leaf = stuff().tags("debris").build();
+        StuffSettingsDefinition root = stuff().column("y").counts(2, 5, 10).inbuilding(false).build();
+        StuffSettingsDefinition middle = stuff().counts(3, 6, 11).build();
+        StuffSettingsDefinition leaf = stuff().tags("debris").build();
 
-        StuffSettingsRE resolved = new StuffObject(TestAssetId.of("test_stuff"), List.of(root, middle, leaf)).getSettings();
+        StuffSettingsDefinition resolved = new StuffObject(TestAssetId.of("test_stuff"), List.of(root, middle, leaf)).getSettings();
 
         assertEquals("y", resolved.getColumn(), "from the root, two links up");
         assertEquals(3, resolved.getMincount(), "the nearest ancestor that declares one wins");
@@ -107,9 +107,9 @@ class RequiredAfterResolutionTest {
 
     @Test
     void multiBuildingChildInheritsTheGridSizeItDoesNotDeclare() {
-        MultiBuildingRE parent = multiBuilding(Optional.of(2), Optional.of(2),
+        MultiBuildingDefinition parent = multiBuilding(Optional.of(2), Optional.of(2),
                 Optional.of(List.of(List.of("urbex:a", "urbex:b"), List.of("urbex:c", "urbex:d"))));
-        MultiBuildingRE child = multiBuilding(Optional.empty(), Optional.empty(),
+        MultiBuildingDefinition child = multiBuilding(Optional.empty(), Optional.empty(),
                 Optional.of(List.of(List.of("urbex:w", "urbex:x"), List.of("urbex:y", "urbex:z"))));
 
         MultiBuilding resolved = new MultiBuilding(TestAssetId.of("test_multi"), List.of(parent, child));
@@ -122,9 +122,9 @@ class RequiredAfterResolutionTest {
 
     @Test
     void multiBuildingGridIsInheritedWhenTheChildDeclaresOnlyItsSize() {
-        MultiBuildingRE parent = multiBuilding(Optional.of(1), Optional.of(1),
+        MultiBuildingDefinition parent = multiBuilding(Optional.of(1), Optional.of(1),
                 Optional.of(List.of(List.of("urbex:tower"))));
-        MultiBuildingRE child = multiBuilding(Optional.of(1), Optional.of(1), Optional.empty());
+        MultiBuildingDefinition child = multiBuilding(Optional.of(1), Optional.of(1), Optional.empty());
 
         assertEquals("urbex:tower", new MultiBuilding(TestAssetId.of("test_multi"), List.of(parent, child)).getBuilding(0, 0));
     }
@@ -148,9 +148,9 @@ class RequiredAfterResolutionTest {
      */
     @Test
     void multiBuildingGridSmallerThanTheDeclaredSizeIsALoadError() {
-        MultiBuildingRE parent = multiBuilding(Optional.of(1), Optional.of(1),
+        MultiBuildingDefinition parent = multiBuilding(Optional.of(1), Optional.of(1),
                 Optional.of(List.of(List.of("urbex:tower"))));
-        MultiBuildingRE child = multiBuilding(Optional.of(2), Optional.of(2), Optional.empty());
+        MultiBuildingDefinition child = multiBuilding(Optional.of(2), Optional.of(2), Optional.empty());
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
                 () -> new MultiBuilding(TestAssetId.of("test_multi"), List.of(parent, child)));
@@ -162,7 +162,7 @@ class RequiredAfterResolutionTest {
 
     @Test
     void multiBuildingRowShorterThanTheDeclaredDepthIsALoadError() {
-        MultiBuildingRE entry = multiBuilding(Optional.of(2), Optional.of(2),
+        MultiBuildingDefinition entry = multiBuilding(Optional.of(2), Optional.of(2),
                 Optional.of(List.of(List.of("urbex:a", "urbex:b"), List.of("urbex:c"))));
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
@@ -203,9 +203,9 @@ class RequiredAfterResolutionTest {
 
     @Test
     void scatteredChildInheritsTheBuildingListItDoesNotDeclare() {
-        ScatteredRE parent = scattered(Optional.of(new Mergeable<>(true, List.of("urbex:cabin"))),
+        ScatteredDefinition parent = scattered(Optional.of(new Mergeable<>(true, List.of("urbex:cabin"))),
                 Optional.empty());
-        ScatteredRE child = scattered(Optional.empty(), Optional.empty());
+        ScatteredDefinition child = scattered(Optional.empty(), Optional.empty());
 
         ScatteredBuilding resolved = new ScatteredBuilding(TestAssetId.of("test_scattered"), List.of(parent, child));
 
@@ -227,11 +227,11 @@ class RequiredAfterResolutionTest {
     @Test
     void worldStyleChildInheritsOutsideStyleAndCityStylesItDoesNotDeclare() {
         ScatteredSettings scattered = new ScatteredSettings(16, 0.5f, 10, List.of());
-        WorldStyleRE parent = worldStyle(Optional.of("urbex:standard"),
+        WorldStyleDefinition parent = worldStyle(Optional.of("urbex:standard"),
                 Optional.of(new Mergeable<>(true,
                         List.of(new CityStyleSelector(1.0f, "urbex:downtown", null)))),
                 Optional.empty());
-        WorldStyleRE child = worldStyle(Optional.empty(), Optional.empty(), Optional.of(scattered));
+        WorldStyleDefinition child = worldStyle(Optional.empty(), Optional.empty(), Optional.of(scattered));
 
         WorldStyle resolved = new WorldStyle(TestAssetId.of("test_world"), List.of(parent, child));
 
@@ -277,16 +277,16 @@ class RequiredAfterResolutionTest {
         return style.cityStyleSelectors().stream().map(pair -> pair.getRight().getRight()).toList();
     }
 
-    private static ScatteredRE scattered(Optional<Mergeable<String>> buildings,
+    private static ScatteredDefinition scattered(Optional<Mergeable<String>> buildings,
                                          Optional<String> multibuilding) {
-        return new ScatteredRE(Optional.empty(), buildings, multibuilding, Optional.empty(),
+        return new ScatteredDefinition(Optional.empty(), buildings, multibuilding, Optional.empty(),
                 Optional.of(ScatteredBuilding.TerrainHeight.AVERAGE),
                 Optional.of(ScatteredBuilding.TerrainFix.NONE), Optional.empty());
     }
 
-    private static MultiBuildingRE multiBuilding(Optional<Integer> dimX, Optional<Integer> dimZ,
+    private static MultiBuildingDefinition multiBuilding(Optional<Integer> dimX, Optional<Integer> dimZ,
                                                  Optional<List<List<String>>> buildings) {
-        return new MultiBuildingRE(Optional.empty(), dimX, dimZ, buildings);
+        return new MultiBuildingDefinition(Optional.empty(), dimX, dimZ, buildings);
     }
 
     /**
@@ -295,10 +295,10 @@ class RequiredAfterResolutionTest {
      * since the code-side defaults were deleted, and has its own coverage in
      * {@link WiringRequiredTest}.
      */
-    private static WorldStyleRE worldStyle(Optional<String> outsideStyle,
+    private static WorldStyleDefinition worldStyle(Optional<String> outsideStyle,
                                            Optional<Mergeable<CityStyleSelector>> cityStyles,
                                            Optional<ScatteredSettings> scattered) {
-        return new WorldStyleRE(Optional.empty(), Optional.empty(), outsideStyle,
+        return new WorldStyleDefinition(Optional.empty(), Optional.empty(), outsideStyle,
                 Optional.empty(), Optional.empty(), scattered,
                 Optional.of(TestWiring.partSelector()),
                 cityStyles, Optional.empty(), Optional.empty());
@@ -339,8 +339,8 @@ class RequiredAfterResolutionTest {
             return this;
         }
 
-        StuffSettingsRE build() {
-            return new StuffSettingsRE(Optional.empty(), tags, column,
+        StuffSettingsDefinition build() {
+            return new StuffSettingsDefinition(Optional.empty(), tags, column,
                     Optional.empty(), Optional.empty(), mincount, maxcount, attempts,
                     inbuilding, Optional.empty(),
                     Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/StyleDisplayNameTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/StyleDisplayNameTest.java
@@ -1,7 +1,7 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
@@ -40,8 +40,8 @@ class StyleDisplayNameTest {
         return Identifier.fromNamespaceAndPath(namespace, path);
     }
 
-    private static WorldStyleRE worldStyle(Optional<String> name) {
-        return new WorldStyleRE(Optional.empty(), name, Optional.of("urbex:outside"),
+    private static WorldStyleDefinition worldStyle(Optional<String> name) {
+        return new WorldStyleDefinition(Optional.empty(), name, Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
@@ -49,8 +49,8 @@ class StyleDisplayNameTest {
                 Optional.empty(), Optional.empty());
     }
 
-    private static CityStyleRE cityStyle(Optional<String> name) {
-        return new CityStyleRE(
+    private static CityStyleDefinition cityStyle(Optional<String> name) {
+        return new CityStyleDefinition(
                 Optional.empty(), Optional.empty(), Optional.empty(), name,
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.of(TestWiring.streetSettings()),
@@ -113,7 +113,7 @@ class StyleDisplayNameTest {
     @Test
     void theStaticFoldTheGuiUsesMatchesWhatTheConstructorResolves() {
         Identifier leaf = id("urbexmt", "moderntweaks");
-        List<WorldStyleRE> chain = List.of(
+        List<WorldStyleDefinition> chain = List.of(
                 worldStyle(Optional.of("Standard")),
                 worldStyle(Optional.of("Modern Tweaks")));
 

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WiringRequiredTest.java
@@ -3,8 +3,8 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.CityStyleRE;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
@@ -117,8 +117,8 @@ class WiringRequiredTest {
 
     @Test
     void aChildAppendsToAHighwayGroupItInherits() {
-        WorldStyleRE parent = worldStyle("parent", TestWiring.partSelector());
-        WorldStyleRE child = worldStyle("child", new PartSelector.Decl(
+        WorldStyleDefinition parent = worldStyle("parent", TestWiring.partSelector());
+        WorldStyleDefinition child = worldStyle("child", new PartSelector.Decl(
                 Optional.of(new HighwayParts.Decl(
                         Optional.of(new Mergeable<>(false, List.of("urbex:highway_tunnel_alt"))),
                         Optional.empty(), Optional.empty(),
@@ -177,7 +177,7 @@ class WiringRequiredTest {
                 Optional.empty());
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new CityStyle(TestAssetId.of("citystyle_halflarge"), List.of(cityStyleRE("halflarge", settings))));
+                () -> new CityStyle(TestAssetId.of("citystyle_halflarge"), List.of(cityStyleDefinition("halflarge", settings))));
 
         assertTrue(e.getMessage().contains("streetblocks.largeparts.end"), e.getMessage());
     }
@@ -246,19 +246,19 @@ class WiringRequiredTest {
         };
     }
 
-    private static CityStyleRE cityStyle(String name, StreetParts.Decl parts) {
-        return cityStyleRE(name, parts == null ? null : TestWiring.streetSettings(parts));
+    private static CityStyleDefinition cityStyle(String name, StreetParts.Decl parts) {
+        return cityStyleDefinition(name, parts == null ? null : TestWiring.streetSettings(parts));
     }
 
-    private static CityStyleRE cityStyleRE(String name, StreetSettings settings) {
-        return new CityStyleRE(
+    private static CityStyleDefinition cityStyleDefinition(String name, StreetSettings settings) {
+        return new CityStyleDefinition(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.ofNullable(settings), Optional.empty());
     }
 
-    private static WorldStyleRE worldStyle(String name, PartSelector.Decl parts) {
-        return new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
+    private static WorldStyleDefinition worldStyle(String name, PartSelector.Decl parts) {
+        return new WorldStyleDefinition(Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.ofNullable(parts),
                 Optional.of(new Mergeable<>(true, List.of())), Optional.empty(), Optional.empty());
     }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyleRotatableTagTest.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleRE;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.CityStyleSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
@@ -41,8 +41,8 @@ class WorldStyleRotatableTagTest {
         return TagKey.create(Registries.BLOCK, Identifier.fromNamespaceAndPath(namespace, path));
     }
 
-    private static WorldStyleRE worldStyle(String name, Optional<TagKey<Block>> rotatable) {
-        return new WorldStyleRE(Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
+    private static WorldStyleDefinition worldStyle(String name, Optional<TagKey<Block>> rotatable) {
+        return new WorldStyleDefinition(Optional.empty(), Optional.empty(), Optional.of("urbex:outside"),
                 Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.of(TestWiring.partSelector()),
                 Optional.of(new Mergeable<>(true,
@@ -79,7 +79,7 @@ class WorldStyleRotatableTagTest {
 
     @Test
     void aReferenceWithoutTheHashIsALoadError() {
-        var result = WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+        var result = WorldStyleDefinition.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
                 {"outsidestyle": "urbex:outside", "rotatable": "urbexza:rotatable"}
                 """));
 
@@ -91,7 +91,7 @@ class WorldStyleRotatableTagTest {
 
     @Test
     void anUnqualifiedReferenceIsALoadErrorRatherThanAMinecraftDefault() {
-        var result = WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+        var result = WorldStyleDefinition.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
                 {"outsidestyle": "urbex:outside", "rotatable": "#rotatable"}
                 """));
 
@@ -103,7 +103,7 @@ class WorldStyleRotatableTagTest {
 
     @Test
     void aDeclaredTagRoundTripsThroughTheCodec() {
-        var decoded = WorldStyleRE.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+        var decoded = WorldStyleDefinition.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
                 {"outsidestyle": "urbex:outside", "rotatable": "#urbexza:rotatable"}
                 """)).getOrThrow();
 

--- a/src/test/java/dev/krona/urbex/worldgen/lost/regassets/data/RetiredKeysRejectedTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/regassets/data/RetiredKeysRejectedTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>
  * The coverage claim is the point of this test, so it is made by enumeration rather than by a list
  * someone has to remember to extend: {@link #everyRegisteredCodecRejectsBothRetiredKeys} reflects
- * the {@code CODEC} field off every {@code *RE} class in the registry package and requires each to
+ * the {@code CODEC} field off every {@code *Definition} class in the registry package and requires each to
  * reject, and {@link #everyDynamicRegistryIsCovered} cross-checks that set against the registry keys
  * {@code CustomRegistries} actually registers, so a fourteenth registry cannot be added uncovered.
  */
@@ -52,12 +52,12 @@ class RetiredKeysRejectedTest {
     private static final Path RE_PACKAGE =
             Path.of("src/main/java/dev/krona/urbex/worldgen/lost/regassets");
 
-    /** Every {@code *RE} class in the registry package, by simple name, with its CODEC. */
+    /** Every {@code *Definition} class in the registry package, by simple name, with its CODEC. */
     private static Map<String, Codec<?>> registryCodecs() throws Exception {
         Map<String, Codec<?>> codecs = new LinkedHashMap<>();
         List<Path> sources;
         try (Stream<Path> files = Files.list(RE_PACKAGE)) {
-            sources = files.filter(p -> p.getFileName().toString().endsWith("RE.java")).sorted().toList();
+            sources = files.filter(p -> p.getFileName().toString().endsWith("Definition.java")).sorted().toList();
         }
         for (Path source : sources) {
             String simple = source.getFileName().toString().replace(".java", "");
@@ -104,7 +104,7 @@ class RetiredKeysRejectedTest {
     /**
      * The reflective sweep above is only a coverage proof if the classes it finds are the classes
      * that get registered. This pins that: {@code CustomRegistries.init()} registers one codec per
-     * registry key, and there are as many registry keys as there are {@code *RE} classes.
+     * registry key, and there are as many registry keys as there are {@code *Definition} classes.
      */
     @Test
     void everyDynamicRegistryIsCovered() throws Exception {
@@ -112,13 +112,13 @@ class RetiredKeysRejectedTest {
                 .filter(f -> Modifier.isStatic(f.getModifiers()) && f.getName().endsWith("_REGISTRY_KEY"))
                 .count();
         assertEquals(registryCodecs().size(), registryKeys,
-                "every dynamic registry key should have exactly one *RE class whose CODEC this test sweeps");
+                "every dynamic registry key should have exactly one *Definition class whose CODEC this test sweeps");
     }
 
     /** A valid file is untouched: the wrapper is a pre-check, not a new required field. */
     @Test
     void aFileWithNeitherKeyStillDecodes() {
-        DataResult<?> result = dev.krona.urbex.worldgen.lost.regassets.PresetRE.CODEC.parse(
+        DataResult<?> result = dev.krona.urbex.worldgen.lost.regassets.PresetDefinition.CODEC.parse(
                 JsonOps.INSTANCE, JsonParser.parseString("{\"extends\":\"urbex:default\"}"));
         assertTrue(result.result().isPresent(), () -> "expected a clean decode, got " + result);
     }
@@ -126,10 +126,10 @@ class RetiredKeysRejectedTest {
     /** Encoding is delegated untouched - the command and GUI export paths depend on it. */
     @Test
     void encodeIsUnaffected() {
-        var re = dev.krona.urbex.worldgen.lost.regassets.PresetRE.CODEC.parse(
+        var re = dev.krona.urbex.worldgen.lost.regassets.PresetDefinition.CODEC.parse(
                 JsonOps.INSTANCE, JsonParser.parseString("{\"extends\":\"urbex:default\"}")).getOrThrow();
         DataResult<JsonElement> encoded =
-                dev.krona.urbex.worldgen.lost.regassets.PresetRE.CODEC.encodeStart(JsonOps.INSTANCE, re);
+                dev.krona.urbex.worldgen.lost.regassets.PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, re);
         assertTrue(encoded.result().isPresent(), () -> "expected a clean encode, got " + encoded);
         assertEquals("urbex:default", encoded.getOrThrow().getAsJsonObject().get("extends").getAsString());
     }
@@ -138,10 +138,10 @@ class RetiredKeysRejectedTest {
     @Test
     void bothKeysAtOnceIsDeterministic() {
         String json = "{\"inherit\":\"urbex:a\",\"parent\":\"urbex:b\"}";
-        String first = dev.krona.urbex.worldgen.lost.regassets.CityStyleRE.CODEC
+        String first = dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition.CODEC
                 .parse(JsonOps.INSTANCE, JsonParser.parseString(json)).error().orElseThrow().message();
         for (int i = 0; i < 20; i++) {
-            assertEquals(first, dev.krona.urbex.worldgen.lost.regassets.CityStyleRE.CODEC
+            assertEquals(first, dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition.CODEC
                     .parse(JsonOps.INSTANCE, JsonParser.parseString(json)).error().orElseThrow().message());
         }
         assertTrue(first.contains("'inherit'"), first);


### PR DESCRIPTION
**128d**, second half — the rename. This completes #128. Phase 2 step 4 of epic #134.

> Stacked on #147 → #146 → #145 → #144. This diff is against #147.

## What changed

`*RE` → `*Definition`, on thirteen classes and every reference to them. Plus the two method names
that carried the suffix: `Preset.toRE()` → `toDefinition()`, and one test helper.
`RetiredKeysRejectedTest` finds its subjects by filename, so its suffix moves too.

**Mechanical only.** No behaviour, no logic, nothing else in the same change — which is the whole
reason `setRegistryName` went in #147 rather than here. Every hunk in this diff is a name.

## Why no `*Patch`

The issue proposed `*Definition`/`*Patch`. Everything became `*Definition`, and that is a decision
rather than an oversight.

`*Patch` would name a type that is *only* an overlay onto something already resolved. There isn't
one. Each of the thirteen is a registry entry that may **also** be a link in an `extends` chain —
being a partial override is a role a definition plays, not a separate type, and the folding is
`Mergeable`'s and the chain resolver's job.

`PresetDefinition` is the closest thing to a genuine patch: it doubles as the customization-overrides
payload `Presets.applyOverrides` takes. But splitting one type's two roles is a semantic change, and
this PR is a rename.

## What was deliberately left alone

- **`docs/superpowers/plans/*.md`** keep the old names. They record what was written at the time;
  renaming them would falsify the record. The design *spec* for this issue is updated, because it is
  the live contract for what remains.
- **The `regassets` package name.** Not part of the issue, and moving a package is its own diff.

## Verification

```
./gradlew test               # pass, 551 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK
```

**Both digest goldens are unchanged**, as they must be for a rename.
