### PR TITLE
feat: check a city style's own palette characters (#56, 56c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   - *A character no palette defines refuses the world.* A character only some `randompalettes` choices
     define is a warning instead: those packs generate correctly most of the time, and refusing them
     would be inventing a rule rather than reporting a break.
+  - *A city style's own character fields are checked too* — all fourteen of `streetblock`,
+    `grassblock`, `railmainblock` and the rest — and the message names the field the character was
+    written in.
   - *A street, highway or railway part that is not 16×16 refuses the world.* The driver masks
     coordinates to the chunk, so an oversized road part wrapped round and overwrote its own beginning
     — silently, with no exception and nothing in the log.

--- a/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
+++ b/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
@@ -132,14 +132,14 @@ other group. Missing even there means missing for every selection containing tha
 selection provably exists. Sound in the only direction that matters - nothing is reported without a
 selection that really breaks - and the shipped pack now reports zero.
 
-*Still not covered*, and neither belongs in this pass:
+**56c — a city style's own character fields.** All fourteen of them, through the same core the part
+check uses, which is why {@code PartPaletteCheck} became `PaletteCharacterCheck`.
+
+*Still not covered:*
 
 - **Condition references** (`inpart`/`belowpart`/`inbuilding`). `Condition` consumes them into a
   `Predicate<ConditionContext>` at construction and does not retain the strings, so reaching them
   means changing that class - a change to a compiled asset, not to the walk.
-- **A city style's character fields** (`streetblock`, `grassblock`, and the seven others). They resolve
-  against the chunk's palette like a part's characters do, but they are not reached through a part, so
-  they need their own usage - the same machinery, a separate pass.
 - **Scattered parts' characters.** A scattered building lands wherever the terrain allows and takes the
   style of the chunk it lands in, which the walk cannot know. Its references are checked; its
   characters are not.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
@@ -186,6 +186,9 @@ public final class AssetGraph {
         Identifier owner = style.getId();
         style(owner, style.getStyle(), "style");
         Style palette = assets.styles().get(style.getStyle());
+        if (palette != null) {
+            PaletteCharacterCheck.checkCityStyle(style, palette, diagnostics);
+        }
         for (ObjectSelector selector : style.selectorList(CityStyle.Sel.BUILDING)) {
             building(owner, selector.value(), "selectors.buildings", palette);
         }
@@ -337,7 +340,7 @@ public final class AssetGraph {
         if (usage.road()) {
             checkRoadGeometry(part, usage);
         }
-        PartPaletteCheck.check(part, usage, diagnostics);
+        PaletteCharacterCheck.check(part, usage, diagnostics);
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCharacterCheck.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCharacterCheck.java
@@ -5,7 +5,9 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -52,23 +54,76 @@ import java.util.TreeSet;
  * the shipped pack's own idiom, and made this check produce 45 warnings about a pack that is
  * correct.</p>
  */
-final class PartPaletteCheck {
+final class PaletteCharacterCheck {
 
-    private PartPaletteCheck() {
+    private PaletteCharacterCheck() {
     }
 
     static void check(BuildingPart part, PartUsage usage, AssetDiagnostics diagnostics) {
         if (usage.style() == null) {
             return;
         }
-        SortedSet<Character> used = charactersUsedBy(part);
+        check("urbex:parts", part.getId(), charactersUsedBy(part), usage.style(),
+                usage.building() == null ? null : usage.building().getLocalPalette(),
+                part.getLocalPalette(), describe(usage) + " uses", diagnostics);
+    }
+
+    /**
+     * A city style's own character fields - {@code streetblock}, {@code grassblock} and the rest.
+     * <p>
+     * They are the same question as a part's characters and were the same crash, from a different
+     * line: the generator resolves them against the chunk's palette too. There is no part or building
+     * layer here, because these are placed on the street rather than inside anything.
+     */
+    static void checkCityStyle(CityStyle cityStyle, Style style, AssetDiagnostics diagnostics) {
+        Map<Character, List<String>> fields = new LinkedHashMap<>();
+        declare(fields, "streetblock", cityStyle.getStreetBlock());
+        declare(fields, "streetbaseblock", cityStyle.getStreetBaseBlock());
+        declare(fields, "streetvariantblock", cityStyle.getStreetVariantBlock());
+        declare(fields, "borderblock", cityStyle.getBorderBlock());
+        declare(fields, "wallblock", cityStyle.getWallBlock());
+        declare(fields, "railmainblock", cityStyle.getRailMainBlock());
+        declare(fields, "grassblock", cityStyle.getGrassBlock());
+        declare(fields, "ironbarsblock", cityStyle.getIronbarsBlock());
+        declare(fields, "glowstoneblock", cityStyle.getGlowstoneBlock());
+        declare(fields, "leavesblock", cityStyle.getLeavesBlock());
+        declare(fields, "rubbledirtblock", cityStyle.getRubbleDirtBlock());
+        declare(fields, "parkelevationblock", cityStyle.getParkElevationBlock());
+        declare(fields, "corridorroofblock", cityStyle.getCorridorRoofBlock());
+        declare(fields, "corridorglassblock", cityStyle.getCorridorGlassBlock());
+        if (fields.isEmpty()) {
+            return;
+        }
+        namedFields = fields;
+        try {
+            check("urbex:citystyles", cityStyle.getId(), new TreeSet<>(fields.keySet()), style,
+                    null, null, "declares", diagnostics);
+        } finally {
+            namedFields = null;
+        }
+    }
+
+    private static void declare(Map<Character, List<String>> fields, String name, @Nullable Character c) {
+        if (c != null) {
+            fields.computeIfAbsent(c, key -> new ArrayList<>()).add(name);
+        }
+    }
+
+    /**
+     * Which field each character came from, for the message, while a city style is being checked.
+     * A thread local is not needed - compilation is single-threaded - and threading it through every
+     * signature would put a parameter on the part path that only the city-style path ever reads.
+     */
+    @Nullable
+    private static Map<Character, List<String>> namedFields;
+
+    private static void check(String registry, Identifier asset, SortedSet<Character> used, Style style,
+                              @Nullable Palette building, @Nullable Palette local, String verb,
+                              AssetDiagnostics diagnostics) {
         if (used.isEmpty()) {
             return;
         }
-        List<List<Pair<Float, Palette>>> groups = usage.style().paletteChoices();
-        Palette local = part.getLocalPalette();
-        Palette building = usage.building() == null ? null : usage.building().getLocalPalette();
-
+        List<List<Pair<Float, Palette>>> groups = style.paletteChoices();
         CompiledPalette everything = merge(groups.stream().flatMap(List::stream)
                 .map(Pair::getRight).toList(), building, local);
 
@@ -83,16 +138,14 @@ final class PartPaletteCheck {
         }
 
         if (!never.isEmpty()) {
-            diagnostics.record("urbex:parts", part.getId(), describe(usage)
-                    + " uses character(s) " + quote(never)
-                    + " that no palette there defines, so generating it would fail on the first chunk "
-                    + "that places it");
+            diagnostics.record(registry, asset, verb + " character(s) " + quote(never)
+                    + " that no palette there defines, so generating would fail on the first chunk "
+                    + "that needs one");
         }
         if (!sometimes.isEmpty()) {
-            diagnostics.warn("urbex:parts", part.getId(), describe(usage)
-                    + " uses character(s) " + quote(sometimes)
-                    + " that only some 'randompalettes' choices of '" + usage.style().getName()
-                    + "' define, so whether this part generates depends on the draw");
+            diagnostics.warn(registry, asset, verb + " character(s) " + quote(sometimes)
+                    + " that only some 'randompalettes' choices of '" + style.getName()
+                    + "' define, so whether it generates depends on the draw");
         }
     }
 
@@ -159,10 +212,13 @@ final class PartPaletteCheck {
                 + " under style '" + usage.style().getName() + "', this part";
     }
 
+    /** Quotes each character, naming the field it was written in when there is one. */
     private static String quote(SortedSet<Character> characters) {
+        Map<Character, List<String>> fields = namedFields;
         List<String> quoted = new ArrayList<>(characters.size());
         for (char c : characters) {
-            quoted.add("'" + c + "'");
+            List<String> names = fields == null ? null : fields.get(c);
+            quoted.add("'" + c + "'" + (names == null ? "" : " (" + String.join(", ", names) + ")"));
         }
         return String.join(", ", quoted);
     }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCharacterCheckTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCharacterCheckTest.java
@@ -1,11 +1,14 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.StyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
 import dev.krona.urbex.worldgen.lost.regassets.data.PaletteSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.StreetSettings;
+import dev.krona.urbex.worldgen.lost.regassets.data.TestWiring;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
@@ -35,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code 'a'} and nothing else, and the first version of this check produced 45 warnings about a pack
  * that is correct. {@link #aCharacterReachedThroughAnotherGroupsPaletteIsNotReported} is that bug.
  */
-class PartPaletteCheckTest {
+class PaletteCharacterCheckTest {
 
     @BeforeAll
     static void bootstrap() {
@@ -48,7 +51,7 @@ class PartPaletteCheckTest {
         AssetDiagnostics diagnostics = new AssetDiagnostics();
         Style style = style(group(palette("base", entry('a', "minecraft:stone"))));
 
-        PartPaletteCheck.check(part("tower", "ab"), usage(style), diagnostics);
+        PaletteCharacterCheck.check(part("tower", "ab"), usage(style), diagnostics);
 
         assertEquals(1, diagnostics.size(), () -> diagnostics.format(""));
         assertTrue(diagnostics.hasFatal(), "no selection can place it, so the world must not load");
@@ -63,7 +66,7 @@ class PartPaletteCheckTest {
                 palette("light", entry('a', "minecraft:stone")),
                 palette("dark", entry('a', "minecraft:deepslate"))));
 
-        PartPaletteCheck.check(part("tower", "aa"), usage(style), diagnostics);
+        PaletteCharacterCheck.check(part("tower", "aa"), usage(style), diagnostics);
 
         assertTrue(diagnostics.isEmpty(), () -> diagnostics.format(""));
     }
@@ -81,7 +84,7 @@ class PartPaletteCheckTest {
                 palette("rich", entry('a', "minecraft:stone"), entry('b', "minecraft:glass")),
                 palette("plain", entry('a', "minecraft:stone"))));
 
-        PartPaletteCheck.check(part("tower", "ab"), usage(style), diagnostics);
+        PaletteCharacterCheck.check(part("tower", "ab"), usage(style), diagnostics);
 
         assertEquals(1, diagnostics.size(), () -> diagnostics.format(""));
         assertFalse(diagnostics.hasFatal(), "the world still loads: most draws place this part fine");
@@ -101,7 +104,7 @@ class PartPaletteCheckTest {
                 group(palette("blocks", entry('a', "minecraft:stone"))),
                 group(palette("aliases", fromPalette('@', 'a'))));
 
-        PartPaletteCheck.check(part("tower", "@@"), usage(style), diagnostics);
+        PaletteCharacterCheck.check(part("tower", "@@"), usage(style), diagnostics);
 
         assertTrue(diagnostics.isEmpty(),
                 () -> "every selection resolves '@' through the other group: " + diagnostics.format(""));
@@ -113,13 +116,57 @@ class PartPaletteCheckTest {
         AssetDiagnostics diagnostics = new AssetDiagnostics();
         Style style = style(group(palette("base", entry('a', "minecraft:stone"))));
 
-        PartPaletteCheck.check(partWithPalette("tower", "ab", entry('b', "minecraft:glass")),
+        PaletteCharacterCheck.check(partWithPalette("tower", "ab", entry('b', "minecraft:glass")),
                 usage(style), diagnostics);
 
         assertTrue(diagnostics.isEmpty(), () -> diagnostics.format(""));
     }
 
+    /**
+     * A city style's own character fields are the same question from a different line: the generator
+     * resolves {@code streetblock} against the chunk's palette exactly as it resolves a part's slice
+     * characters, and an undefined one was the same crash.
+     */
+    @Test
+    void aCityStyleCharacterNoPaletteDefinesIsALoadErrorNamingTheField() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Style style = style(group(palette("base", entry('a', "minecraft:stone"))));
+
+        PaletteCharacterCheck.checkCityStyle(cityStyle('z'), style, diagnostics);
+
+        assertEquals(1, diagnostics.size(), () -> diagnostics.format(""));
+        assertTrue(diagnostics.hasFatal());
+        String message = diagnostics.problems().getFirst().message();
+        assertTrue(message.contains("'z'"), message);
+        assertTrue(message.contains("streetblock"), () -> "the message has to name the field: " + message);
+    }
+
+    @Test
+    void aCityStyleCharacterThePaletteDefinesIsNotReported() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Style style = style(group(palette("base", entry('a', "minecraft:stone"))));
+
+        PaletteCharacterCheck.checkCityStyle(cityStyle('a'), style, diagnostics);
+
+        assertTrue(diagnostics.isEmpty(), () -> diagnostics.format(""));
+    }
+
     // ------------------------------------------------------------------ fixtures
+
+    /** A city style whose {@code streetblock} is the character under test. */
+    private static CityStyle cityStyle(char streetBlock) {
+        return new CityStyle(Identifier.fromNamespaceAndPath("urbex", "citystyle_test"),
+                List.of(new CityStyleDefinition(
+                        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                        Optional.empty(), Optional.empty(),
+                        Optional.of(new StreetSettings(Optional.empty(), Optional.empty(),
+                                Optional.empty(), Optional.of(Character.toString(streetBlock)),
+                                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                                Optional.of(TestWiring.streetParts("street")), Optional.empty(),
+                                Optional.empty())),
+                        Optional.empty())));
+    }
 
     private static PartUsage usage(Style style) {
         return new PartUsage(style, null, false, "parts", Identifier.fromNamespaceAndPath("urbex", "owner"));


### PR DESCRIPTION
**56c** of #56 — the city style's own character fields. One of the two gaps #150 named.
Design: [`docs/superpowers/specs/2026-08-12-reachable-graph-validation.md`](docs/superpowers/specs/2026-08-12-reachable-graph-validation.md).

## What was missing

A city style declares **fourteen** characters of its own — `streetblock`, `streetbaseblock`,
`streetvariantblock`, `borderblock`, `wallblock`, `railmainblock`, `grassblock`, `ironbarsblock`,
`glowstoneblock`, `leavesblock`, `rubbledirtblock`, `parkelevationblock`, `corridorroofblock`,
`corridorglassblock` — and the generator resolves them against the chunk's palette exactly as it
resolves a part's slice characters.

An undefined one was the same crash from a different line. #150 checked parts and left these, because
they are not reached *through* a part and so had no usage to hang off.

## What changed

They are the same question, so they get the same answer: `PartPaletteCheck` becomes
`PaletteCharacterCheck` with two entry points over one implementation — the fatal/warning split, the
witness construction for "only some `randompalettes` choices define it", and the merge built by
`CompiledPalette` itself are all shared rather than copied.

No part or building palette layer on this path: these are placed on the street rather than inside
anything, so the merge is the style's palettes alone.

**The message names the field.** `"'z' is not defined"` is not actionable when a city style has
fourteen places to look, so it reads `'z' (streetblock)`. `aCityStyleCharacterNoPaletteDefinesIsALoadErrorNamingTheField`
pins that.

## What is still not covered

One gap left from #150, and it is the one that needs a change outside the walk:

- **Condition references** (`inpart` / `belowpart` / `inbuilding`). `Condition` consumes them into a
  `Predicate<ConditionContext>` at construction and keeps no strings, and conditions are reached from
  a palette entry's `loot`/`mob` rather than from the asset graph — so covering them means retaining
  the strings *and* adding a traversal layer through palettes. That is a change to a compiled asset,
  not to the validator, so it does not belong in this PR.
- **Scattered parts' characters**, unchanged from #150: a scattered building takes the style of
  whatever chunk it lands in, which the walk cannot know. Checking it against a style it may never be
  used with is the false-positive direction.

## Verification

```
./gradlew clean build      # pass, 564 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK, 0 problems
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK, 0 problems
```

**Both goldens unchanged, bundled pack reports zero.**
