### PR TITLE
feat: resolve every reachable asset reference at load (#56, 56a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **A datapack reference that names nothing is now a message about a file, not a crashed chunk.**
+  Every cross-asset reference a world can reach — a city style's building and part selectors, a world
+  style's highway and railway wiring, a building's `parts`, a multibuilding's grid, a scattered
+  entry's list, a predefined city's buildings — is resolved when the world loads and reported with
+  everything else that is wrong (issue #56).
+  - *These references are names, not objects.* Generation resolved them one at a time, on whichever
+    chunk first needed one — about forty `getOrThrow` sites across the generator, highways, railways
+    and scattered placement. A building naming a part no datapack registers surfaced as an exception
+    from a worldgen worker, on a chunk somewhere out in the world, long after the world opened.
+  - *Scoped to what a world can select*, following the rule city styles already used: a part only an
+    unreachable city style names is not a broken pack, and refusing a world over a file nothing uses
+    is worse than not checking.
+  - *One bad name does not hide the rest.* An unqualified reference is a line in the report, not the
+    exception that ends the walk.
+  - *`/urbex validate` gets it for free*, since it runs the same compile.
+  - *No worldgen change*: both digest goldens are unchanged.
+
 - **The authored asset types are named `*Definition`, not `*RE`.** Thirteen classes and every
   reference to them; a `PaletteRE` is a `PaletteDefinition`, `Preset.toRE()` is
   `Preset.toDefinition()`. Mechanical only — no behaviour, no logic, nothing else in the same change

--- a/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
+++ b/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
@@ -1,0 +1,131 @@
+# Reachable-graph validation (issue #56, second half)
+
+Phase 2, step 5 of epic #134. The first half landed in #140 (aggregated diagnostics, `/urbex
+validate`, null-guarded `ErrorLogger`); this is the per-reference / per-character walk it deferred.
+
+## Why it waited, and what actually unblocked it
+
+The sequencing note on #56 blocked this on "#128 moves that merge to compile time, into the immutable
+`AssetSnapshot`". Read literally that did not happen, and it cannot: `CityGenerator.computePalette`
+builds a `CompiledPalette` per chunk from the style/building palette plus the part's own, and *which*
+style a part is used under is a property of the chunk, not of the part.
+
+What the note was actually protecting against is gone. It feared a validator would have to **guess**
+at the merge. It does not: every input is now fixed snapshot data — `Style.getRandomPalette` draws
+from resolved `Palette` objects, `getLocalPalette()` is a field read, `frompalette` is a
+character-to-character reference resolved inside `CompiledPalette`. A validator can therefore build
+the *exact* palette generation will build, by calling the same constructor. The only registries
+generation still reads are non-asset vanilla ones: structures, `BLOCK_ENTITY_TYPE`, biomes.
+
+## What is already checked, so this does not re-litigate it
+
+- **Per-part slice geometry.** `BuildingPart.checkGeometry` refuses a part whose slice strings do not
+  total `xsize * zsize`, at compile time, naming the part.
+- **Typed references resolved during compilation**: a style's `randompalettes`
+  (`Style` → `palettes.getOrThrow`), a part's `refpalette`, a predefined city's `citystyle`, and
+  every `extends` chain. These already fail the world naming the file.
+- **Requiredness after chain resolution** (`Resolved.require`), retired keys, one-character palette
+  markers, undrawable `randompalettes` groups.
+
+## What is missing
+
+Everything reached by a **name held as a String in the compiled model** and looked up during
+generation. There are ~40 such lookups (`assets().parts().getOrThrow(...)` and friends in
+`CityGenerator`, `Highways`, `Railways`, `Scattered`). Each is a datapack error that surfaces from a
+worldgen worker on whichever chunk first needs it.
+
+Three checks, in the order they are worth having:
+
+### 1. Dangling references reachable from what a world can select
+
+A walk from the roots a world can actually select, following every String-held reference:
+
+```
+worldStyle ─┬─ outsidestyle ──────────────► style
+            ├─ citystyles[].citystyle ────► cityStyle
+            ├─ scattered.list[].name ─────► scatteredBuilding
+            └─ parts.{highways,railways}.* ► part
+
+cityStyle ──┬─ style ────────────────────► style
+            ├─ selectors.{buildings,multibuildings} ► building / multiBuilding
+            ├─ selectors.{bridges,largebridges,parks,fountains,stairs,fronts,raildungeons} ► part
+            └─ streetblocks.{parts,largeparts,tertiaryparts}.* ► part
+
+building ───┬─ parts[]/parts2[].part ────► part
+            └─ {inpart,belowpart,inbuilding} ► part / building
+multiBuilding ─ buildings[][] ───────────► building
+scatteredBuilding ─┬─ buildings[] ───────► building
+                   └─ multibuilding ─────► multiBuilding
+condition ── values[].{inpart,belowpart,inbuilding} ► part / building
+predefinedCity ─ buildings[].building ───► building
+```
+
+**Roots** are the world styles and the predefined cities, plus the preset's
+`cityStyleAlternative`. That mirrors `AssetCompiler`'s existing reachability rule for city styles: a
+city style that nothing can select is allowed to be incomplete, so a *part* only reachable through
+one must not be a load error either.
+
+**Fatal, not a warning.** These already throw from a worker today; moving them to load time makes
+them earlier, not stricter. The exception is anything currently reached with `getOrWarn` (the
+optional street/highway components), which stays a warning so a pack that deliberately omits one
+keeps working.
+
+### 2. Undefined palette characters
+
+Two populations:
+
+- **A part's slice characters.** Every distinct character in `getVslices()`.
+- **A city style's character fields**: `streetBlock`, `streetBaseBlock`, `streetVariantBlock`,
+  `railMainBlock`, `grassBlock`, `ironbarsBlock`, `glowstoneBlock`, `leavesBlock`, `rubbleDirtBlock`.
+
+Both resolve against the merged palette for the context the part is used in. A part is used in
+several contexts, and the merge differs per context, so the check is per **(context, part)** pairing
+the walk above already enumerates.
+
+**The guaranteed-character set.** A style's palette is one choice per `randompalettes` group, merged.
+Checking one arbitrary selection is wrong (it passes for characters that only some worlds get);
+enumerating the cartesian product is exponential and unnecessary. A character is guaranteed iff:
+
+```
+c ∈ partPalette ∪ buildingPalette ∪ ⋃over groups g ( ⋂over choices p in g  chars(p) )
+```
+
+— i.e. defined by the part or building outright, or defined by *every* choice of at least one group.
+That is exact, and linear in the number of palettes.
+
+`frompalette` is followed by building the merge through `CompiledPalette`'s own constructor rather
+than reimplementing it, so the validator cannot drift from what generation does.
+
+### 3. Slice sizes relative to the role a part is wired into
+
+`BuildingPart.checkGeometry` proves a part is self-consistent, not that it fits where it is used.
+`ChunkDriver.current` converts chunk-local to absolute without clamping, and `block()`/`add()` then
+mask with `& 0xf` — so **a part wider than 16 wraps around and overwrites its own beginning**,
+silently, with no exception and nothing in the log.
+
+A part reached through a street, highway or railway wiring slot must therefore be 16×16. Building
+parts are not covered by this rule (a building part is placed at a computed offset and may legitimately
+differ), so the check is per role, which the walk already knows.
+
+## Shape
+
+`AssetGraph` — one pass over an `AssetSnapshot`, producing diagnostics through the existing
+`AssetDiagnostics`. Called from `AssetCompiler.compile` after every index is built, so it is part of
+the one report a world load already produces, and `/urbex validate` gets it for free.
+
+It reads the snapshot and nothing else. No registry, no level, no `ServerAccess` — which is only
+possible because #128 finished.
+
+## The PRs
+
+**56a — the reachable walk and dangling references.** `AssetGraph`, the root set, the traversal, and
+check 1. The traversal is the expensive part to get right and is what checks 2 and 3 ride on.
+
+**56b — characters and role sizes.** Checks 2 and 3, on the pairings 56a's walk already produces.
+
+## Digest expectations
+
+Neither PR may move a golden. Both are load-time refusals over data the bundled pack already
+satisfies — `DatapackReferenceIntegrityTest` has enforced the same reference rules against the
+shipped files since #94, so a moved golden would mean the walk changed what compiles, not what is
+reported.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -104,11 +105,17 @@ public final class AssetCompiler {
         AssetIndex<StuffObject> stuff = AssetStage.compileAll(access,
                 CustomRegistries.STUFF_REGISTRY_KEY, (id, chain) -> new StuffObject(id, chain), diagnostics);
 
-        promoteReachableCityStyleProblems(access, worldStyles, cityStyles, cityStyleProblems, diagnostics);
+        Set<Identifier> reachableCityStyles = reachableCityStyles(access, worldStyles);
+        promoteReachableCityStyleProblems(cityStyles, reachableCityStyles, cityStyleProblems, diagnostics);
 
         AssetSnapshot snapshot = new AssetSnapshot(variants, palettes, conditions, styles, parts,
                 buildings, multiBuildings, scattered, worldStyles, cityStyles, predefinedCities,
                 stuff, groupStuffByTag(stuff.all()));
+        // Last, on the finished snapshot: the cross-asset references are names, and resolving them
+        // needs every index built. Generation resolves them one at a time on whichever chunk first
+        // needs one, which is the whole of what issue #56's second half is about.
+        AssetGraph.validate(snapshot, reachableCityStyles.stream()
+                .map(cityStyles::get).filter(Objects::nonNull).toList(), diagnostics);
         Urbex.getLogger().info("Compiled {} Urbex assets ({} problem(s))",
                 snapshot.totalAssets(), diagnostics.size());
         return snapshot;
@@ -128,11 +135,7 @@ public final class AssetCompiler {
      * in that chain resolves to, so the union over raw entries is the same set of city styles, and
      * reading them raw means a broken preset chain is not turned into a city-style failure.</p>
      */
-    private static void promoteReachableCityStyleProblems(RegistryAccess access,
-                                                          AssetIndex<WorldStyle> worldStyles,
-                                                          AssetIndex<CityStyle> cityStyles,
-                                                          AssetDiagnostics candidates,
-                                                          AssetDiagnostics fatal) {
+    static Set<Identifier> reachableCityStyles(RegistryAccess access, AssetIndex<WorldStyle> worldStyles) {
         Set<Identifier> reachable = new HashSet<>();
         for (WorldStyle style : worldStyles.all()) {
             for (Pair<Predicate<Holder<Biome>>, Pair<Float, String>> selector : style.cityStyleSelectors()) {
@@ -149,6 +152,13 @@ public final class AssetCompiler {
                 reachable.add(DataTools.fromName(city.getCityStyle()));
             }
         }
+        return reachable;
+    }
+
+    private static void promoteReachableCityStyleProblems(AssetIndex<CityStyle> cityStyles,
+                                                          Set<Identifier> reachable,
+                                                          AssetDiagnostics candidates,
+                                                          AssetDiagnostics fatal) {
         for (AssetDiagnostics.Problem problem : candidates.problems()) {
             if (problem.asset() != null && reachable.contains(problem.asset())) {
                 fatal.record(problem.registry(), problem.asset(), problem.message());

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
@@ -1,0 +1,304 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
+import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
+import dev.krona.urbex.worldgen.lost.regassets.data.ObjectSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
+import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
+import dev.krona.urbex.worldgen.lost.regassets.data.ScatteredReference;
+import dev.krona.urbex.worldgen.lost.regassets.data.ScatteredSettings;
+import dev.krona.urbex.worldgen.lost.regassets.data.StreetParts;
+import net.minecraft.resources.Identifier;
+
+import javax.annotation.Nullable;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Walks every asset a world can reach and reports the references that name nothing.
+ *
+ * <p>Cross-asset references are held in the compiled model as <strong>names</strong>, not as objects:
+ * a city style's {@code buildings} selector, a world style's highway wiring, a building's
+ * {@code parts}. Generation resolves them one at a time, on whichever chunk first needs one - there
+ * are around forty {@code assets().parts().getOrThrow(...)} sites in {@code CityGenerator},
+ * {@code Highways}, {@code Railways} and {@code Scattered}. A building naming a part that no datapack
+ * registers is therefore an exception from a worldgen worker, on a chunk somewhere out in the world,
+ * rather than a message about a file (issue #56).</p>
+ *
+ * <p>This resolves all of them once, at compile time, and reports them together through
+ * {@link AssetDiagnostics}. Nothing here reads a registry, a level or a server - it reads the
+ * finished {@link AssetSnapshot} and nothing else, which is what #128 made possible.</p>
+ *
+ * <h2>Reachability, and why it is not "every registered asset"</h2>
+ *
+ * <p>The walk starts from what a world can actually select and follows references outward. That is
+ * the same rule {@link AssetCompiler#promoteReachableCityStyleProblems} already applies to city
+ * styles, and for the same reason: requiredness is a property of the end of a chain. A part that only
+ * an unreachable city style names is not a broken pack, and sweeping every registered asset instead
+ * would refuse worlds over files that are never used - which is precisely the mistake an earlier
+ * draft of the compiler made with city styles.</p>
+ *
+ * <p><strong>Fatal, not a warning.</strong> Every reference below already throws from a worker today.
+ * Reporting it at load makes it earlier, not stricter. The exception is the optional street
+ * components, which generation reaches with {@code getOrWarn} - a pack may legitimately leave one
+ * out - so an absent one of those is left alone here too.</p>
+ */
+public final class AssetGraph {
+
+    private final AssetSnapshot assets;
+    private final AssetDiagnostics diagnostics;
+    /** Every (kind, id) already walked, so a diamond in the graph is visited once and a cycle ends. */
+    private final Set<String> seen = new HashSet<>();
+    private final Deque<Runnable> pending = new ArrayDeque<>();
+
+    private AssetGraph(AssetSnapshot assets, AssetDiagnostics diagnostics) {
+        this.assets = assets;
+        this.diagnostics = diagnostics;
+    }
+
+    /**
+     * Reports every dangling reference reachable from {@code reachableCityStyles} and from the
+     * snapshot's world styles and predefined cities.
+     *
+     * @param reachableCityStyles the city styles something can select, already resolved. Handed over
+     *                            as objects rather than as names on purpose: the compiler works the
+     *                            set out from the world styles, the presets and the predefined
+     *                            cities - a route only the registries expose - and taking it
+     *                            pre-resolved means this class cannot become a fifth place that
+     *                            looks a city style up by name (see {@code CityStyleLookupSitesTest},
+     *                            which exists because such a site reverts silently to failing from a
+     *                            worldgen worker). One that did not compile is not here, and is
+     *                            already reported by the compiler.
+     */
+    public static void validate(AssetSnapshot assets, Collection<CityStyle> reachableCityStyles,
+                                AssetDiagnostics diagnostics) {
+        AssetGraph graph = new AssetGraph(assets, diagnostics);
+        for (WorldStyle style : assets.worldStyles().all()) {
+            graph.walkWorldStyle(style);
+        }
+        for (PredefinedCity city : assets.predefinedCities().all()) {
+            graph.walkPredefinedCity(city);
+        }
+        for (CityStyle style : reachableCityStyles) {
+            graph.walkCityStyle(style);
+        }
+        graph.drain();
+    }
+
+    /** Depth is unbounded in a datapack, so the walk is a queue rather than recursion. */
+    private void drain() {
+        while (!pending.isEmpty()) {
+            pending.poll().run();
+        }
+    }
+
+    private void walkWorldStyle(WorldStyle style) {
+        if (!first("worldstyle", style.getId())) {
+            return;
+        }
+        Identifier owner = style.getId();
+        style(owner, style.getOutsideStyle(), "outsidestyle");
+        // citystyles are deliberately not followed from here: the compiler already resolved which
+        // ones anything can select, and hands them to validate() as the walk's other root.
+        ScatteredSettings scattered = style.getScatteredSettings();
+        if (scattered != null) {
+            for (ScatteredReference reference : scattered.getList()) {
+                scattered(owner, reference.getName(), "scattered.list");
+            }
+        }
+        PartSelector selector = style.getPartSelector();
+        HighwayParts highways = selector.highwayParts();
+        parts(owner, highways.tunnel(), "parts.highways.tunnel");
+        parts(owner, highways.open(), "parts.highways.open");
+        parts(owner, highways.bridge(), "parts.highways.bridge");
+        parts(owner, highways.tunnelBi(), "parts.highways.tunnelbi");
+        parts(owner, highways.openBi(), "parts.highways.openbi");
+        parts(owner, highways.bridgeBi(), "parts.highways.bridgebi");
+        RailwayParts railways = selector.railwayParts();
+        parts(owner, railways.stationUnderground(), "parts.railways.stationunderground");
+        parts(owner, railways.stationOpen(), "parts.railways.stationopen");
+        parts(owner, railways.stationUndergroundStairs(), "parts.railways.stationundergroundstairs");
+        parts(owner, railways.stationStaircase(), "parts.railways.stationstaircase");
+        parts(owner, railways.stationStaircaseSurface(), "parts.railways.stationstaircasesurface");
+        parts(owner, railways.rails3Split(), "parts.railways.rails3split");
+        parts(owner, railways.railsDown2(), "parts.railways.railsdown2");
+        parts(owner, railways.railsDown1(), "parts.railways.railsdown1");
+        parts(owner, railways.railsBend(), "parts.railways.railsbend");
+        parts(owner, railways.railsFlat(), "parts.railways.railsflat");
+        parts(owner, railways.railsHorizontal(), "parts.railways.railshorizontal");
+        parts(owner, railways.railsHorizontalEnd(), "parts.railways.railshorizontalend");
+        parts(owner, railways.railsHorizontalWater(), "parts.railways.railshorizontalwater");
+        parts(owner, railways.railsVertical(), "parts.railways.railsvertical");
+        parts(owner, railways.railsVerticalWater(), "parts.railways.railsverticalwater");
+        parts(owner, railways.stationOpenRoof(), "parts.railways.stationopenroof");
+    }
+
+    private void walkCityStyle(CityStyle style) {
+        if (!first("citystyle", style.getId())) {
+            return;
+        }
+        Identifier owner = style.getId();
+        style(owner, style.getStyle(), "style");
+        for (ObjectSelector selector : style.selectorList(CityStyle.Sel.BUILDING)) {
+            building(owner, selector.value(), "selectors.buildings");
+        }
+        for (ObjectSelector selector : style.selectorList(CityStyle.Sel.MULTI_BUILDING)) {
+            multiBuilding(owner, selector.value(), "selectors.multibuildings");
+        }
+        selectorParts(owner, style, CityStyle.Sel.BRIDGE, "selectors.bridges");
+        selectorParts(owner, style, CityStyle.Sel.LARGE_BRIDGE, "selectors.largebridges");
+        selectorParts(owner, style, CityStyle.Sel.PARK, "selectors.parks");
+        selectorParts(owner, style, CityStyle.Sel.FOUNTAIN, "selectors.fountains");
+        selectorParts(owner, style, CityStyle.Sel.STAIR, "selectors.stairs");
+        selectorParts(owner, style, CityStyle.Sel.FRONT, "selectors.fronts");
+        selectorParts(owner, style, CityStyle.Sel.RAIL_DUNGEON, "selectors.raildungeons");
+        streetParts(owner, style.getStreetParts(), "streetblocks.parts");
+        streetParts(owner, style.getLargeStreetParts(), "streetblocks.largeparts");
+        streetParts(owner, style.getTertiaryStreetParts(), "streetblocks.tertiaryparts");
+    }
+
+    private void selectorParts(Identifier owner, CityStyle style, CityStyle.Sel kind, String field) {
+        for (ObjectSelector selector : style.selectorList(kind)) {
+            part(owner, selector.value(), field);
+        }
+    }
+
+    private void streetParts(Identifier owner, @Nullable StreetParts family, String field) {
+        if (family == null) {
+            return;
+        }
+        parts(owner, family.straight(), field + ".straight");
+        parts(owner, family.end(), field + ".end");
+        parts(owner, family.bend(), field + ".bend");
+        parts(owner, family.t(), field + ".t");
+        parts(owner, family.none(), field + ".none");
+        parts(owner, family.all(), field + ".all");
+        parts(owner, family.connector(), field + ".connector");
+        parts(owner, family.stair(), field + ".stair");
+    }
+
+    private void walkBuilding(Building building) {
+        if (!first("building", building.getId())) {
+            return;
+        }
+        for (String name : building.partNames()) {
+            part(building.getId(), name, "parts");
+        }
+    }
+
+    private void walkMultiBuilding(MultiBuilding multi) {
+        if (!first("multibuilding", multi.getId())) {
+            return;
+        }
+        if (multi.getBuildingSet() != null) {
+            for (String name : multi.getBuildingSet()) {
+                building(multi.getId(), name, "buildings");
+            }
+        }
+    }
+
+    private void walkScattered(ScatteredBuilding scattered) {
+        if (!first("scattered", scattered.getId())) {
+            return;
+        }
+        // Either arm may be absent: a scattered entry declares 'buildings' or 'multibuilding', and
+        // the constructor requires one of the two rather than both.
+        if (scattered.getBuildings() != null) {
+            for (String name : scattered.getBuildings()) {
+                building(scattered.getId(), name, "buildings");
+            }
+        }
+        multiBuilding(scattered.getId(), scattered.getMultibuilding(), "multibuilding");
+    }
+
+    private void walkPredefinedCity(PredefinedCity city) {
+        if (!first("predefinedcity", city.getId())) {
+            return;
+        }
+        if (city.getPredefinedBuildings() == null) {
+            return;
+        }
+        for (PredefinedBuilding building : city.getPredefinedBuildings()) {
+            if (building.multi()) {
+                multiBuilding(city.getId(), building.building(), "buildings");
+            } else {
+                building(city.getId(), building.building(), "buildings");
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ one reference
+
+    private void parts(Identifier owner, @Nullable List<String> names, String field) {
+        if (names == null) {
+            return;
+        }
+        for (String name : names) {
+            part(owner, name, field);
+        }
+    }
+
+    private void part(Identifier owner, @Nullable String name, String field) {
+        resolve(owner, name, field, assets.parts(), this::walkPart);
+    }
+
+    private void building(Identifier owner, @Nullable String name, String field) {
+        resolve(owner, name, field, assets.buildings(), this::walkBuilding);
+    }
+
+    private void multiBuilding(Identifier owner, @Nullable String name, String field) {
+        resolve(owner, name, field, assets.multiBuildings(), this::walkMultiBuilding);
+    }
+
+    private void scattered(Identifier owner, @Nullable String name, String field) {
+        resolve(owner, name, field, assets.scattered(), this::walkScattered);
+    }
+
+    private void style(Identifier owner, @Nullable String name, String field) {
+        resolve(owner, name, field, assets.styles(), style -> { });
+    }
+
+    /** A part is a leaf for this walk: its {@code refpalette} was resolved when it compiled. */
+    private void walkPart(BuildingPart part) {
+    }
+
+    /**
+     * Resolves one name, reporting it if it names nothing and queueing what it names if it does.
+     * <p>
+     * An unparseable name is reported as absent rather than thrown: {@code DataTools.fromName}
+     * refuses a bare name deliberately (a reference is written fully qualified), and an author who
+     * wrote one needs that in the same report as everything else, not as the exception that ended
+     * the walk.
+     */
+    private <T> void resolve(Identifier owner, @Nullable String name, String field,
+                             AssetIndex<T> index, java.util.function.Consumer<T> walk) {
+        if (name == null || name.isBlank()) {
+            return;
+        }
+        Identifier id;
+        try {
+            id = DataTools.fromName(name);
+        } catch (RuntimeException e) {
+            diagnostics.record(index.registry(), owner,
+                    "'" + field + "' names '" + name + "', which is not a valid asset id: " + e.getMessage());
+            return;
+        }
+        T found = index.get(id);
+        if (found == null) {
+            diagnostics.record(index.registry(), owner,
+                    "'" + field + "' names '" + name + "', which no loaded datapack registers");
+            return;
+        }
+        pending.add(() -> walk.accept(found));
+    }
+
+    /** True the first time this asset is reached, so a diamond costs one visit and a cycle ends. */
+    private boolean first(String kind, Identifier id) {
+        return seen.add(kind + "/" + id);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
@@ -140,6 +140,25 @@ public class Building {
         return name;
     }
 
+    /**
+     * Every part name this building can place, from both {@code parts} and {@code parts2}, with the
+     * conditions stripped off.
+     * <p>
+     * For {@link AssetGraph}, which asks "what could this reach" rather than "what will this pick":
+     * a condition that never fires in one world fires in the next, so a reference behind one is
+     * still a reference. Duplicates are not removed - the caller dedupes by asset, not by mention.
+     */
+    List<String> partNames() {
+        List<String> names = new ArrayList<>(parts.size() + parts2.size());
+        for (Pair<Predicate<ConditionContext>, String> part : parts) {
+            names.add(part.getRight());
+        }
+        for (Pair<Predicate<ConditionContext>, String> part : parts2) {
+            names.add(part.getRight());
+        }
+        return names;
+    }
+
     public Palette getLocalPalette() {
         return localPalette;
     }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraphTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraphTest.java
@@ -1,0 +1,218 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import dev.krona.urbex.worldgen.lost.regassets.BuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
+import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A reference that names nothing is a message about a file, not an exception from a worldgen worker
+ * (issue #56).
+ * <p>
+ * Cross-asset references live in the compiled model as names, and generation resolves them one at a
+ * time on whichever chunk first needs one. A building naming a part no datapack registers used to
+ * surface as {@code "Can't find 'urbex:nope' in urbex/parts!"} thrown from a worker, on a chunk
+ * somewhere out in the world, long after the world loaded. {@link AssetGraph} resolves them all at
+ * compile time, into the one report a load already produces.
+ * <p>
+ * The shipped pack is covered from the other side: {@code DatapackReferenceIntegrityTest} reads its
+ * JSON, and both digest runs now compile with this walk active. What is tested here is the walk
+ * itself - that it reports, that it scopes to what a world can reach, and that a datapack cannot make
+ * it spin. Predefined cities are the root throughout because they are the cheapest one to build; the
+ * other two roots (world styles, reachable city styles) enter the same traversal.
+ */
+class AssetGraphTest {
+
+    private static final Identifier PRESENT_PART = Identifier.fromNamespaceAndPath("urbex", "present_part");
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void aPartNameNothingRegistersIsReportedNamingTheBuildingAndTheField() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture()
+                .building("tower", "urbex:no_such_part")
+                .city("downtown", building("urbex:tower"));
+
+        AssetGraph.validate(fixture.snapshot(), List.of(), diagnostics);
+
+        assertEquals(1, diagnostics.size(), () -> diagnostics.format("expected exactly one"));
+        AssetDiagnostics.Problem problem = diagnostics.problems().getFirst();
+        assertEquals("urbex:parts", problem.registry());
+        assertEquals(Identifier.fromNamespaceAndPath("urbex", "tower"), problem.asset(),
+                "the report names the asset holding the bad reference, not the one it wanted");
+        assertTrue(problem.message().contains("urbex:no_such_part"), problem.message());
+        assertTrue(problem.message().contains("parts"), problem.message());
+    }
+
+    @Test
+    void aReferenceThatResolvesIsNotReported() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture()
+                .building("tower", PRESENT_PART.toString())
+                .city("downtown", building("urbex:tower"));
+
+        AssetGraph.validate(fixture.snapshot(), List.of(), diagnostics);
+
+        assertTrue(diagnostics.isEmpty(), () -> diagnostics.format("expected nothing"));
+    }
+
+    /**
+     * A bare name is a load error by design - {@code DataTools.fromName} refuses it rather than
+     * defaulting it to the urbex namespace - and it has to arrive as a line in the report rather than
+     * as the exception that ends the walk, or one typo hides every other problem in the pack.
+     */
+    @Test
+    void aNameThatIsNotFullyQualifiedIsReportedRatherThanEndingTheWalk() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture()
+                .building("first", "present_part")
+                .building("second", "urbex:also_missing")
+                .city("downtown", building("urbex:first"), building("urbex:second"));
+
+        AssetGraph.validate(fixture.snapshot(), List.of(), diagnostics);
+
+        assertEquals(2, diagnostics.size(),
+                () -> "the unqualified name must not stop the walk before the second building: "
+                        + diagnostics.format(""));
+    }
+
+    /**
+     * Nothing reaches this building, so its broken reference is not this world's problem. Same rule
+     * the compiler already applies to city styles: requiredness is a property of the end of a chain,
+     * and refusing a world over a file nothing can select is how an earlier draft of the compiler
+     * refused the shipped pack's own world.
+     */
+    @Test
+    void anAssetNoRootReachesIsNotWalked() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture().building("orphan", "urbex:no_such_part");
+
+        AssetGraph.validate(fixture.snapshot(), List.of(), diagnostics);
+
+        assertTrue(diagnostics.isEmpty(),
+                () -> "an unreachable asset is not a broken pack: " + diagnostics.format(""));
+    }
+
+    /**
+     * One building reached by two paths - directly and through a multibuilding - reports once. A
+     * datapack is user input, so "an author would not write that" is not an argument: the walk has to
+     * terminate and not multiply its own report.
+     */
+    @Test
+    void anAssetReachableTwiceIsWalkedOnce() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture()
+                .building("shared", "urbex:no_such_part")
+                .multiBuilding("block", "urbex:shared")
+                .city("downtown", building("urbex:shared"), multi("urbex:block"));
+
+        AssetGraph.validate(fixture.snapshot(), List.of(), diagnostics);
+
+        assertEquals(1, diagnostics.size(),
+                () -> "reachable twice, reported once: " + diagnostics.format(""));
+    }
+
+    /** A multibuilding naming a building that names it back must not spin. */
+    @Test
+    void aCycleTerminates() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture()
+                .multiBuilding("left", "urbex:right_holder")
+                .building("right_holder", "urbex:no_such_part")
+                .multiBuilding("right", "urbex:right_holder")
+                .city("downtown", multi("urbex:left"), multi("urbex:right"));
+
+        AssetGraph.validate(fixture.snapshot(), List.of(), diagnostics);
+
+        assertEquals(1, diagnostics.size(), () -> diagnostics.format(""));
+    }
+
+    // ------------------------------------------------------------------ fixtures
+
+    private static PredefinedBuilding building(String name) {
+        return new PredefinedBuilding(name, 0, 0, false, false);
+    }
+
+    private static PredefinedBuilding multi(String name) {
+        return new PredefinedBuilding(name, 0, 0, true, false);
+    }
+
+    /** Assembles a snapshot holding only what a test names, with one registered part to resolve to. */
+    private static final class Fixture {
+
+        private final Map<Identifier, Building> buildings = new HashMap<>();
+        private final Map<Identifier, MultiBuilding> multiBuildings = new HashMap<>();
+        private final Map<Identifier, PredefinedCity> cities = new HashMap<>();
+
+        Fixture building(String path, String partName) {
+            PartRef ref = new PartRef(partName, Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+            Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+            buildings.put(id, new Building(id, BuiltInRegistries.BLOCK, null,
+                    AssetIndex.empty("urbex:palettes"), List.of(new BuildingDefinition(
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.of('#'), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.of(new Mergeable<>(true, List.of(ref))), Optional.empty()))));
+            return this;
+        }
+
+        Fixture multiBuilding(String path, String... names) {
+            Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+            multiBuildings.put(id, new MultiBuilding(id, List.of(new MultiBuildingDefinition(
+                    Optional.empty(), Optional.of(names.length), Optional.of(1),
+                    Optional.of(List.of(List.of(names)))))));
+            return this;
+        }
+
+        Fixture city(String path, PredefinedBuilding... contents) {
+            Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+            cities.put(id, new PredefinedCity(id, List.of(new PredefinedCityDefinition(
+                    Optional.empty(), Optional.of("minecraft:overworld"), Optional.of(0), Optional.of(0),
+                    Optional.of(1), Optional.of("urbex:citystyle_common"),
+                    Optional.of(new Mergeable<>(true, List.of(contents))), Optional.empty()))));
+            return this;
+        }
+
+        AssetSnapshot snapshot() {
+            AssetSnapshot empty = AssetSnapshot.empty();
+            Map<Identifier, BuildingPart> parts = new HashMap<>();
+            // A part is a leaf for the walk, so this one exists only so that "resolves" and "does
+            // not resolve" are both reachable states. One block, so it satisfies checkGeometry.
+            parts.put(PRESENT_PART, new BuildingPart(PRESENT_PART, BuiltInRegistries.BLOCK, null,
+                    AssetIndex.empty("urbex:palettes"), List.of(new BuildingPartDefinition(
+                    Optional.empty(), Optional.of(1), Optional.of(1),
+                    Optional.of(List.of(List.of("a"))), Optional.empty(), Optional.empty(),
+                    Optional.empty()))));
+            return new AssetSnapshot(empty.variants(), empty.palettes(), empty.conditions(),
+                    empty.styles(), new AssetIndex<>("urbex:parts", parts),
+                    new AssetIndex<>("urbex:buildings", buildings),
+                    new AssetIndex<>("urbex:multibuildings", multiBuildings), empty.scattered(),
+                    empty.worldStyles(), empty.cityStyles(),
+                    new AssetIndex<>("urbex:predefinedcities", cities), empty.stuff(), empty.stuffByTag());
+        }
+    }
+}


### PR DESCRIPTION
**56a** of #56 — the reachable-reference walk. Phase 2 step 5 of epic #134.
Design: [`docs/superpowers/specs/2026-08-12-reachable-graph-validation.md`](docs/superpowers/specs/2026-08-12-reachable-graph-validation.md).

## What was wrong

Cross-asset references live in the compiled model as **names**, not objects — a city style's
`buildings` selector, a world style's highway wiring, a building's `parts`. Generation resolves them
one at a time, on whichever chunk first needs one; there are about forty
`assets().parts().getOrThrow(...)` sites across `CityGenerator`, `Highways`, `Railways` and
`Scattered`.

So a building naming a part no datapack registers was an exception from a worldgen worker, on a chunk
somewhere out in the world, long after the world opened — and `CityFeature` catches it, so the chunk
is saved half-generated.

## What changed

`AssetGraph` walks from the roots a world can actually select and resolves every reference it finds,
reporting through the `AssetDiagnostics` a load already produces. It reads the finished
`AssetSnapshot` and nothing else — no registry, no level, no `ServerAccess` — which is exactly what
#128 made possible.

```
worldStyle ─┬─ outsidestyle → style
            ├─ scattered.list[] → scattered → buildings / multibuilding
            └─ parts.{highways,railways}.* → part          (22 wiring components)
cityStyle ──┬─ style, selectors.{buildings,multibuildings} → building / multiBuilding
            ├─ selectors.{bridges,largebridges,parks,fountains,stairs,fronts,raildungeons} → part
            └─ streetblocks.{parts,largeparts,tertiaryparts}.* → part
building ─── parts[] + parts2[] → part
multiBuilding ─ buildings[][] → building
predefinedCity ─ buildings[] → building / multiBuilding
```

## Three decisions worth reviewing

**Reachable, not exhaustive.** The walk starts from what a world can select rather than sweeping every
registered asset. That is the rule city styles already use, for the same reason: requiredness is a
property of the end of a chain. A part that only an unreachable city style names is not a broken pack
— and refusing a world over a file nothing uses is precisely the mistake an earlier draft of the
compiler made, which the digest run caught then.

**An unparseable name is reported, not thrown.** A bare reference is a load error by design
(`DataTools.fromName` refuses it rather than defaulting the namespace), but if it propagated it would
end the walk and hide every other problem in the pack. `aNameThatIsNotFullyQualifiedIsReportedRatherThanEndingTheWalk`
pins that.

**The walk takes city styles pre-resolved, not by name.** `CityStyleLookupSitesTest` failed on my
first draft, correctly: I had added a fifth place that resolves a city style by name. The fix is not
to widen that test's list — it is to hand `validate` the resolved `Collection<CityStyle>` the compiler
already computed, so this class *cannot* be a name source. The reachable-set computation moved out of
`promoteReachableCityStyleProblems` so both callers share one rule rather than drifting.

## What the digest run caught that no unit test would have

`ScatteredBuilding.getBuildings()` is **null** when the entry declares `multibuilding` instead — the
constructor requires one of the two, not both. The first version of the walk NPE'd on the shipped
pack. Fixed, and the nullable arms of `MultiBuilding` and `PredefinedCity` are guarded for the same
reason.

## What is left of #56 (56b)

Not in this PR, and named in the spec:

- **Undefined palette characters** — a part's slice characters and a city style's character fields,
  against the guaranteed-character set across `randompalettes` groups.
- **Slice sizes relative to role** — `ChunkDriver.current` does not clamp and `block()`/`add()` mask
  with `& 0xf`, so a street/highway/railway part wider than 16 **wraps and overwrites its own start**,
  silently. Per-part geometry is already checked; fitting the role is not.
- **Condition references** (`inpart`/`belowpart`/`inbuilding`) — `Condition` consumes them into a
  `Predicate` at construction and does not retain the strings, so covering them needs a change there.

## Verification

```
./gradlew test               # pass, 557 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK
```

**Both digest goldens are unchanged**, and both runs now compile with the walk active — which is also
the strongest statement that the shipped pack's references all resolve.
