### PR TITLE
feat: walk condition references, and let optional content be absent (#56, 56d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@
     — silently, with no exception and nothing in the log.
   - *No worldgen change*: both digest goldens are unchanged, and the bundled pack reports nothing.
 
+- **A reference that is *allowed* not to resolve no longer pretends to be a problem.** Conditions
+  are now walked too, and what happens to a broken reference depends on what generation does with it
+  (issue #56).
+  - *A palette marker's `loot`/`mob` names a condition, which generation dereferences* — so one that
+    names nothing refuses the world, like every other dereference.
+  - *A condition's `inpart`/`inbuilding` are matchers.* Naming a part nothing registers does not
+    crash; the condition silently never fires. That is a warning, not a refusal.
+  - *And it is only a warning if the thing that would provide it is installed.* A pack may
+    deliberately name a part, mob or loot table from something it does not require, so that players
+    who have it get the content and everyone else does not — saying so every load would be a warning
+    per optional entry for a pack working exactly as written. A mod is checked with the loader; a
+    datapack, which need not be a mod, by whether anything loaded registers assets in that namespace.
+  - *The predicate is unchanged.* `Condition` compiles its matchers once and tests them per draw,
+    which is the right shape; it just keeps the entries beside them, because a closure cannot be
+    asked what it matches on.
+
 - **A datapack reference that names nothing is now a message about a file, not a crashed chunk.**
   Every cross-asset reference a world can reach — a city style's building and part selectors, a world
   style's highway and railway wiring, a building's `parts`, a multibuilding's grid, a scattered

--- a/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
+++ b/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
@@ -133,13 +133,36 @@ selection provably exists. Sound in the only direction that matters - nothing is
 selection that really breaks - and the shipped pack now reports zero.
 
 **56c — a city style's own character fields.** All fourteen of them, through the same core the part
-check uses, which is why {@code PartPaletteCheck} became `PaletteCharacterCheck`.
+check uses, which is why `PartPaletteCheck` became `PaletteCharacterCheck`.
+
+**56d — condition references, and what a reference is allowed *not* to resolve to.** The predicate is
+kept: it is compiled once and tested per draw, which is the right shape, and re-reading the
+`ConditionTest` fields on every floor of every building would be far worse. `Condition` simply retains
+its entries beside it, because a closure cannot be asked what it matches on.
+
+The rule this settled is worth more than the traversal. What happens to a broken reference depends on
+what generation does with it:
+
+| Kind | At generation | Answer |
+|---|---|---|
+| **Dereference** — a city style's building, a palette marker's `loot`/`mob` condition | `getOrThrow` throws from a worker | **Fatal**, whatever the author intended |
+| **Matcher** — a condition's `inpart` / `inbuilding` | silently never fires | **Warning**, and only if the provider is installed |
+| **Handed to Minecraft** — a condition's entity id | empty spawner | **Warning**, and only if the provider is installed |
+
+A pack may deliberately name content from something it does not require, so that players who have it
+get the content and everyone else does not. Reporting those would be a warning per optional entry,
+every load, for a pack working exactly as written — so `ReferenceProvider` asks whether the
+*provider* is installed before saying anything. The presence test differs by provider: a mod answers
+through `FabricLoader.isModLoaded`, while a datapack need not be a mod at all, so an asset reference
+asks whether anything loaded registers assets in that namespace.
 
 *Still not covered:*
 
-- **Condition references** (`inpart`/`belowpart`/`inbuilding`). `Condition` consumes them into a
-  `Predicate<ConditionContext>` at construction and does not retain the strings, so reaching them
-  means changing that class - a change to a compiled asset, not to the walk.
+- **Loot table ids.** A condition's values are checkable as entity ids and not as loot tables: loot
+  tables live in a reloadable server registry rather than in the frozen ones this compiles against, so
+  at this point in the load there is nothing to ask.
+- **`PartRef`'s own condition fields** inside a building. `Building.readParts` discards those strings
+  exactly as `Condition` used to discard its own; the same one-line retention would expose them.
 - **Scattered parts' characters.** A scattered building lands wherever the terrain allows and takes the
   style of the chunk it lands in, which the walk cannot know. Its references are checked; its
   characters are not.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
@@ -1,5 +1,6 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
+import dev.krona.urbex.worldgen.lost.regassets.data.ConditionPart;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.ObjectSelector;
@@ -10,6 +11,9 @@ import dev.krona.urbex.worldgen.lost.regassets.data.ScatteredReference;
 import dev.krona.urbex.worldgen.lost.regassets.data.ScatteredSettings;
 import dev.krona.urbex.worldgen.lost.regassets.data.StreetParts;
 import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.biome.Biome;
 import org.apache.commons.lang3.tuple.Pair;
@@ -77,9 +81,18 @@ public final class AssetGraph {
     private final Map<Identifier, CityStyle> reachable = new HashMap<>();
     private final Deque<Runnable> pending = new ArrayDeque<>();
 
+    /** Every namespace something loaded registers Urbex assets in; see {@link ReferenceProvider}. */
+    private final Set<String> assetNamespaces = new HashSet<>();
+
     private AssetGraph(AssetSnapshot assets, AssetDiagnostics diagnostics) {
         this.assets = assets;
         this.diagnostics = diagnostics;
+        for (Identifier id : assets.parts().ids()) {
+            assetNamespaces.add(id.getNamespace());
+        }
+        for (Identifier id : assets.buildings().ids()) {
+            assetNamespaces.add(id.getNamespace());
+        }
     }
 
     /**
@@ -188,6 +201,11 @@ public final class AssetGraph {
         Style palette = assets.styles().get(style.getStyle());
         if (palette != null) {
             PaletteCharacterCheck.checkCityStyle(style, palette, diagnostics);
+            for (List<Pair<Float, Palette>> group : palette.paletteChoices()) {
+                for (Pair<Float, Palette> choice : group) {
+                    walkPalette(choice.getRight());
+                }
+            }
         }
         for (ObjectSelector selector : style.selectorList(CityStyle.Sel.BUILDING)) {
             building(owner, selector.value(), "selectors.buildings", palette);
@@ -393,6 +411,112 @@ public final class AssetGraph {
 
     private void style(Identifier owner, @Nullable String name, String field) {
         resolve(owner, name, field, assets.styles(), style -> { });
+    }
+
+    /**
+     * The conditions a palette's markers name, and what those conditions in turn reference.
+     *
+     * <p>A {@code loot} or {@code mob} marker holds a <em>condition</em> name, which
+     * {@code CityGenerator.getRandomSpawnerMob} resolves with {@code getOrThrow} - so a marker naming
+     * a condition nothing registers is a crashed chunk, and fatal here like every other dereference.
+     * What the condition then hands back is a loot table or an entity id, which is not, and is
+     * treated as such below.</p>
+     */
+    private void walkPalette(@Nullable Palette palette) {
+        if (palette == null || !first("palette", palette.getId())) {
+            return;
+        }
+        for (Palette.PE entry : palette.getPalette().values()) {
+            Palette.Info info = entry.info();
+            if (info == null) {
+                continue;
+            }
+            condition(palette.getId(), info.loot(), "loot", false);
+            condition(palette.getId(), info.mobId(), "mob", true);
+        }
+    }
+
+    /**
+     * @param entities whether this condition's values are entity ids. A condition is a weighted list
+     *                 of strings and nothing in it says what they are - the marker that named it does:
+     *                 a {@code mob} marker's values are entity types, a {@code loot} marker's are loot
+     *                 tables. Reached as both, it is walked as both.
+     */
+    private void condition(Identifier owner, @Nullable String name, String field, boolean entities) {
+        resolve(owner, name, field, assets.conditions(), condition -> walkCondition(condition, entities));
+    }
+
+    /**
+     * A condition's own references, none of which generation dereferences - so none of them is fatal
+     * and some are not even reported.
+     *
+     * <p>Its matchers ({@code inpart}, {@code inbuilding}) are string membership tests: naming a part
+     * nothing registers does not crash, the condition just silently never fires. Its values are loot
+     * tables and entity ids handed to Minecraft. Both are the shape a pack may deliberately write for
+     * content it does not require, so {@link ReferenceProvider} decides whether the absence is worth a
+     * line at all: it is when the pack or mod that would provide it <em>is</em> installed, and it is
+     * not when nobody has it.</p>
+     */
+    private void walkCondition(Condition condition, boolean entities) {
+        if (!first("condition/" + entities, condition.getId())) {
+            return;
+        }
+        for (ConditionPart entry : condition.entries()) {
+            softAssetRefs(condition.getId(), entry.getInpart(), "values.inpart", assets.parts());
+            softAssetRefs(condition.getId(), entry.getInbuilding(), "values.inbuilding", assets.buildings());
+            if (entities) {
+                softEntityRef(condition.getId(), entry.getValue());
+            }
+        }
+    }
+
+    /** A matcher naming an Urbex asset: reported only when a pack using that namespace is loaded. */
+    private void softAssetRefs(Identifier owner, @Nullable Set<String> names, String field,
+                               AssetIndex<?> index) {
+        if (names == null) {
+            return;
+        }
+        for (String name : names) {
+            Identifier id;
+            try {
+                id = DataTools.fromName(name);
+            } catch (RuntimeException e) {
+                continue;   // an unqualified matcher is the codec's business, not this walk's
+            }
+            if (index.get(id) != null || !ReferenceProvider.packIsInstalled(id, assetNamespaces)) {
+                continue;
+            }
+            if (reported.add(index.registry() + "|" + owner + "|" + field + "|" + name)) {
+                diagnostics.warn(index.registry(), owner,
+                        "'" + field + "' matches on '" + name + "', which no loaded datapack "
+                                + "registers even though other assets in that namespace are loaded; "
+                                + "this condition can never fire for it");
+            }
+        }
+    }
+
+    /**
+     * An entity id a {@code mob} condition hands to a spawner. Never fatal - a spawner with an
+     * unknown entity is an empty spawner, not a crash - and silent unless the mod that would provide
+     * it is installed, which is the case a pack listing another mod's mobs deliberately relies on.
+     * <p>
+     * Loot tables have no equivalent check: they live in a reloadable server registry rather than in
+     * the frozen ones this compiles against, so at this point in the load there is nothing to ask.
+     */
+    private void softEntityRef(Identifier owner, @Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        Identifier id = Identifier.tryParse(value);
+        if (id == null || !ReferenceProvider.modIsInstalled(id)
+                || BuiltInRegistries.ENTITY_TYPE.get(ResourceKey.create(Registries.ENTITY_TYPE, id)).isPresent()) {
+            return;
+        }
+        if (reported.add("entity|" + owner + "|" + value)) {
+            diagnostics.warn(assets.conditions().registry(), owner,
+                    "hands back mob '" + value + "', which '" + id.getNamespace()
+                            + "' is installed but does not provide; a spawner using it stays empty");
+        }
     }
 
     /** A part is a leaf for this walk: its {@code refpalette} was resolved when it compiled. */

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Condition.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Condition.java
@@ -17,6 +17,17 @@ public class Condition {
     private final Identifier name;
 
     private final List<Pair<Predicate<ConditionContext>, Pair<Float, String>>> valueSelector = new ArrayList<>();
+    /**
+     * The entries this was folded from, kept beside the compiled predicates rather than instead of
+     * them.
+     * <p>
+     * {@link ConditionContext#parseTest} turns each entry's matchers into one closure chain, tested
+     * once per draw - that is the right shape and it stays. But a closure cannot be asked what it
+     * matches on, so a condition naming a part no datapack registers used to be invisible: the
+     * predicate simply never fired, and nothing said why. Keeping the entries costs one reference and
+     * lets {@link AssetGraph} report it (issue #56).
+     */
+    private final List<ConditionPart> entries;
 
     /**
      * Builds a fully resolved condition from its {@code extends} chain, root first: a declared
@@ -35,12 +46,18 @@ public class Condition {
             }
         }
         Resolved.require(anyValues ? values : null, name, "values");
+        entries = List.copyOf(values);
         for (ConditionPart cp : values) {
             float factor = cp.getFactor();
             String value = cp.getValue();
             Predicate<ConditionContext> test = ConditionContext.parseTest(cp);
             valueSelector.add(Pair.of(test, Pair.of(factor, value)));
         }
+    }
+
+    /** What each entry matched on and hands back, for the load-time walk. */
+    List<ConditionPart> entries() {
+        return entries;
     }
 
     /** The fully-qualified id, e.g. {@code "urbex:chestloot"}. */

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ReferenceProvider.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ReferenceProvider.java
@@ -1,0 +1,58 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.resources.Identifier;
+
+import java.util.Set;
+
+/**
+ * Whether the thing that would satisfy a reference is installed at all.
+ *
+ * <p>"Does this resolve" is the wrong question for a reference that is allowed not to. A pack may
+ * list a loot table or a mob from a mod it does not require, so that the content appears for players
+ * who have that mod and is simply absent for everyone else - and reporting those would mean a warning
+ * per optional entry, every load, for a pack that is working as written.</p>
+ *
+ * <p>So a soft reference is only reported when its <em>provider</em> is present and the id still does
+ * not resolve. That is a different fact: the mod is installed and renamed the thing, or the name is a
+ * typo. Both are worth a line; "you do not have that mod" is not.</p>
+ *
+ * <p>The presence test differs by what would provide it, which is why there are two methods rather
+ * than one. A block, an entity or a loot table comes from a <strong>mod</strong>, so the loader
+ * answers. An Urbex asset comes from a <strong>datapack</strong>, which need not be a mod at all - a
+ * pack shipping only JSON registers assets under its own namespace with no mod id to ask about - so
+ * the question is whether anything loaded actually registered assets in that namespace.</p>
+ *
+ * <p>None of this applies to a reference generation <em>dereferences</em>. A city style naming a
+ * building that is not installed is fatal whatever the author intended, because
+ * {@code getOrThrow} throws from a worldgen worker either way; only references that fail softly - a
+ * matcher that never fires, a loot table that yields nothing - can be quietly absent.</p>
+ */
+final class ReferenceProvider {
+
+    private ReferenceProvider() {
+    }
+
+    /**
+     * For a reference into a mod's registries: a block, an entity type, a loot table.
+     *
+     * <p>{@code minecraft} always counts as installed, which is the point of asking - a vanilla id
+     * that stops resolving has been renamed, and that is exactly the failure that made the whole
+     * {@code urbex:chains} decoration invisible (issue #91).</p>
+     */
+    static boolean modIsInstalled(Identifier reference) {
+        String namespace = reference.getNamespace();
+        return "minecraft".equals(namespace) || FabricLoader.getInstance().isModLoaded(namespace);
+    }
+
+    /**
+     * For a reference to another Urbex asset: is anything loaded registering assets in that
+     * namespace?
+     *
+     * @param namespaces every namespace the compiled snapshot holds assets in, which is the closest
+     *                   thing to "which packs are installed" that a datapack-only pack can be seen by
+     */
+    static boolean packIsInstalled(Identifier reference, Set<String> namespaces) {
+        return namespaces.contains(reference.getNamespace());
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraphTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraphTest.java
@@ -1,5 +1,12 @@
 package dev.krona.urbex.worldgen.lost.cityassets;
 
+import dev.krona.urbex.worldgen.lost.regassets.ConditionDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.PaletteDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.StyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.data.ConditionPart;
+import dev.krona.urbex.worldgen.lost.regassets.data.PaletteEntry;
+import dev.krona.urbex.worldgen.lost.regassets.data.PaletteSelector;
+import com.mojang.datafixers.util.Either;
 import dev.krona.urbex.worldgen.lost.regassets.BuildingDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.CityStyleDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.BuildingPartDefinition;
@@ -23,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -188,6 +196,41 @@ class AssetGraphTest {
         assertTrue(diagnostics.isEmpty(), () -> diagnostics.format(""));
     }
 
+    /**
+     * A matcher is not a dereference: a condition naming a part nothing registers does not crash, it
+     * silently never fires. Worth a line, not worth refusing a world for.
+     */
+    @Test
+    void aConditionMatchingOnAMissingPartOfAnInstalledPackIsAWarning() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        // 'urbex' is a namespace this snapshot has assets in, so the pack is installed and the name
+        // is a typo rather than absent content.
+        Fixture fixture = new Fixture().condition("loot_table", "urbex:no_such_part");
+        CityStyle root = fixture.cityStyleNaming("urbex:loot_table");
+
+        AssetGraph.validate(fixture.snapshot(), List.of(root), diagnostics);
+
+        assertFalse(diagnostics.isEmpty(), "a typo in an installed pack is worth saying");
+        assertFalse(diagnostics.hasFatal(), "but the condition merely never fires, so the world loads");
+    }
+
+    /**
+     * The case that must stay quiet. A pack may match on, or hand back, content from a mod it does not
+     * require - so that players who have it get the content and everyone else simply does not. Saying
+     * so every load would be a warning per optional entry for a pack working exactly as written.
+     */
+    @Test
+    void aConditionMatchingOnAnUninstalledPacksPartSaysNothing() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture().condition("loot_table", "somemod:their_part");
+        CityStyle root = fixture.cityStyleNaming("urbex:loot_table");
+
+        AssetGraph.validate(fixture.snapshot(), List.of(root), diagnostics);
+
+        assertTrue(diagnostics.isEmpty(),
+                () -> "nobody has that pack, which is not a defect: " + diagnostics.format(""));
+    }
+
     // ------------------------------------------------------------------ fixtures
 
     private static PredefinedBuilding building(String name) {
@@ -205,6 +248,8 @@ class AssetGraphTest {
         private final Map<Identifier, MultiBuilding> multiBuildings = new HashMap<>();
         private final Map<Identifier, PredefinedCity> cities = new HashMap<>();
         private final Map<Identifier, BuildingPart> extraParts = new HashMap<>();
+        private final Map<Identifier, Condition> conditions = new HashMap<>();
+        private final Map<Identifier, Style> styles = new HashMap<>();
 
         Fixture building(String path, String partName) {
             PartRef ref = new PartRef(partName, Optional.empty(), Optional.empty(), Optional.empty(),
@@ -259,6 +304,63 @@ class AssetGraphTest {
                             Optional.empty())));
         }
 
+        /** A condition whose one entry matches on {@code inpart}, which is a matcher, not a lookup. */
+        Fixture condition(String path, String inPart) {
+            Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+            ConditionPart entry = new ConditionPart(1.0f, "minecraft:chests/simple_dungeon",
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.of(Either.right(inPart)), Optional.empty(), Optional.empty(),
+                    Optional.empty());
+            conditions.put(id, new Condition(id, List.of(new ConditionDefinition(
+                    Optional.empty(), Optional.of(new Mergeable<>(true, List.of(entry)))))));
+            return this;
+        }
+
+        /**
+         * A city style whose style has one palette, whose one marker names {@code conditionName} as
+         * its loot table - which is how a condition is reached at all.
+         */
+        CityStyle cityStyleNaming(String conditionName) {
+            Identifier paletteId = Identifier.fromNamespaceAndPath("urbex", "loot_palette");
+            PaletteEntry marker = new PaletteEntry("L", Optional.of("minecraft:chest"),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.of(conditionName), Optional.empty(), Optional.empty(),
+                    Optional.empty());
+            // 'a' as well as the loot marker: the road part this city style wires in is built from
+            // 'a', and the character check would otherwise fire on the fixture rather than on what
+            // the test is about.
+            PaletteEntry filler = new PaletteEntry("a", Optional.of("minecraft:stone"),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty());
+            Palette palette = new Palette(paletteId, BuiltInRegistries.BLOCK, null,
+                    List.of(new PaletteDefinition(Optional.empty(), Optional.of(List.of(marker, filler)))));
+            Identifier styleId = Identifier.fromNamespaceAndPath("urbex", "style_loot");
+            styles.put(styleId, new Style(styleId,
+                    new AssetIndex<>("urbex:palettes", Map.of(paletteId, palette)),
+                    List.of(new StyleDefinition(Optional.empty(), Optional.of(new Mergeable<>(true,
+                            List.of(List.of(new PaletteSelector(1.0f, paletteId.toString())))))))));
+            return new CityStyle(Identifier.fromNamespaceAndPath("urbex", "citystyle_loot"),
+                    List.of(new CityStyleDefinition(
+                            Optional.empty(), Optional.of(styleId.toString()), Optional.empty(),
+                            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                            Optional.empty(), Optional.empty(), Optional.empty(),
+                            Optional.of(new StreetSettings(Optional.empty(), Optional.empty(),
+                                    Optional.empty(), Optional.empty(), Optional.empty(),
+                                    Optional.empty(), Optional.empty(), Optional.empty(),
+                                    Optional.of(roadFamily()), Optional.empty(),
+                                    Optional.empty())),
+                            Optional.empty())));
+        }
+
+        /** Every street slot pointing at one 16x16 part this fixture registers. */
+        private StreetParts.Decl roadFamily() {
+            part("road", 16, 16);
+            Optional<Mergeable<String>> one = Optional.of(new Mergeable<>(true, List.of("urbex:road")));
+            return new StreetParts.Decl(one, one, one, one, one, one, one, one);
+        }
+
         Fixture city(String path, PredefinedBuilding... contents) {
             Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
             cities.put(id, new PredefinedCity(id, List.of(new PredefinedCityDefinition(
@@ -279,8 +381,9 @@ class AssetGraphTest {
                     Optional.of(List.of(List.of("a"))), Optional.empty(), Optional.empty(),
                     Optional.empty()))));
             parts.putAll(extraParts);
-            return new AssetSnapshot(empty.variants(), empty.palettes(), empty.conditions(),
-                    empty.styles(), new AssetIndex<>("urbex:parts", parts),
+            return new AssetSnapshot(empty.variants(), empty.palettes(),
+                    new AssetIndex<>("urbex:conditions", conditions),
+                    new AssetIndex<>("urbex:styles", styles), new AssetIndex<>("urbex:parts", parts),
                     new AssetIndex<>("urbex:buildings", buildings),
                     new AssetIndex<>("urbex:multibuildings", multiBuildings), empty.scattered(),
                     empty.worldStyles(), empty.cityStyles(),


### PR DESCRIPTION
**56d** of #56 — condition references, and the rule for what a reference is *allowed* not to resolve to.
Design: [`docs/superpowers/specs/2026-08-12-reachable-graph-validation.md`](docs/superpowers/specs/2026-08-12-reachable-graph-validation.md).

## The predicate was never the problem

`Condition` compiles each entry's matchers into one `Predicate<ConditionContext>` chain, tested once
per draw. **That is the right shape and it is unchanged** — re-reading the `ConditionTest` fields on
every floor of every building would be far worse.

Nor is this the #128 move: resolving `inpart` to a `BuildingPart` object would buy nothing, because
it is a *membership test* on a name (`part.contains(context.getPart())`, and `getPart()` is itself a
`String`) rather than a dereference. It would only pay off if `ConditionContext` carried objects, a
much wider change through `BuildingInfo` and the floor loops.

What a closure cannot do is answer *what it matches on*. So `Condition` keeps its entries beside the
predicates — one field — and the walk can see them.

## Three kinds of reference, three answers

The rule this settled matters more than the traversal:

| Kind | At generation | Answer |
|---|---|---|
| **Dereference** — a palette marker's `loot`/`mob` names a *condition* | `getOrThrow` throws from a worker | **Fatal** |
| **Matcher** — a condition's `inpart` / `inbuilding` | silently never fires | **Warning** |
| **Handed to Minecraft** — a condition's entity id | empty spawner | **Warning** |

Worth being explicit about the first row: `marker.loot()` and `marker.mobId()` hold a **condition
name**, which `CityGenerator.getRandomSpawnerMob` resolves with `getOrThrow`. That is a crashed chunk,
so it is fatal like every other dereference. What the condition then *hands back* is the loot table or
entity id — and that is not.

## …and a warning only when the provider is installed

This is the part you asked for. A pack may deliberately name a part, mob or loot table from something
it does not require, so that players who have it get the content and everyone else simply does not.
Reporting those would be **a warning per optional entry, every load, for a pack working exactly as
written**.

`ReferenceProvider` asks whether the *provider* is present before saying anything — and asks it
differently depending on what would provide it:

- **a mod** (entity, loot table, block) → `FabricLoader.isModLoaded`, with `minecraft` always counting,
  which is what keeps a renamed vanilla id reportable;
- **a datapack** (an Urbex asset) → whether anything loaded registers assets in that namespace. A pack
  shipping only JSON has no mod id to ask about, so the loader is the wrong question for it.

Both sides are pinned: `aConditionMatchingOnAMissingPartOfAnInstalledPackIsAWarning` and
`aConditionMatchingOnAnUninstalledPacksPartSaysNothing`.

## What is still not covered

- **Loot table ids.** Checkable as entity ids, not as loot tables: those live in a reloadable server
  registry rather than the frozen ones this compiles against, so at this point in the load there is
  nothing to ask.
- **`PartRef`'s own condition fields** inside a building. `Building.readParts` discards those strings
  exactly as `Condition` used to discard its own — the same one-line retention would expose them.
- **Scattered parts' characters**, unchanged: a scattered building takes the style of whatever chunk
  it lands in, which the walk cannot know.

## A note on #91

The same principle argues that #146's per-block warning should be quiet when the block's namespace is
an uninstalled mod — today it warns for any unresolvable id. Not changed here, because it is a
different PR's behaviour and worth its own decision.

## Verification

```
./gradlew clean build      # pass, 566 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK, 0 problems
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK, 0 problems
```

**Both goldens unchanged, bundled pack reports zero.**
