### PR TITLE
feat: check palette characters and road part sizes at load (#56, 56b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **A palette character that resolves to nothing, and a road part that does not fit its chunk, are
+  caught at load.** Both used to surface from a worldgen worker on the first chunk that placed the
+  part (issue #56).
+  - *Characters are checked where the part is used*, not against the part's own palette. A part's
+    characters resolve against the chunk's style palette, the building's, and the part's own merged
+    together — so the same part reached from two city styles is two questions with two answers. The
+    check builds that merge with the generator's own code rather than reimplementing it.
+  - *A character no palette defines refuses the world.* A character only some `randompalettes` choices
+    define is a warning instead: those packs generate correctly most of the time, and refusing them
+    would be inventing a rule rather than reporting a break.
+  - *A street, highway or railway part that is not 16×16 refuses the world.* The driver masks
+    coordinates to the chunk, so an oversized road part wrapped round and overwrote its own beginning
+    — silently, with no exception and nothing in the log.
+  - *No worldgen change*: both digest goldens are unchanged, and the bundled pack reports nothing.
+
 - **A datapack reference that names nothing is now a message about a file, not a crashed chunk.**
   Every cross-asset reference a world can reach — a city style's building and part selectors, a world
   style's highway and railway wiring, a building's `parts`, a multibuilding's grid, a scattered

--- a/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
+++ b/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
@@ -123,6 +123,27 @@ check 1. The traversal is the expensive part to get right and is what checks 2 a
 
 **56b — characters and role sizes.** Checks 2 and 3, on the pairings 56a's walk already produces.
 
+*Outcome.* The guaranteed-character formula above is **wrong as written** and was replaced. Testing a
+choice on its own reports every `frompalette` that points at a character another group supplies -
+`urbex:glass_side_variant_glass` maps `'@'` to `'a'` and nothing else - which is the shipped pack's own
+idiom, and produced 45 warnings about a pack that is correct. The check constructs a *witness*
+instead: for each choice, look the character up in the merge of that choice with every choice of every
+other group. Missing even there means missing for every selection containing that choice, so a failing
+selection provably exists. Sound in the only direction that matters - nothing is reported without a
+selection that really breaks - and the shipped pack now reports zero.
+
+*Still not covered*, and neither belongs in this pass:
+
+- **Condition references** (`inpart`/`belowpart`/`inbuilding`). `Condition` consumes them into a
+  `Predicate<ConditionContext>` at construction and does not retain the strings, so reaching them
+  means changing that class - a change to a compiled asset, not to the walk.
+- **A city style's character fields** (`streetblock`, `grassblock`, and the seven others). They resolve
+  against the chunk's palette like a part's characters do, but they are not reached through a part, so
+  they need their own usage - the same machinery, a separate pass.
+- **Scattered parts' characters.** A scattered building lands wherever the terrain allows and takes the
+  style of the chunk it lands in, which the walk cannot know. Its references are checked; its
+  characters are not.
+
 ## Digest expectations
 
 Neither PR may move a golden. Both are load-time refusals over data the bundled pack already

--- a/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
+++ b/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
@@ -214,6 +214,12 @@ public final class GenerationSession {
         AssetSnapshot assets = AssetCompiler.compile(level.registryAccess(), diagnostics);
         // Before publication, not after: a snapshot nobody validated is exactly the partially
         // compiled view this whole issue removes.
+        if (!diagnostics.isEmpty()) {
+            // Logged whether or not it refuses the world: a warning is a thing an author wants to
+            // see, and throwIfAny only speaks when something is fatal.
+            Urbex.getLogger().warn(diagnostics.format(
+                    diagnostics.size() + " Urbex asset problem(s) found while compiling this world:"));
+        }
         diagnostics.throwIfAny();
         Compiled world = new Compiled(assets, new TagEpoch(TagSnapshot.capture(assets)));
         compiled = world;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetDiagnostics.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetDiagnostics.java
@@ -28,18 +28,31 @@ public final class AssetDiagnostics {
      * @param asset    the asset that failed, or null when the problem belongs to the sweep rather
      *                 than to one entry
      * @param message  what is wrong, already phrased for an author
+     * @param fatal    whether this alone must refuse the world. Almost everything here is: a
+     *                 reference that names nothing, a required field nothing declares. The exception
+     *                 is a break that only <em>some</em> worlds hit - a palette character only some
+     *                 {@code randompalettes} choices define - where packs that ship it generate
+     *                 correctly most of the time, and refusing them would be a rule this report
+     *                 invented rather than a break it found (issue #56).
      */
-    public record Problem(String registry, @Nullable Identifier asset, String message) {
+    public record Problem(String registry, @Nullable Identifier asset, String message, boolean fatal) {
         @Override
         public String toString() {
-            return registry + (asset == null ? "" : " / " + asset) + ": " + message;
+            return (fatal ? "" : "[warning] ") + registry
+                    + (asset == null ? "" : " / " + asset) + ": " + message;
         }
     }
 
     private final List<Problem> problems = new ArrayList<>();
 
+    /** Records a problem that must refuse the world. */
     public synchronized void record(String registry, @Nullable Identifier asset, String message) {
-        problems.add(new Problem(registry, asset, message));
+        problems.add(new Problem(registry, asset, message, true));
+    }
+
+    /** Records a problem worth telling the author about that must not refuse the world. */
+    public synchronized void warn(String registry, @Nullable Identifier asset, String message) {
+        problems.add(new Problem(registry, asset, message, false));
     }
 
     /**
@@ -58,8 +71,18 @@ public final class AssetDiagnostics {
         record(registry, asset, message == null ? root.toString() : message);
     }
 
+    /** True when nothing at all was recorded, warnings included. */
     public synchronized boolean isEmpty() {
         return problems.isEmpty();
+    }
+
+    /** True when something here must refuse the world. */
+    public synchronized boolean hasFatal() {
+        return problems.stream().anyMatch(Problem::fatal);
+    }
+
+    public synchronized int fatalCount() {
+        return (int) problems.stream().filter(Problem::fatal).count();
     }
 
     public synchronized int size() {
@@ -85,15 +108,19 @@ public final class AssetDiagnostics {
     }
 
     /**
-     * Refuses the world if anything is wrong, naming everything at once.
+     * Refuses the world if anything fatal is wrong, naming everything at once.
+     *
+     * <p>Warnings travel in the same message rather than in a separate one: an author reading about a
+     * broken reference wants the near-misses in front of them too, and a world that loads has already
+     * had them logged by the caller.</p>
      *
      * @throws IllegalStateException listing every problem
      */
     public void throwIfAny() {
-        if (isEmpty()) {
+        if (!hasFatal()) {
             return;
         }
         throw new IllegalStateException(format(
-                size() + " Urbex asset problem(s) must be fixed before this world can load:"));
+                fatalCount() + " Urbex asset problem(s) must be fixed before this world can load:"));
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
@@ -9,15 +9,22 @@ import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.ScatteredReference;
 import dev.krona.urbex.worldgen.lost.regassets.data.ScatteredSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.StreetParts;
+import net.minecraft.core.Holder;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.biome.Biome;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Walks every asset a world can reach and reports the references that name nothing.
@@ -54,6 +61,20 @@ public final class AssetGraph {
     private final AssetDiagnostics diagnostics;
     /** Every (kind, id) already walked, so a diamond in the graph is visited once and a cycle ends. */
     private final Set<String> seen = new HashSet<>();
+    /**
+     * Every (part, style, building, road) already checked. Separate from {@link #seen} on purpose: a
+     * missing reference is reported once per asset, but a character is a question about a
+     * <em>usage</em>, and the same part under two styles is two questions with two answers.
+     */
+    private final Set<String> checkedUsages = new HashSet<>();
+    /** Every dangling reference already reported, so four paths to one typo are one line. */
+    private final Set<String> reported = new HashSet<>();
+    /**
+     * The reachable city styles by id, so a world style can pair its road wiring with the styles that
+     * world can actually put under it. Built from the collection handed in - this is not a lookup
+     * into the snapshot's city-style index, which would make this class a name-resolution site.
+     */
+    private final Map<Identifier, CityStyle> reachable = new HashMap<>();
     private final Deque<Runnable> pending = new ArrayDeque<>();
 
     private AssetGraph(AssetSnapshot assets, AssetDiagnostics diagnostics) {
@@ -78,6 +99,9 @@ public final class AssetGraph {
     public static void validate(AssetSnapshot assets, Collection<CityStyle> reachableCityStyles,
                                 AssetDiagnostics diagnostics) {
         AssetGraph graph = new AssetGraph(assets, diagnostics);
+        for (CityStyle style : reachableCityStyles) {
+            graph.reachable.put(style.getId(), style);
+        }
         for (WorldStyle style : assets.worldStyles().all()) {
             graph.walkWorldStyle(style);
         }
@@ -111,31 +135,48 @@ public final class AssetGraph {
                 scattered(owner, reference.getName(), "scattered.list");
             }
         }
+        // A road part is placed in whatever chunk the road runs through, so the palette it is drawn
+        // against is that chunk's city style - not the world style's. Pairing with each city style
+        // this world style can select is the precise answer; checking against every reachable style
+        // would report combinations no world can produce, which is the direction that costs someone a
+        // world. The style-less usage is what carries the geometry check when a world style selects
+        // nothing that resolved.
+        List<Style> roadStyles = new ArrayList<>();
+        roadStyles.add(null);
+        for (Pair<Predicate<Holder<Biome>>, Pair<Float, String>> selected : style.cityStyleSelectors()) {
+            CityStyle city = reachable.get(DataTools.fromName(selected.getRight().getRight()));
+            if (city != null) {
+                Style resolved = assets.styles().get(city.getStyle());
+                if (resolved != null) {
+                    roadStyles.add(resolved);
+                }
+            }
+        }
         PartSelector selector = style.getPartSelector();
         HighwayParts highways = selector.highwayParts();
-        parts(owner, highways.tunnel(), "parts.highways.tunnel");
-        parts(owner, highways.open(), "parts.highways.open");
-        parts(owner, highways.bridge(), "parts.highways.bridge");
-        parts(owner, highways.tunnelBi(), "parts.highways.tunnelbi");
-        parts(owner, highways.openBi(), "parts.highways.openbi");
-        parts(owner, highways.bridgeBi(), "parts.highways.bridgebi");
+        roadParts(owner, highways.tunnel(), "parts.highways.tunnel", roadStyles);
+        roadParts(owner, highways.open(), "parts.highways.open", roadStyles);
+        roadParts(owner, highways.bridge(), "parts.highways.bridge", roadStyles);
+        roadParts(owner, highways.tunnelBi(), "parts.highways.tunnelbi", roadStyles);
+        roadParts(owner, highways.openBi(), "parts.highways.openbi", roadStyles);
+        roadParts(owner, highways.bridgeBi(), "parts.highways.bridgebi", roadStyles);
         RailwayParts railways = selector.railwayParts();
-        parts(owner, railways.stationUnderground(), "parts.railways.stationunderground");
-        parts(owner, railways.stationOpen(), "parts.railways.stationopen");
-        parts(owner, railways.stationUndergroundStairs(), "parts.railways.stationundergroundstairs");
-        parts(owner, railways.stationStaircase(), "parts.railways.stationstaircase");
-        parts(owner, railways.stationStaircaseSurface(), "parts.railways.stationstaircasesurface");
-        parts(owner, railways.rails3Split(), "parts.railways.rails3split");
-        parts(owner, railways.railsDown2(), "parts.railways.railsdown2");
-        parts(owner, railways.railsDown1(), "parts.railways.railsdown1");
-        parts(owner, railways.railsBend(), "parts.railways.railsbend");
-        parts(owner, railways.railsFlat(), "parts.railways.railsflat");
-        parts(owner, railways.railsHorizontal(), "parts.railways.railshorizontal");
-        parts(owner, railways.railsHorizontalEnd(), "parts.railways.railshorizontalend");
-        parts(owner, railways.railsHorizontalWater(), "parts.railways.railshorizontalwater");
-        parts(owner, railways.railsVertical(), "parts.railways.railsvertical");
-        parts(owner, railways.railsVerticalWater(), "parts.railways.railsverticalwater");
-        parts(owner, railways.stationOpenRoof(), "parts.railways.stationopenroof");
+        roadParts(owner, railways.stationUnderground(), "parts.railways.stationunderground", roadStyles);
+        roadParts(owner, railways.stationOpen(), "parts.railways.stationopen", roadStyles);
+        roadParts(owner, railways.stationUndergroundStairs(), "parts.railways.stationundergroundstairs", roadStyles);
+        roadParts(owner, railways.stationStaircase(), "parts.railways.stationstaircase", roadStyles);
+        roadParts(owner, railways.stationStaircaseSurface(), "parts.railways.stationstaircasesurface", roadStyles);
+        roadParts(owner, railways.rails3Split(), "parts.railways.rails3split", roadStyles);
+        roadParts(owner, railways.railsDown2(), "parts.railways.railsdown2", roadStyles);
+        roadParts(owner, railways.railsDown1(), "parts.railways.railsdown1", roadStyles);
+        roadParts(owner, railways.railsBend(), "parts.railways.railsbend", roadStyles);
+        roadParts(owner, railways.railsFlat(), "parts.railways.railsflat", roadStyles);
+        roadParts(owner, railways.railsHorizontal(), "parts.railways.railshorizontal", roadStyles);
+        roadParts(owner, railways.railsHorizontalEnd(), "parts.railways.railshorizontalend", roadStyles);
+        roadParts(owner, railways.railsHorizontalWater(), "parts.railways.railshorizontalwater", roadStyles);
+        roadParts(owner, railways.railsVertical(), "parts.railways.railsvertical", roadStyles);
+        roadParts(owner, railways.railsVerticalWater(), "parts.railways.railsverticalwater", roadStyles);
+        roadParts(owner, railways.stationOpenRoof(), "parts.railways.stationopenroof", roadStyles);
     }
 
     private void walkCityStyle(CityStyle style) {
@@ -144,60 +185,87 @@ public final class AssetGraph {
         }
         Identifier owner = style.getId();
         style(owner, style.getStyle(), "style");
+        Style palette = assets.styles().get(style.getStyle());
         for (ObjectSelector selector : style.selectorList(CityStyle.Sel.BUILDING)) {
-            building(owner, selector.value(), "selectors.buildings");
+            building(owner, selector.value(), "selectors.buildings", palette);
         }
         for (ObjectSelector selector : style.selectorList(CityStyle.Sel.MULTI_BUILDING)) {
-            multiBuilding(owner, selector.value(), "selectors.multibuildings");
+            multiBuilding(owner, selector.value(), "selectors.multibuildings", palette);
         }
-        selectorParts(owner, style, CityStyle.Sel.BRIDGE, "selectors.bridges");
-        selectorParts(owner, style, CityStyle.Sel.LARGE_BRIDGE, "selectors.largebridges");
-        selectorParts(owner, style, CityStyle.Sel.PARK, "selectors.parks");
-        selectorParts(owner, style, CityStyle.Sel.FOUNTAIN, "selectors.fountains");
-        selectorParts(owner, style, CityStyle.Sel.STAIR, "selectors.stairs");
-        selectorParts(owner, style, CityStyle.Sel.FRONT, "selectors.fronts");
-        selectorParts(owner, style, CityStyle.Sel.RAIL_DUNGEON, "selectors.raildungeons");
-        streetParts(owner, style.getStreetParts(), "streetblocks.parts");
-        streetParts(owner, style.getLargeStreetParts(), "streetblocks.largeparts");
-        streetParts(owner, style.getTertiaryStreetParts(), "streetblocks.tertiaryparts");
+        selectorParts(owner, style, CityStyle.Sel.BRIDGE, "selectors.bridges", palette);
+        selectorParts(owner, style, CityStyle.Sel.LARGE_BRIDGE, "selectors.largebridges", palette);
+        selectorParts(owner, style, CityStyle.Sel.PARK, "selectors.parks", palette);
+        selectorParts(owner, style, CityStyle.Sel.FOUNTAIN, "selectors.fountains", palette);
+        selectorParts(owner, style, CityStyle.Sel.STAIR, "selectors.stairs", palette);
+        selectorParts(owner, style, CityStyle.Sel.FRONT, "selectors.fronts", palette);
+        selectorParts(owner, style, CityStyle.Sel.RAIL_DUNGEON, "selectors.raildungeons", palette);
+        streetParts(owner, style.getStreetParts(), "streetblocks.parts", palette);
+        streetParts(owner, style.getLargeStreetParts(), "streetblocks.largeparts", palette);
+        streetParts(owner, style.getTertiaryStreetParts(), "streetblocks.tertiaryparts", palette);
     }
 
-    private void selectorParts(Identifier owner, CityStyle style, CityStyle.Sel kind, String field) {
+    private void selectorParts(Identifier owner, CityStyle style, CityStyle.Sel kind, String field,
+                               @Nullable Style palette) {
         for (ObjectSelector selector : style.selectorList(kind)) {
-            part(owner, selector.value(), field);
+            // Not a road: bridges, parks, fountains and the rest are placed inside a chunk at a
+            // computed offset, so their size is theirs to choose.
+            part(owner, selector.value(), field, usage(palette, null, false, field, owner));
         }
     }
 
-    private void streetParts(Identifier owner, @Nullable StreetParts family, String field) {
+    /** One road usage per style the part can be drawn against, so the geometry is checked once. */
+    private void roadParts(Identifier owner, @Nullable List<String> names, String field,
+                           List<Style> roadStyles) {
+        if (names == null) {
+            return;
+        }
+        for (String name : names) {
+            for (Style roadStyle : roadStyles) {
+                part(owner, name, field, new PartUsage(roadStyle, null, true, field, owner));
+            }
+        }
+    }
+
+    private void streetParts(Identifier owner, @Nullable StreetParts family, String field,
+                            @Nullable Style palette) {
         if (family == null) {
             return;
         }
-        parts(owner, family.straight(), field + ".straight");
-        parts(owner, family.end(), field + ".end");
-        parts(owner, family.bend(), field + ".bend");
-        parts(owner, family.t(), field + ".t");
-        parts(owner, family.none(), field + ".none");
-        parts(owner, family.all(), field + ".all");
-        parts(owner, family.connector(), field + ".connector");
-        parts(owner, family.stair(), field + ".stair");
+        roadParts(owner, family.straight(), field + ".straight", java.util.Arrays.asList(null, palette));
+        roadParts(owner, family.end(), field + ".end", java.util.Arrays.asList(null, palette));
+        roadParts(owner, family.bend(), field + ".bend", java.util.Arrays.asList(null, palette));
+        roadParts(owner, family.t(), field + ".t", java.util.Arrays.asList(null, palette));
+        roadParts(owner, family.none(), field + ".none", java.util.Arrays.asList(null, palette));
+        roadParts(owner, family.all(), field + ".all", java.util.Arrays.asList(null, palette));
+        roadParts(owner, family.connector(), field + ".connector", java.util.Arrays.asList(null, palette));
+        roadParts(owner, family.stair(), field + ".stair", java.util.Arrays.asList(null, palette));
     }
 
-    private void walkBuilding(Building building) {
-        if (!first("building", building.getId())) {
+    /**
+     * A building's parts are checked under the style that reached it, so the same building selected by
+     * two city styles is two sets of answers - which is the whole reason a usage exists.
+     * {@link #seen} still gates the <em>reference</em> walk to once per building; the character check
+     * has its own gate on the usage.
+     */
+    private void walkBuilding(Building building, @Nullable Style palette) {
+        // Keyed by the style as well as the building: the same building under two city styles is two
+        // sets of character answers, and both have to be reached. Finite either way, so a cycle still
+        // ends - there are only so many (building, style) pairs.
+        if (!first("building/" + styleKey(palette), building.getId())) {
             return;
         }
         for (String name : building.partNames()) {
-            part(building.getId(), name, "parts");
+            part(building.getId(), name, "parts", usage(palette, building, false, "parts", building.getId()));
         }
     }
 
-    private void walkMultiBuilding(MultiBuilding multi) {
-        if (!first("multibuilding", multi.getId())) {
+    private void walkMultiBuilding(MultiBuilding multi, @Nullable Style palette) {
+        if (!first("multibuilding/" + styleKey(palette), multi.getId())) {
             return;
         }
         if (multi.getBuildingSet() != null) {
             for (String name : multi.getBuildingSet()) {
-                building(multi.getId(), name, "buildings");
+                building(multi.getId(), name, "buildings", palette);
             }
         }
     }
@@ -208,12 +276,14 @@ public final class AssetGraph {
         }
         // Either arm may be absent: a scattered entry declares 'buildings' or 'multibuilding', and
         // the constructor requires one of the two rather than both.
+        // No style: a scattered building lands wherever the terrain allows and takes the style of
+        // the chunk it lands in, which the walk cannot know. Its references are still checked.
         if (scattered.getBuildings() != null) {
             for (String name : scattered.getBuildings()) {
-                building(scattered.getId(), name, "buildings");
+                building(scattered.getId(), name, "buildings", null);
             }
         }
-        multiBuilding(scattered.getId(), scattered.getMultibuilding(), "multibuilding");
+        multiBuilding(scattered.getId(), scattered.getMultibuilding(), "multibuilding", null);
     }
 
     private void walkPredefinedCity(PredefinedCity city) {
@@ -224,35 +294,94 @@ public final class AssetGraph {
             return;
         }
         for (PredefinedBuilding building : city.getPredefinedBuildings()) {
+            // The predefined city names its own city style, and the compiler has already checked that
+            // it resolves; the palette context comes from there when it does.
+            Style palette = paletteOf(city.getCityStyle());
             if (building.multi()) {
-                multiBuilding(city.getId(), building.building(), "buildings");
+                multiBuilding(city.getId(), building.building(), "buildings", palette);
             } else {
-                building(city.getId(), building.building(), "buildings");
+                building(city.getId(), building.building(), "buildings", palette);
             }
         }
     }
 
     // ------------------------------------------------------------------ one reference
 
-    private void parts(Identifier owner, @Nullable List<String> names, String field) {
+    private void parts(Identifier owner, @Nullable List<String> names, String field,
+                       @Nullable PartUsage usage) {
         if (names == null) {
             return;
         }
         for (String name : names) {
-            part(owner, name, field);
+            part(owner, name, field, usage);
         }
     }
 
-    private void part(Identifier owner, @Nullable String name, String field) {
-        resolve(owner, name, field, assets.parts(), this::walkPart);
+    private void part(Identifier owner, @Nullable String name, String field, @Nullable PartUsage usage) {
+        resolve(owner, name, field, assets.parts(), part -> checkPart(part, usage));
     }
 
-    private void building(Identifier owner, @Nullable String name, String field) {
-        resolve(owner, name, field, assets.buildings(), this::walkBuilding);
+    /**
+     * Everything that is a question about a part <em>where it is used</em>, rather than about the
+     * part on its own.
+     *
+     * <p>{@code usage} is null where the walk reached a part without knowing the style it will be
+     * drawn against - today only a scattered building's parts, whose chunk takes its style from the
+     * terrain around it. Those keep the reference check and skip the character check rather than
+     * being checked against a style they might not be used with.</p>
+     */
+    private void checkPart(BuildingPart part, @Nullable PartUsage usage) {
+        if (usage == null || !checkedUsages.add(usage.key(part.getId()))) {
+            return;
+        }
+        if (usage.road()) {
+            checkRoadGeometry(part, usage);
+        }
+        PartPaletteCheck.check(part, usage, diagnostics);
     }
 
-    private void multiBuilding(Identifier owner, @Nullable String name, String field) {
-        resolve(owner, name, field, assets.multiBuildings(), this::walkMultiBuilding);
+    /**
+     * A part wired into a street, highway or railway slot is addressed as a whole chunk, and nothing
+     * clamps it: {@code ChunkDriver.current} converts chunk-local to absolute unchanged and
+     * {@code block()} masks the result with {@code & 0xf}, so a part wider than 16 <strong>wraps
+     * around and overwrites its own beginning</strong> - no exception, nothing in the log, just a
+     * road that comes out wrong. {@code BuildingPart.checkGeometry} proves a part is self-consistent;
+     * this is the separate question of whether it fits where it was wired in.
+     */
+    private void checkRoadGeometry(BuildingPart part, PartUsage usage) {
+        if (part.getXSize() != 16 || part.getZSize() != 16) {
+            diagnostics.record("urbex:parts", part.getId(),
+                    "is wired into '" + usage.owner() + "' (" + usage.field() + ") as a road piece, "
+                            + "which is placed as a whole chunk, but it is " + part.getXSize() + "x"
+                            + part.getZSize() + " rather than 16x16; the driver masks coordinates to "
+                            + "the chunk, so the overflow would silently overwrite the part's own start");
+        }
+    }
+
+    private void building(Identifier owner, @Nullable String name, String field, @Nullable Style palette) {
+        resolve(owner, name, field, assets.buildings(), building -> walkBuilding(building, palette));
+    }
+
+    private void multiBuilding(Identifier owner, @Nullable String name, String field,
+                               @Nullable Style palette) {
+        resolve(owner, name, field, assets.multiBuildings(), multi -> walkMultiBuilding(multi, palette));
+    }
+
+    /** A usage, or null when there is no style to check characters against. */
+    @Nullable
+    private static PartUsage usage(@Nullable Style palette, @Nullable Building building, boolean road,
+                                   String field, Identifier owner) {
+        return palette == null && !road ? null : new PartUsage(palette, building, road, field, owner);
+    }
+
+    /** The style a city style draws from, or null if that reference is the thing that is broken. */
+    @Nullable
+    private Style paletteOf(@Nullable String cityStyleName) {
+        if (cityStyleName == null) {
+            return null;
+        }
+        CityStyle city = reachable.get(DataTools.fromName(cityStyleName));
+        return city == null ? null : assets.styles().get(city.getStyle());
     }
 
     private void scattered(Identifier owner, @Nullable String name, String field) {
@@ -284,14 +413,20 @@ public final class AssetGraph {
         try {
             id = DataTools.fromName(name);
         } catch (RuntimeException e) {
-            diagnostics.record(index.registry(), owner,
-                    "'" + field + "' names '" + name + "', which is not a valid asset id: " + e.getMessage());
+            if (reported.add(index.registry() + "|" + owner + "|" + field + "|" + name)) {
+                diagnostics.record(index.registry(), owner,
+                        "'" + field + "' names '" + name + "', which is not a valid asset id: " + e.getMessage());
+            }
             return;
         }
         T found = index.get(id);
         if (found == null) {
-            diagnostics.record(index.registry(), owner,
-                    "'" + field + "' names '" + name + "', which no loaded datapack registers");
+            // Deduped on the reference itself, not on the walk: the same bad name reached by four
+            // paths is one thing to fix, and the walk now visits a building once per style.
+            if (reported.add(index.registry() + "|" + owner + "|" + field + "|" + name)) {
+                diagnostics.record(index.registry(), owner,
+                        "'" + field + "' names '" + name + "', which no loaded datapack registers");
+            }
             return;
         }
         pending.add(() -> walk.accept(found));
@@ -300,5 +435,9 @@ public final class AssetGraph {
     /** True the first time this asset is reached, so a diamond costs one visit and a cycle ends. */
     private boolean first(String kind, Identifier id) {
         return seen.add(kind + "/" + id);
+    }
+
+    private static String styleKey(@Nullable Style palette) {
+        return palette == null ? "-" : palette.getId().toString();
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PartPaletteCheck.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PartPaletteCheck.java
@@ -1,0 +1,169 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import net.minecraft.resources.Identifier;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Whether the characters a part's slices use will resolve where the part is used.
+ *
+ * <p>A missing character is {@code "Could not find entry 'x' in the palette for part 'y'!"} thrown
+ * from a worldgen worker, on the first chunk that places the part - which for a rarely-selected
+ * building can be a long way into a world (issue #56).</p>
+ *
+ * <h2>The palette is built, not guessed</h2>
+ *
+ * <p>Every candidate merge is assembled with {@link CompiledPalette}'s own constructor, in the same
+ * order {@code CityGenerator.computePalette} uses: style palette, then the building's, then the
+ * part's. Reimplementing the merge would mean two definitions of what a character resolves to, and
+ * the validator's would be the one that drifts - which is precisely the "guesses at the merge"
+ * failure the sequencing note on #56 warned about.</p>
+ *
+ * <h2>Two answers, because there are two defects</h2>
+ *
+ * <p>A style's palette is <em>one choice per {@code randompalettes} group</em>, so a part has as many
+ * possible palettes as the product of the group sizes. Checking one arbitrary selection would pass
+ * characters that only some worlds get; enumerating the product is exponential and unnecessary:</p>
+ *
+ * <ul>
+ *   <li><strong>Undefined everywhere</strong> - not present even when every choice of every group is
+ *       merged in at once. No selection can place it, so this is a load error.</li>
+ *   <li><strong>Undefined in some selections</strong> - present in that everything-merge, but not
+ *       guaranteed: some worlds get it and some do not. Reported as a warning rather than a refusal,
+ *       because packs that ship this generate correctly most of the time today and refusing them
+ *       would be this check inventing a rule rather than reporting a break.</li>
+ * </ul>
+ *
+ * <p>The second answer is found by <strong>constructing a witness</strong> rather than by reasoning
+ * about which palette defines what. For each group and each choice in it, the character is looked up
+ * in the merge of that one choice with <em>every</em> choice of every other group. If it is missing
+ * even there, then it is missing for every selection that picks that choice - the other groups were
+ * given more than any real selection would - so a failing selection provably exists. Nothing is
+ * reported without one, so the warning cannot fire on a pack that always works.</p>
+ *
+ * <p>That construction is not an optimisation, it is the correctness fix. Testing a choice on its own
+ * instead reports every {@code frompalette} that points at a character another group supplies -
+ * {@code urbex:glass_side_variant_glass} maps {@code '@'} to {@code 'a'} and nothing else - which is
+ * the shipped pack's own idiom, and made this check produce 45 warnings about a pack that is
+ * correct.</p>
+ */
+final class PartPaletteCheck {
+
+    private PartPaletteCheck() {
+    }
+
+    static void check(BuildingPart part, PartUsage usage, AssetDiagnostics diagnostics) {
+        if (usage.style() == null) {
+            return;
+        }
+        SortedSet<Character> used = charactersUsedBy(part);
+        if (used.isEmpty()) {
+            return;
+        }
+        List<List<Pair<Float, Palette>>> groups = usage.style().paletteChoices();
+        Palette local = part.getLocalPalette();
+        Palette building = usage.building() == null ? null : usage.building().getLocalPalette();
+
+        CompiledPalette everything = merge(groups.stream().flatMap(List::stream)
+                .map(Pair::getRight).toList(), building, local);
+
+        SortedSet<Character> never = new TreeSet<>();
+        SortedSet<Character> sometimes = new TreeSet<>();
+        for (char c : used) {
+            if (!everything.isDefined(c)) {
+                never.add(c);
+            } else if (hasFailingSelection(c, groups, building, local)) {
+                sometimes.add(c);
+            }
+        }
+
+        if (!never.isEmpty()) {
+            diagnostics.record("urbex:parts", part.getId(), describe(usage)
+                    + " uses character(s) " + quote(never)
+                    + " that no palette there defines, so generating it would fail on the first chunk "
+                    + "that places it");
+        }
+        if (!sometimes.isEmpty()) {
+            diagnostics.warn("urbex:parts", part.getId(), describe(usage)
+                    + " uses character(s) " + quote(sometimes)
+                    + " that only some 'randompalettes' choices of '" + usage.style().getName()
+                    + "' define, so whether this part generates depends on the draw");
+        }
+    }
+
+    /**
+     * The merge the generator would build, in the generator's order: the style's palettes first, then
+     * the building's, then the part's, so a part's own entry wins over what it is placed into.
+     */
+    private static CompiledPalette merge(List<Palette> stylePalettes, @Nullable Palette building,
+                                         @Nullable Palette part) {
+        List<Palette> all = new ArrayList<>(stylePalettes);
+        if (building != null) {
+            all.add(building);
+        }
+        if (part != null) {
+            all.add(part);
+        }
+        return new CompiledPalette(all.toArray(new Palette[0]));
+    }
+
+    /**
+     * Whether some selection provably fails to define {@code c}.
+     *
+     * <p>The witness is one choice plus everything every other group offers. That is more than any
+     * real selection gets, so a character missing from it is missing from every selection containing
+     * that choice - which makes this sound in the only direction that matters: nothing is reported
+     * without a selection that really breaks.</p>
+     */
+    private static boolean hasFailingSelection(char c, List<List<Pair<Float, Palette>>> groups,
+                                               @Nullable Palette building, @Nullable Palette part) {
+        for (int g = 0; g < groups.size(); g++) {
+            for (Pair<Float, Palette> choice : groups.get(g)) {
+                List<Palette> witness = new ArrayList<>();
+                for (int other = 0; other < groups.size(); other++) {
+                    if (other == g) {
+                        witness.add(choice.getRight());
+                    } else {
+                        groups.get(other).forEach(alternative -> witness.add(alternative.getRight()));
+                    }
+                }
+                if (!merge(witness, building, part).isDefined(c)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static SortedSet<Character> charactersUsedBy(BuildingPart part) {
+        SortedSet<Character> used = new TreeSet<>();
+        for (char[] slice : part.getVslices()) {
+            if (slice == null) {
+                continue;
+            }
+            for (char c : slice) {
+                used.add(c);
+            }
+        }
+        return used;
+    }
+
+    private static String describe(PartUsage usage) {
+        return "as used by '" + usage.owner() + "' (" + usage.field() + ")"
+                + (usage.building() == null ? "" : " inside building '" + usage.building().getName() + "'")
+                + " under style '" + usage.style().getName() + "', this part";
+    }
+
+    private static String quote(SortedSet<Character> characters) {
+        List<String> quoted = new ArrayList<>(characters.size());
+        for (char c : characters) {
+            quoted.add("'" + c + "'");
+        }
+        return String.join(", ", quoted);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PartUsage.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PartUsage.java
@@ -1,0 +1,42 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import net.minecraft.resources.Identifier;
+
+import javax.annotation.Nullable;
+
+/**
+ * One way a part is used: the style whose palette it will be drawn against, the building it sits in
+ * if any, and whether it is placed as a chunk-sized road piece.
+ *
+ * <p>A part's characters do not resolve against the part's own palette. They resolve against the
+ * merge {@code CityGenerator.computePalette} performs - the chunk's style palette, the building's
+ * local palette if there is one, and the part's own on top - so "is this character defined" is a
+ * question about a <em>usage</em>, not about a part. The same part reached from two city styles is
+ * two questions, and a part that is fine in one may be broken in the other (issue #56).</p>
+ *
+ * <p>That is why the sequencing note on #56 said this had to wait for #128. It does not any more, and
+ * not because the merge moved: it is because every input to the merge is now fixed snapshot data, so
+ * this can build the <em>exact</em> palette generation will build rather than approximating one.</p>
+ *
+ * @param style     the style whose {@code randompalettes} the chunk will draw from, or null where
+ *                  the walk reached the part without knowing one - a road part is placed in
+ *                  whatever chunk the road runs through, so it is paired with each city style its
+ *                  world style can select, and reached once more with no style at all so its
+ *                  geometry is checked even by a world style that selects none
+ * @param building  the building the part sits in, or null for a road, highway, railway or scattered
+ *                  placement - which have no building palette layer
+ * @param road      true when the part is wired into a street, highway or railway slot, where the
+ *                  generator addresses it as a whole chunk. See
+ *                  {@link AssetGraph} for what that costs a part of the wrong size.
+ * @param field     where the reference was written, for the message
+ * @param owner     the asset that wired this part in, for the message
+ */
+record PartUsage(@Nullable Style style, @Nullable Building building, boolean road, String field,
+                 Identifier owner) {
+
+    /** Identity for de-duplication: the same part under the same style and building is one question. */
+    String key(Identifier part) {
+        return part + "|" + (style == null ? "-" : style.getId())
+                + "|" + (building == null ? "-" : building.getId()) + "|" + road;
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraphTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraphTest.java
@@ -1,12 +1,15 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.worldgen.lost.regassets.BuildingDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
+import dev.krona.urbex.worldgen.lost.regassets.data.StreetParts;
+import dev.krona.urbex.worldgen.lost.regassets.data.StreetSettings;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
@@ -149,6 +152,42 @@ class AssetGraphTest {
         assertEquals(1, diagnostics.size(), () -> diagnostics.format(""));
     }
 
+    /**
+     * A street, highway or railway part is addressed as a whole chunk and nothing clamps it:
+     * {@code ChunkDriver.current} converts chunk-local to absolute unchanged, and {@code block()}
+     * masks the result with {@code & 0xf}. A part wider than 16 therefore wraps round and overwrites
+     * its own beginning - no exception, nothing in the log, just a road that comes out wrong.
+     * {@code BuildingPart.checkGeometry} proves a part is self-consistent; this is the separate
+     * question of whether it fits the slot it was wired into.
+     */
+    @Test
+    void aRoadPartThatIsNotChunkSizedIsALoadError() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture().part("too_wide", 24, 16);
+
+        AssetGraph.validate(fixture.snapshot(), List.of(fixture.cityStyleWiring("urbex:too_wide")),
+                diagnostics);
+
+        assertTrue(diagnostics.hasFatal(), () -> diagnostics.format("expected a refusal"));
+        String message = diagnostics.problems().getFirst().message();
+        assertTrue(message.contains("24x16"), message);
+        assertTrue(message.contains("16x16"), message);
+    }
+
+    /** A building part is placed at a computed offset inside a chunk, so its size is its own business. */
+    @Test
+    void aBuildingPartThatIsNotChunkSizedIsFine() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture()
+                .part("narrow", 4, 4)
+                .building("tower", "urbex:narrow")
+                .city("downtown", building("urbex:tower"));
+
+        AssetGraph.validate(fixture.snapshot(), List.of(), diagnostics);
+
+        assertTrue(diagnostics.isEmpty(), () -> diagnostics.format(""));
+    }
+
     // ------------------------------------------------------------------ fixtures
 
     private static PredefinedBuilding building(String name) {
@@ -165,6 +204,7 @@ class AssetGraphTest {
         private final Map<Identifier, Building> buildings = new HashMap<>();
         private final Map<Identifier, MultiBuilding> multiBuildings = new HashMap<>();
         private final Map<Identifier, PredefinedCity> cities = new HashMap<>();
+        private final Map<Identifier, BuildingPart> extraParts = new HashMap<>();
 
         Fixture building(String path, String partName) {
             PartRef ref = new PartRef(partName, Optional.empty(), Optional.empty(), Optional.empty(),
@@ -188,6 +228,37 @@ class AssetGraphTest {
             return this;
         }
 
+        /** A part of an explicit size, for the road-geometry check. */
+        Fixture part(String path, int xSize, int zSize) {
+            Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+            List<List<String>> slices = List.of(List.of("a".repeat(xSize * zSize)));
+            extraParts.put(id, new BuildingPart(id, BuiltInRegistries.BLOCK, null,
+                    AssetIndex.empty("urbex:palettes"), List.of(new BuildingPartDefinition(
+                    Optional.empty(), Optional.of(xSize), Optional.of(zSize), Optional.of(slices),
+                    Optional.empty(), Optional.empty(), Optional.empty()))));
+            return this;
+        }
+
+        /**
+         * A city style whose whole street family is one part, so the walk reaches it as a road. It
+         * declares no {@code style}, which leaves the character check without a palette context and
+         * the geometry check as the only thing this asserts.
+         */
+        CityStyle cityStyleWiring(String partName) {
+            Optional<Mergeable<String>> one = Optional.of(new Mergeable<>(true, List.of(partName)));
+            StreetParts.Decl family = new StreetParts.Decl(one, one, one, one, one, one, one, one);
+            return new CityStyle(Identifier.fromNamespaceAndPath("urbex", "citystyle_roads"),
+                    List.of(new CityStyleDefinition(
+                            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                            Optional.empty(), Optional.empty(),
+                            Optional.of(new StreetSettings(Optional.empty(), Optional.empty(),
+                                    Optional.empty(), Optional.empty(), Optional.empty(),
+                                    Optional.empty(), Optional.empty(), Optional.empty(),
+                                    Optional.of(family), Optional.empty(), Optional.empty())),
+                            Optional.empty())));
+        }
+
         Fixture city(String path, PredefinedBuilding... contents) {
             Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
             cities.put(id, new PredefinedCity(id, List.of(new PredefinedCityDefinition(
@@ -207,6 +278,7 @@ class AssetGraphTest {
                     Optional.empty(), Optional.of(1), Optional.of(1),
                     Optional.of(List.of(List.of("a"))), Optional.empty(), Optional.empty(),
                     Optional.empty()))));
+            parts.putAll(extraParts);
             return new AssetSnapshot(empty.variants(), empty.palettes(), empty.conditions(),
                     empty.styles(), new AssetIndex<>("urbex:parts", parts),
                     new AssetIndex<>("urbex:buildings", buildings),

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PartPaletteCheckTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PartPaletteCheckTest.java
@@ -1,0 +1,187 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.StyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
+import dev.krona.urbex.worldgen.lost.regassets.data.PaletteSelector;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Whether a part's slice characters resolve where the part is used (issue #56).
+ * <p>
+ * A character that resolves to nothing is {@code "Could not find entry 'x' in the palette for part
+ * 'y'!"} thrown from a worldgen worker, on the first chunk that places the part.
+ * <p>
+ * The hard part is not finding an undefined character; it is not reporting a defined one. A style's
+ * palette is one choice per {@code randompalettes} group, and palettes cross-reference each other
+ * with {@code frompalette}, so the naive test - does this one choice define the character - flags the
+ * shipped pack's own idiom. It did: {@code urbex:glass_side_variant_glass} maps {@code '@'} to
+ * {@code 'a'} and nothing else, and the first version of this check produced 45 warnings about a pack
+ * that is correct. {@link #aCharacterReachedThroughAnotherGroupsPaletteIsNotReported} is that bug.
+ */
+class PartPaletteCheckTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void aCharacterNoPaletteDefinesIsALoadError() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Style style = style(group(palette("base", entry('a', "minecraft:stone"))));
+
+        PartPaletteCheck.check(part("tower", "ab"), usage(style), diagnostics);
+
+        assertEquals(1, diagnostics.size(), () -> diagnostics.format(""));
+        assertTrue(diagnostics.hasFatal(), "no selection can place it, so the world must not load");
+        assertTrue(diagnostics.problems().getFirst().message().contains("'b'"),
+                diagnostics.problems().getFirst().message());
+    }
+
+    @Test
+    void aCharacterEveryChoiceDefinesIsNotReported() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Style style = style(group(
+                palette("light", entry('a', "minecraft:stone")),
+                palette("dark", entry('a', "minecraft:deepslate"))));
+
+        PartPaletteCheck.check(part("tower", "aa"), usage(style), diagnostics);
+
+        assertTrue(diagnostics.isEmpty(), () -> diagnostics.format(""));
+    }
+
+    /**
+     * The defect that is real but not fatal: the character exists, so some worlds place the part and
+     * some crash on it. Refusing the world would make packs that mostly work stop loading, which is
+     * this check inventing a rule rather than reporting a break - so it is a warning, and the world
+     * still loads.
+     */
+    @Test
+    void aCharacterOnlySomeChoicesDefineIsAWarningRatherThanARefusal() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Style style = style(group(
+                palette("rich", entry('a', "minecraft:stone"), entry('b', "minecraft:glass")),
+                palette("plain", entry('a', "minecraft:stone"))));
+
+        PartPaletteCheck.check(part("tower", "ab"), usage(style), diagnostics);
+
+        assertEquals(1, diagnostics.size(), () -> diagnostics.format(""));
+        assertFalse(diagnostics.hasFatal(), "the world still loads: most draws place this part fine");
+        assertTrue(diagnostics.problems().getFirst().message().contains("'b'"),
+                diagnostics.problems().getFirst().message());
+    }
+
+    /**
+     * The shipped pack's idiom, and the bug this check had first. {@code '@'} is defined only as
+     * "whatever {@code 'a'} is", and {@code 'a'} comes from a different {@code randompalettes} group -
+     * so testing a choice in isolation says undefined, while every real selection resolves it.
+     */
+    @Test
+    void aCharacterReachedThroughAnotherGroupsPaletteIsNotReported() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Style style = style(
+                group(palette("blocks", entry('a', "minecraft:stone"))),
+                group(palette("aliases", fromPalette('@', 'a'))));
+
+        PartPaletteCheck.check(part("tower", "@@"), usage(style), diagnostics);
+
+        assertTrue(diagnostics.isEmpty(),
+                () -> "every selection resolves '@' through the other group: " + diagnostics.format(""));
+    }
+
+    /** A part's own palette wins over the style's, so a character it defines is always available. */
+    @Test
+    void aCharacterThePartDefinesItselfIsNotReported() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Style style = style(group(palette("base", entry('a', "minecraft:stone"))));
+
+        PartPaletteCheck.check(partWithPalette("tower", "ab", entry('b', "minecraft:glass")),
+                usage(style), diagnostics);
+
+        assertTrue(diagnostics.isEmpty(), () -> diagnostics.format(""));
+    }
+
+    // ------------------------------------------------------------------ fixtures
+
+    private static PartUsage usage(Style style) {
+        return new PartUsage(style, null, false, "parts", Identifier.fromNamespaceAndPath("urbex", "owner"));
+    }
+
+    private static BuildingPart part(String path, String slice) {
+        return buildPart(path, slice, Optional.empty());
+    }
+
+    private static BuildingPart partWithPalette(String path, String slice, PaletteEntry... entries) {
+        return buildPart(path, slice, Optional.of(
+                new PaletteDefinition(Optional.empty(), Optional.of(List.of(entries)))));
+    }
+
+    /** A 1x{@code slice.length()} part, so the slice string is the character list under test. */
+    private static BuildingPart buildPart(String path, String slice, Optional<PaletteDefinition> local) {
+        Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+        return new BuildingPart(id, BuiltInRegistries.BLOCK, null, AssetIndex.empty("urbex:palettes"),
+                List.of(new BuildingPartDefinition(Optional.empty(), Optional.of(1), Optional.of(1),
+                        Optional.of(List.of(List.of(slice.substring(0, 1)), List.of(slice.substring(1)))),
+                        Optional.empty(), local, Optional.empty())));
+    }
+
+    @SafeVarargs
+    private static Style style(List<PaletteSelector>... groups) {
+        Map<Identifier, Palette> byId = new HashMap<>();
+        for (List<PaletteSelector> group : groups) {
+            for (PaletteSelector selector : group) {
+                Identifier id = Identifier.parse(selector.palette());
+                byId.put(id, PALETTES.get(id));
+            }
+        }
+        return new Style(Identifier.fromNamespaceAndPath("urbex", "test_style"),
+                new AssetIndex<>("urbex:palettes", byId),
+                List.of(new StyleDefinition(Optional.empty(),
+                        Optional.of(new Mergeable<>(true, List.of(groups))))));
+    }
+
+    private static final Map<Identifier, Palette> PALETTES = new HashMap<>();
+
+    private static List<PaletteSelector> group(String... palettes) {
+        return List.of(palettes).stream().map(p -> new PaletteSelector(1.0f, p)).toList();
+    }
+
+    /** Registers a palette and returns its id, so {@link #group} can name it. */
+    private static String palette(String path, PaletteEntry... entries) {
+        Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+        PALETTES.put(id, new Palette(id, BuiltInRegistries.BLOCK, null,
+                List.of(new PaletteDefinition(Optional.empty(), Optional.of(List.of(entries))))));
+        return id.toString();
+    }
+
+    private static PaletteEntry entry(char marker, String block) {
+        return new PaletteEntry(Character.toString(marker), Optional.of(block),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    private static PaletteEntry fromPalette(char marker, char target) {
+        return new PaletteEntry(Character.toString(marker), Optional.empty(),
+                Optional.empty(), Optional.of(Character.toString(target)), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty());
+    }
+}


### PR DESCRIPTION
**56b** of #56 — palette characters and road part sizes. Completes the walk started in #149.
Design: [`docs/superpowers/specs/2026-08-12-reachable-graph-validation.md`](docs/superpowers/specs/2026-08-12-reachable-graph-validation.md).

> Stacked on #149. This diff is against it.

## What was wrong

Two more failures that arrived from a worldgen worker on the first chunk that placed a part:

1. `"Could not find entry 'x' in the palette for part 'y'!"` — a slice character nothing resolves.
2. Nothing at all: a street, highway or railway part wider than 16 **wraps round and overwrites its
   own beginning**. `ChunkDriver.current` converts chunk-local to absolute unchanged and `block()`
   masks the result with `& 0xf`. No exception, nothing in the log, just a road that comes out wrong.

## Characters are a question about a *usage*

A part's characters do not resolve against the part's own palette. They resolve against the merge
`CityGenerator.computePalette` performs — the chunk's style palette, the building's, the part's on top
— so the same part reached from two city styles is two questions with two answers. #149's walk already
enumerates those pairings; `PartUsage` names one and `PartPaletteCheck` answers it.

The merge is built with `CompiledPalette`'s **own constructor**, in the generator's order. Reimplementing
it would mean two definitions of what a character resolves to, and the validator's would be the one
that drifts — which is exactly the "guesses at the merge" failure the sequencing note on #56 warned
about.

**Fatal vs warning.** A character no palette defines refuses the world. A character only *some*
`randompalettes` choices define is a warning — those packs generate correctly most of the time, and
refusing them would be this check inventing a rule rather than reporting a break. `AssetDiagnostics`
grows that distinction and `throwIfAny` now speaks only for the fatal half.

## The part worth reviewing: my first version of this was wrong

The spec said a character is guaranteed if every choice in some group defines it. I implemented that,
and **the digest run reported 45 warnings about a pack that is correct**.

The reason is the shipped pack's own idiom: `urbex:glass_side_variant_glass` is

```json
{ "palette": [ { "char": "@", "frompalette": "a" } ] }
```

`'@'` is defined only as "whatever `'a'` is", and `'a'` comes from a *different* `randompalettes`
group. Testing a choice in isolation can never see it.

The fix is to **construct a witness** rather than reason about which palette defines what: for each
choice, look the character up in the merge of that one choice with *every* choice of every other
group. If it is missing even there — where the other groups were given more than any real selection
gets — then it is missing for every selection containing that choice, so a failing selection provably
exists. Nothing is reported without one.

The shipped pack now reports **zero**, and `aCharacterReachedThroughAnotherGroupsPaletteIsNotReported`
pins the case that caught it.

## What is deliberately not covered

Recorded in the spec rather than half-done:

- **Condition references** (`inpart`/`belowpart`/`inbuilding`). `Condition` consumes them into a
  `Predicate<ConditionContext>` at construction and keeps no strings — reaching them is a change to a
  compiled asset, not to the walk.
- **A city style's own character fields** (`streetblock`, `grassblock`, and seven others). Same
  machinery, but they are not reached through a part, so they need their own usage.
- **Scattered parts' characters.** A scattered building takes the style of whatever chunk it lands in,
  which the walk cannot know. Its references are checked; its characters are not — better than
  checking it against a style it may never be used with.

## Verification

```
./gradlew clean build      # pass, 562 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK, 0 problems
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK, 0 problems
```

**Both goldens unchanged, and the bundled pack reports nothing** — which after the 45-warning draft is
the number that matters.
