### PR TITLE
feat: walk a building's own parts-entry matchers (#56, 56e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@
   (issue #56).
   - *A palette marker's `loot`/`mob` names a condition, which generation dereferences* — so one that
     names nothing refuses the world, like every other dereference.
-  - *A condition's `inpart`/`inbuilding` are matchers.* Naming a part nothing registers does not
+  - *A building's own `parts` entries carry matchers too* — `inpart`, `belowpart`, `inbuilding` —
+    and they are checked the same way. Nothing in the bundled pack writes `belowpart`, so no digest
+    could ever have caught a break here.
+  - *A condition's `inpart`/`belowpart`/`inbuilding` are matchers.* Naming a part nothing registers does not
     crash; the condition silently never fires. That is a warning, not a refusal.
   - *And it is only a warning if the thing that would provide it is installed.* A pack may
     deliberately name a part, mob or loot table from something it does not require, so that players

--- a/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
+++ b/docs/superpowers/specs/2026-08-12-reachable-graph-validation.md
@@ -156,13 +156,15 @@ every load, for a pack working exactly as written — so `ReferenceProvider` ask
 through `FabricLoader.isModLoaded`, while a datapack need not be a mod at all, so an asset reference
 asks whether anything loaded registers assets in that namespace.
 
+**56e — `PartRef`'s own condition fields.** The last references the walk could not see, closed the
+same way `Condition`'s were: `Building` retains the entries beside the compiled predicates. Their
+`belowpart` also revealed one the condition walk had missed, so both now cover all three matchers.
+
 *Still not covered:*
 
 - **Loot table ids.** A condition's values are checkable as entity ids and not as loot tables: loot
   tables live in a reloadable server registry rather than in the frozen ones this compiles against, so
   at this point in the load there is nothing to ask.
-- **`PartRef`'s own condition fields** inside a building. `Building.readParts` discards those strings
-  exactly as `Condition` used to discard its own; the same one-line retention would expose them.
 - **Scattered parts' characters.** A scattered building lands wherever the terrain allows and takes the
   style of the chunk it lands in, which the walk cannot know. Its references are checked; its
   characters are not.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraph.java
@@ -4,6 +4,7 @@ import dev.krona.urbex.worldgen.lost.regassets.data.ConditionPart;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.ObjectSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
 import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
@@ -278,6 +279,13 @@ public final class AssetGraph {
         for (String name : building.partNames()) {
             part(building.getId(), name, "parts", usage(palette, building, false, "parts", building.getId()));
         }
+        // The matchers on those same entries. Not dereferences - a parts entry whose 'belowpart'
+        // names nothing simply never fires - so they follow the soft rule, like a condition's.
+        for (PartRef ref : building.partConditions()) {
+            softAssetRefs(building.getId(), ref.getInpart(), "parts.inpart", assets.parts());
+            softAssetRefs(building.getId(), ref.getBelowPart(), "parts.belowpart", assets.parts());
+            softAssetRefs(building.getId(), ref.getInbuilding(), "parts.inbuilding", assets.buildings());
+        }
     }
 
     private void walkMultiBuilding(MultiBuilding multi, @Nullable Style palette) {
@@ -463,6 +471,7 @@ public final class AssetGraph {
         }
         for (ConditionPart entry : condition.entries()) {
             softAssetRefs(condition.getId(), entry.getInpart(), "values.inpart", assets.parts());
+            softAssetRefs(condition.getId(), entry.getBelowPart(), "values.belowpart", assets.parts());
             softAssetRefs(condition.getId(), entry.getInbuilding(), "values.inbuilding", assets.buildings());
             if (entities) {
                 softEntityRef(condition.getId(), entry.getValue());

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Building.java
@@ -40,6 +40,16 @@ public class Building {
 
     private final List<Pair<Predicate<ConditionContext>, String>> parts = new ArrayList<>();
     private final List<Pair<Predicate<ConditionContext>, String>> parts2 = new ArrayList<>();
+    /**
+     * The entries the two lists above were compiled from, kept beside the predicates rather than
+     * instead of them.
+     * <p>
+     * Same reason {@link Condition} keeps its own: {@code readParts} turns each entry's matchers into
+     * one closure, which is the right shape for something tested per floor of every building - but a
+     * closure cannot be asked what it matches on, so a {@code belowpart} naming a part nothing
+     * registers was invisible. The entry just never fired, and nothing said why (issue #56).
+     */
+    private final List<PartRef> partRefs;
 
     /**
      * Builds a fully resolved building from its {@code extends} chain, root first: every scalar
@@ -129,6 +139,10 @@ public class Building {
 
         readParts(this.parts, partRefs);
         readParts(this.parts2, partRefs2);
+        List<PartRef> allRefs = new ArrayList<>(partRefs.size() + partRefs2.size());
+        allRefs.addAll(partRefs);
+        allRefs.addAll(partRefs2);
+        this.partRefs = List.copyOf(allRefs);
     }
 
     /** The fully-qualified id, e.g. {@code "urbex:radiotower"}. */
@@ -138,6 +152,11 @@ public class Building {
 
     public Identifier getId() {
         return name;
+    }
+
+    /** What the {@code parts} and {@code parts2} entries matched on, for the load-time walk. */
+    List<PartRef> partConditions() {
+        return partRefs;
     }
 
     /**

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraphTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetGraphTest.java
@@ -14,6 +14,7 @@ import dev.krona.urbex.worldgen.lost.regassets.MultiBuildingDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.PredefinedCityDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
+import dev.krona.urbex.worldgen.lost.regassets.data.PartRef;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
 import dev.krona.urbex.worldgen.lost.regassets.data.StreetParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.StreetSettings;
@@ -231,6 +232,26 @@ class AssetGraphTest {
                 () -> "nobody has that pack, which is not a defect: " + diagnostics.format(""));
     }
 
+    /**
+     * A building's {@code parts} entries carry matchers of their own, and they were the last
+     * references the walk could not see. Nothing in the bundled pack writes {@code belowpart}, so no
+     * golden can catch a revert of this - which is why it is pinned here.
+     */
+    @Test
+    void aBuildingPartsEntryMatchingOnAMissingPartIsAWarning() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Fixture fixture = new Fixture()
+                .buildingBelow("tower", PRESENT_PART.toString(), "urbex:no_such_floor")
+                .city("downtown", building("urbex:tower"));
+
+        AssetGraph.validate(fixture.snapshot(), List.of(), diagnostics);
+
+        assertFalse(diagnostics.isEmpty(), "a belowpart naming nothing means the entry never fires");
+        assertFalse(diagnostics.hasFatal(), "which is not worth refusing a world for");
+        assertTrue(diagnostics.problems().getFirst().message().contains("belowpart"),
+                diagnostics.problems().getFirst().message());
+    }
+
     // ------------------------------------------------------------------ fixtures
 
     private static PredefinedBuilding building(String name) {
@@ -270,6 +291,22 @@ class AssetGraphTest {
             multiBuildings.put(id, new MultiBuilding(id, List.of(new MultiBuildingDefinition(
                     Optional.empty(), Optional.of(names.length), Optional.of(1),
                     Optional.of(List.of(List.of(names)))))));
+            return this;
+        }
+
+        /** A building whose one {@code parts} entry only fires below {@code belowPart}. */
+        Fixture buildingBelow(String path, String partName, String belowPart) {
+            PartRef ref = new PartRef(partName, Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.of(Either.right(belowPart)), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty());
+            Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+            buildings.put(id, new Building(id, BuiltInRegistries.BLOCK, null,
+                    AssetIndex.empty("urbex:palettes"), List.of(new BuildingDefinition(
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.of('#'), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.of(new Mergeable<>(true, List.of(ref))), Optional.empty()))));
             return this;
         }
 


### PR DESCRIPTION
**56e** of #56 — the last references the walk could not see. Closes #56.

## What was missing

A building's `parts` and `parts2` entries carry matchers of their own — `inpart`, `belowpart`,
`inbuilding` — and `Building.readParts` compiled them into closures and dropped the strings. Exactly
what `Condition` used to do, with the same consequence: an entry whose `belowpart` named a part
nothing registers simply never fired, and nothing said why.

Closed the same way — `Building` retains the entries beside the predicates. **The predicates are
untouched**: they are tested per floor of every building, and re-reading the `ConditionTest` fields
there would be far worse. A closure just cannot be asked what it matches on.

## Writing it found one 56d had missed

`belowpart`. #152 covered `inpart` and `inbuilding` on a condition but not the third matcher on the
same object. Both walks cover all three now.

These are matchers, not dereferences, so they follow the rule #152 settled: a warning, and only when
the pack that would provide the name is installed.

## No golden can catch this one

Nothing in the bundled pack writes `belowpart`, so a revert here would be invisible to both digest
runs. `aBuildingPartsEntryMatchingOnAMissingPartIsAWarning` is the guard instead.

## Verification

```
./gradlew clean build      # pass, 571 tests
./gradlew runDigestCheck          # DRIVERDIGEST=688914e862e938fb — OK, 0 problems
./gradlew runDigestCheckFeatures  # DRIVERDIGEST=7b5348f28e0a6d23 — OK, 0 problems
```

**Both goldens unchanged, bundled pack reports zero.**

## What #56 leaves behind

One thing, and it is not deferred work — it is not answerable at that point in the load:

- **Loot table ids.** A condition's values are checkable as entity ids and not as loot tables: loot
  tables live in a reloadable server registry rather than in the frozen ones compilation sees.
- **Scattered parts' characters**, which the walk cannot know the style for. Their *references* are
  checked; checking their characters against a style they may never be used with is the
  false-positive direction.
