### PR TITLE
fix: do not warn about blocks from mods nobody has (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,10 @@
     `BuiltInRegistries.BLOCK` if it was not. Both are the same registry — blocks are static and
     frozen at mod init — so nothing was ever wrong, but nothing said so either, and it was the last
     place outside the editor that asset compilation reached a server for anything (issue #60).
-  - *An unknown block id still generates as air, warned once.* It used to arrive there through a
+  - *An unknown block id still generates as air, and is warned about once — but only when the mod
+    that would provide it is installed.* A pack naming a block from a mod it does not require is
+    doing the right thing, and a line per optional entry every load is noise; a `minecraft:` id, or
+    one from a mod you do have, that still does not resolve was renamed or mistyped, and stays loud. It used to arrive there through a
     defaulted registry's default value; it is an explicit return now, so the decision issue #91 has
     to make is one line rather than a registry quirk to find. Pinned by `BlockResolutionTest`.
   - *No worldgen change*: both digest goldens are unchanged, verified by running `runDigestCheck`

--- a/src/main/java/dev/krona/urbex/varia/Tools.java
+++ b/src/main/java/dev/krona/urbex/varia/Tools.java
@@ -1,6 +1,7 @@
 package dev.krona.urbex.varia;
 
 import dev.krona.urbex.Urbex;
+import dev.krona.urbex.worldgen.lost.cityassets.ReferenceProvider;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -94,10 +95,10 @@ public class Tools {
      * world, which is the decision issue #91 records: a pack naming one absent block generates the
      * rest of itself.
      * <p>
-     * Each distinct string is warned about once, however many entries name it, and that warning is
-     * the only report. This deliberately raises no load-time diagnostic: making an absent block
-     * refuse the world is the strict half of #91 and was not chosen, because a pack written around
-     * optional cross-mod blocks would then refuse to load on a vanilla install.
+     * A missing block is warned about once per string, and only when the mod that would provide it is
+     * installed - see {@link #missing}. This deliberately raises no load-time diagnostic either:
+     * making an absent block refuse the world is the strict half of #91 and was not chosen, because a
+     * pack written around optional cross-mod blocks would then refuse to load on a vanilla install.
      * <p>
      * The pre-flattening {@code name@meta} form lands here as an unparseable id rather than as an
      * upgrade: {@code @} is not a legal path character so {@link Identifier#tryParse} rejects it,
@@ -110,7 +111,9 @@ public class Tools {
         int properties = s.indexOf('[');
         Identifier id = Identifier.tryParse(properties < 0 ? s : s.substring(0, properties));
         if (id == null) {
-            return missing(s, owner);
+            // No namespace to ask about, and nothing optional about it: this is not a legal id in any
+            // installation. Always reported.
+            return missing(s, null, owner);
         }
         boolean known = blockLookup.get(ResourceKey.create(Registries.BLOCK, id)).isPresent();
 
@@ -119,7 +122,7 @@ public class Tools {
                 // The crash half of #91: a property-carrying string whose block is absent threw out
                 // of the parser below, and since compilation moved to load time that refused the
                 // whole world rather than one chunk.
-                return missing(s, owner);
+                return missing(s, id, owner);
             }
             try {
                 return BlockStateParser.parseForBlock(blockLookup, new StringReader(s), false).blockState();
@@ -135,17 +138,32 @@ public class Tools {
         Optional<Holder.Reference<Block>> upgraded = upgradedId == null
                 ? Optional.empty()
                 : blockLookup.get(ResourceKey.create(Registries.BLOCK, upgradedId));
-        return upgraded.map(block -> block.value().defaultBlockState()).orElseGet(() -> missing(s, owner));
+        return upgraded.map(block -> block.value().defaultBlockState())
+                .orElseGet(() -> missing(s, id, owner));
     }
 
+    /**
+     * Absent, and said so only when saying so helps.
+     * <p>
+     * A pack may name a block from a mod it does not require, so that players who have that mod get
+     * the block and everyone else gets the entry skipped - that is what #91 decided the behaviour
+     * should be, and warning about it would mean a line per optional entry, every load, for a pack
+     * working exactly as written. So the warning is kept for the case where the block <em>should</em>
+     * have been there: the mod that would provide it is installed (or it is {@code minecraft}) and the
+     * id still does not resolve, which means it was renamed or mistyped. That is the
+     * {@code minecraft:chain} case, and it stays loud.
+     *
+     * @param id the parsed id, or null when the string is not a legal identifier at all - which is
+     *           nobody's optional content and is always reported
+     */
     @Nullable
-    private static BlockState missing(String s, @Nullable Object owner) {
-        if (WARNED_MISSING_BLOCKS.add(s)) {
+    private static BlockState missing(String s, @Nullable Identifier id, @Nullable Object owner) {
+        if ((id == null || ReferenceProvider.modIsInstalled(id)) && WARNED_MISSING_BLOCKS.add(s)) {
             Urbex.LOGGER.warn(
                     "Block '{}'{} does not exist in this Minecraft version. Entries naming it are "
                             + "skipped and the remaining ones share the draw; a palette character "
-                            + "left with nothing generates as air. If this is not a block from an "
-                            + "uninstalled mod, it was most likely renamed - check the current id.",
+                            + "left with nothing generates as air. It was most likely renamed - "
+                            + "check the current id and update the asset.",
                     s, owner == null ? "" : " (in " + owner + ")");
         }
         return null;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ReferenceProvider.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/ReferenceProvider.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * {@code getOrThrow} throws from a worldgen worker either way; only references that fail softly - a
  * matcher that never fires, a loot table that yields nothing - can be quietly absent.</p>
  */
-final class ReferenceProvider {
+public final class ReferenceProvider {
 
     private ReferenceProvider() {
     }
@@ -36,11 +36,13 @@ final class ReferenceProvider {
     /**
      * For a reference into a mod's registries: a block, an entity type, a loot table.
      *
-     * <p>{@code minecraft} always counts as installed, which is the point of asking - a vanilla id
-     * that stops resolving has been renamed, and that is exactly the failure that made the whole
-     * {@code urbex:chains} decoration invisible (issue #91).</p>
+     * <p>{@code minecraft} always counts as installed, and that is not belt-and-braces: it is the
+     * point of asking. A vanilla id that stops resolving has been renamed, which is exactly the
+     * failure that made the whole {@code urbex:chains} decoration invisible (issue #91), and it must
+     * stay reportable. It is also why this cannot be left to the loader alone - outside a game,
+     * {@code isModLoaded("minecraft")} answers false.</p>
      */
-    static boolean modIsInstalled(Identifier reference) {
+    public static boolean modIsInstalled(Identifier reference) {
         String namespace = reference.getNamespace();
         return "minecraft".equals(namespace) || FabricLoader.getInstance().isModLoaded(namespace);
     }

--- a/src/test/java/dev/krona/urbex/varia/BlockResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/varia/BlockResolutionTest.java
@@ -104,6 +104,20 @@ class BlockResolutionTest {
     }
 
     /**
+     * Absent either way - what changes with the provider is only whether anyone is told.
+     * <p>
+     * A pack may name a block from a mod it does not require; #91 skips those entries, and warning
+     * about them would be a line per optional entry, every load, for a pack working as written. The
+     * warning is kept for the case where the block should have been there, which is what
+     * {@code ReferenceProviderTest} pins.
+     */
+    @Test
+    void anAbsentBlockResolvesTheSameWhoeverWouldHaveProvidedIt() {
+        assertNull(Tools.resolveState("somemod:no_such_block", BuiltInRegistries.BLOCK, OWNER));
+        assertNull(Tools.resolveState("minecraft:no_such_block", BuiltInRegistries.BLOCK, OWNER));
+    }
+
+    /**
      * The boundary itself: a lookup that does not have the block answers "not here", even though the
      * process-global registry three lines away does have it. Before the lookup became a parameter
      * there was no way to write this test, because there was no way to say which registry to ask.

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/ReferenceProviderTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/ReferenceProviderTest.java
@@ -1,0 +1,50 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import net.minecraft.resources.Identifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Whether the thing that would satisfy a reference is installed - which is what decides whether an
+ * unresolvable reference is worth telling anyone about (issues #56, #91).
+ * <p>
+ * A pack may name a block, mob, loot table or part from something it does not require, so that
+ * players who have it get the content and everyone else does not. Those must be silent. A reference
+ * whose provider <em>is</em> installed and still does not resolve is a rename or a typo, and must
+ * not be.
+ */
+class ReferenceProviderTest {
+
+    /**
+     * The special case that carries the whole vanilla story. Outside a game
+     * {@code isModLoaded("minecraft")} answers false, so without this a renamed vanilla id - the
+     * {@code minecraft:chain} that made {@code urbex:chains} invisible - would be filed as somebody
+     * else's missing mod and never reported.
+     */
+    @Test
+    void minecraftAlwaysCounts() {
+        assertTrue(ReferenceProvider.modIsInstalled(Identifier.parse("minecraft:iron_chain")));
+    }
+
+    @Test
+    void aModNobodyHasDoesNot() {
+        assertFalse(ReferenceProvider.modIsInstalled(Identifier.parse("somemod:fancy_block")));
+    }
+
+    /**
+     * A datapack need not be a mod, so the loader is the wrong question for an asset reference: a
+     * pack shipping only JSON has no mod id to ask about. What is asked instead is whether anything
+     * loaded actually registered assets in that namespace.
+     */
+    @Test
+    void aPackIsInstalledWhenItsNamespaceHasAssets() {
+        Set<String> loaded = Set.of("urbex", "urbexmt");
+
+        assertTrue(ReferenceProvider.packIsInstalled(Identifier.parse("urbexmt:tower"), loaded));
+        assertFalse(ReferenceProvider.packIsInstalled(Identifier.parse("somepack:tower"), loaded));
+    }
+}


### PR DESCRIPTION
Brings #146 (issue #91) in line with the rule #152 settled for conditions.

## What was inconsistent

#91 decided a block from an uninstalled mod is **skipped**, not fatal — that is what lets a pack name
optional cross-mod content. But #146 still **warned** about every one of them, so a pack written that
way logged a line per optional entry on every load, about content that is absent exactly as intended.

#152 then established the opposite rule for conditions: report only when the thing that would provide
the reference is installed. Two adjacent checks, two answers to the same question.

## What changed

The block warning now asks that same question. If the mod is installed — or it is `minecraft` — and
the id still does not resolve, it was renamed or mistyped, and it stays loud. That is the
`minecraft:chain` → `minecraft:iron_chain` case that made the whole `urbex:chains` decoration
invisible, which is what the warning exists for.

An id that is not a legal identifier at all has no namespace to ask about and is nobody's optional
content, so it is always reported.

**The behaviour is otherwise unchanged** — the block resolves to air either way. What changed is only
who gets told. `anAbsentBlockResolvesTheSameWhoeverWouldHaveProvidedIt` asserts both namespaces still
resolve identically.

## One thing worth knowing about `ReferenceProvider`

Its `minecraft` special case turns out to be **load-bearing, not defensive**. I probed it: outside a
game, `FabricLoader.getInstance().isModLoaded("minecraft")` answers **false**. Without the special
case, a renamed vanilla id would be filed as somebody else's missing mod and never reported — the
exact failure this warning was added for. `ReferenceProviderTest.minecraftAlwaysCounts` pins it.

`ReferenceProvider` becomes public for this. It was already the home of the rule, introduced for
conditions in #152, so this is one policy in one place rather than two implementations.

## Verification

```
./gradlew clean build      # pass, 570 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK, 0 problems
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK, 0 problems
```

**Both goldens unchanged** — the bundled pack names no absent block, so neither the old warning nor
the new silence applies to it.
