### PR TITLE
refactor: a dimension's height bounds and water line become a value (#129, 129b)

### DIFF
--- a/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
@@ -10,6 +10,7 @@ import dev.krona.urbex.worldgen.ChunkHeightmap;
 import dev.krona.urbex.worldgen.DimensionCaches;
 import dev.krona.urbex.setup.WorldStyleMix;
 import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.LevelShape;
 import dev.krona.urbex.worldgen.WorldStyleField;
 import dev.krona.urbex.worldgen.CityGenerator;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetCompiler;
@@ -233,6 +234,16 @@ public class NullDimensionInfo implements IDimensionInfo {
     @Override
     public WorldGenLevel getWorld() {
         return null;
+    }
+
+    /**
+     * The vanilla overworld's, because a preview runs before any level exists and the overworld is
+     * what it draws. Every planning rule that reads a height bound or the water line now gets a real
+     * answer here rather than an NPE off the null level above (issue #129).
+     */
+    @Override
+    public LevelShape shape() {
+        return LevelShape.VANILLA_OVERWORLD;
     }
 
     @Nullable

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -206,8 +206,8 @@ public class CityGenerator {
 
     private boolean isVoid(ChunkGenContext ctx, int x, int z) {
         ChunkDriver driver = ctx.driver;
-        driver.current(x, provider.getWorld().getMaxY(), z);
-        int minHeight = provider.getWorld().getMinY();
+        driver.current(x, provider.shape().maxY(), z);
+        int minHeight = provider.shape().minY();
         while (driver.getBlock() == air && driver.getY() > minHeight) {
             driver.decY();
         }
@@ -459,8 +459,8 @@ public class CityGenerator {
         boolean hasCollectedDamage = false;
         float[][] collectedDamage = new float[16][16];
 
-        int minSection = provider.getWorld().getMinY() >> 4;
-        int maxSection = provider.getWorld().getMaxY() >> 4;
+        int minSection = provider.shape().minSection();
+        int maxSection = provider.shape().maxSection();
         for (int yy = minSection; yy <= maxSection; yy++) {
             java.util.List<dev.krona.urbex.worldgen.lost.Explosion> sectionExplosions = damageArea.explosionsIntersecting(yy);
             boolean hasExplosions = !sectionExplosions.isEmpty();
@@ -713,7 +713,7 @@ public class CityGenerator {
      */
     private void fillSupportBelow(ChunkGenContext ctx, int x, int z, int y) {
         ChunkDriver driver = ctx.driver;
-        int lowest = provider.getWorld().getMinY() + profile.BEDROCK_LAYER;
+        int lowest = provider.shape().minY() + profile.BEDROCK_LAYER;
         driver.current(x, y, z);
         while (driver.getY() > lowest && isEmpty(driver.getBlock())) {
             driver.block(base);
@@ -727,7 +727,7 @@ public class CityGenerator {
         int maxYTouched = Short.MIN_VALUE;       // Max Y that we touched
         // Find the first non-empty block starting at the given height
         driver.current(x, height, z);
-        int minHeight = provider.getWorld().getMinY();
+        int minHeight = provider.shape().minY();
         // We assume here we are not in a void chunk
         while (isFoliageOrEmpty(ctx.tags, driver.getBlock()) && driver.getY() > minHeight) {
             driver.decY();
@@ -907,7 +907,7 @@ public class CityGenerator {
         boolean building = info.hasBuilding;
 
         if (info.profile.isDefault()) {
-            int minHeight = info.provider.getWorld().getMinY();
+            int minHeight = info.provider.shape().minY();
             BlockState bedrock = Blocks.BEDROCK.defaultBlockState();
             for (int x = 0; x < 16; ++x) {
                 for (int z = 0; z < 16; ++z) {
@@ -931,7 +931,7 @@ public class CityGenerator {
             int ground = info.getCityGroundLevel();
             for (int x = 0; x < 16; x++) {
                 for (int z = 0; z < 16; z++) {
-                    int maxTouchedY = moveDown(ctx, x, z, ground + 1, provider.getWorld().getMaxY() + 1);
+                    int maxTouchedY = moveDown(ctx, x, z, ground + 1, provider.shape().maxBuildHeight());
                     if (maxTouchedY == Short.MIN_VALUE) {
                         moveUp(ctx, x, z, ground, info.waterLevel > info.groundLevel);
                     }
@@ -1037,7 +1037,7 @@ public class CityGenerator {
                 } else {
                     for (int x = 0; x < 16; x++) {
                         for (int z = 0; z < 16; z++) {
-                            driver.setBlockRangeToAir(x, y + 1, z, provider.getWorld().getMaxY() + 1);
+                            driver.setBlockRangeToAir(x, y + 1, z, provider.shape().maxBuildHeight());
                         }
                     }
                 }
@@ -1163,7 +1163,7 @@ public class CityGenerator {
         Predicate<BlockState> checkIronbars = infobarsChar == null ? s -> s == ironbarsState : infoBarSet::contains;
         Character rubbleBlock = info.getBuilding().getRubbleBlock();
 
-        int maxBuildHeight = info.provider.getWorld().getMaxY() + 1;
+        int maxBuildHeight = info.provider.shape().maxBuildHeight();
         for (int x = 0; x < 16; ++x) {
             for (int z = 0; z < 16; ++z) {
                 double v = ruinBuffer[x + z * 16];
@@ -1337,7 +1337,7 @@ public class CityGenerator {
     private void fillToBedrockStreetBlock(ChunkGenContext ctx, ChunkPlan info) {
         ChunkDriver driver = ctx.driver;
         // Base blocks below streets
-        int minHeight = info.provider.getWorld().getMinY();
+        int minHeight = info.provider.shape().minY();
         for (int x = 0; x < 16; ++x) {
             for (int z = 0; z < 16; ++z) {
                 int y = info.getCityGroundLevel() - 1;
@@ -2180,8 +2180,8 @@ public class CityGenerator {
                 // How many go this direction (approx, based on cardinal directions from building as well as number that simply fall down)
                 destroyedBlocks /= info.profile.DEBRIS_TO_NEARBYCHUNK_FACTOR;
                 int startHeight = adjacentInfo.getMaxHeight() + 10;
-                int maxBuildHeight = info.provider.getWorld().getMaxY() + 1;
-                int minBuildHeight = info.provider.getWorld().getMinY();
+                int maxBuildHeight = info.provider.shape().maxBuildHeight();
+                int minBuildHeight = info.provider.shape().minY();
                 if (startHeight > maxBuildHeight - 1) {
                     // Clamp to the top of the world: the old code clamped an out-of-range start
                     // to minBuildHeight - 1, dropping debris at bedrock and reading below minY
@@ -2261,7 +2261,7 @@ public class CityGenerator {
         int lowestLevel = info.getBuildingBottomHeight();
         int cellars = info.cellars;
         int floors = info.getNumFloors();
-        int max = info.provider.getWorld().getMaxY() - 1 - FLOORHEIGHT;
+        int max = info.provider.shape().maxY() - 1 - FLOORHEIGHT;
 
         CompiledPalette palette = info.getCompiledPalette();
         makeRoomForBuilding(ctx, info, lowestLevel, heightmap, palette);
@@ -2337,8 +2337,8 @@ public class CityGenerator {
             // We also remove all blocks from the inside because we generate buildings on top of
             // generated chunks as opposed to blank chunks with non-floating worlds
             double[] bottomLayerBuffer = ctx.buffers.bottomLayer = this.bottomLayerNoise.getRegion(ctx.buffers.bottomLayer, (info.coord.chunkX() << 4), (info.coord.chunkZ() << 4), 16, 16, 8.0 / 16.0, 8.0 / 16.0, 1.0D);
-            int minBuildHeight = info.provider.getWorld().getMinY();
-            int maxBuildHeight = info.provider.getWorld().getMaxY() + 1;
+            int minBuildHeight = info.provider.shape().minY();
+            int maxBuildHeight = info.provider.shape().maxBuildHeight();
             for (int x = 0; x < 16; ++x) {
                 for (int z = 0; z < 16; ++z) {
                     double vr = bottomLayerBuffer[x + z * 16] / 4.0f;

--- a/src/main/java/dev/krona/urbex/worldgen/DefaultDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DefaultDimensionInfo.java
@@ -31,6 +31,7 @@ public class DefaultDimensionInfo implements IDimensionInfo {
     // cannot be swapped out from under a worker thread, which is what the per-dimension lock in
     // CityFeature.place used to be protecting.
     private final WorldGenLevel world;
+    private final LevelShape shape;
     private final AssetSnapshot assets;
     private final Preset profile;
     private final WorldStyleField styles;
@@ -43,6 +44,10 @@ public class DefaultDimensionInfo implements IDimensionInfo {
     public DefaultDimensionInfo(WorldGenLevel world, AssetSnapshot assets, Preset preset,
                                 WorldStyleMix worldStyles) {
         this.world = world.getLevel();
+        // Resolved here, on the thread that loads the level, rather than per call from generation:
+        // the dimension type fixes the two bounds and the chunk generator fixes the sea level, and
+        // neither can change while the level is loaded.
+        this.shape = LevelShape.of(this.world);
         this.assets = assets;
         this.profile = preset;
         this.caches = new DimensionCaches(this.world.getSeed());
@@ -66,6 +71,11 @@ public class DefaultDimensionInfo implements IDimensionInfo {
     @Override
     public WorldGenLevel getWorld() {
         return world;
+    }
+
+    @Override
+    public LevelShape shape() {
+        return shape;
     }
 
     @Override

--- a/src/main/java/dev/krona/urbex/worldgen/IDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/IDimensionInfo.java
@@ -31,6 +31,15 @@ public interface IDimensionInfo {
     WorldGenLevel getWorld();
 
     /**
+     * How deep this dimension goes, how high it goes, and where its water sits.
+     * <p>
+     * Resolved once, when the dimension's runtime is built. Planning and generation ask this rather
+     * than {@link #getWorld()} for the same three numbers, so the code that needs a bound does not
+     * have to hold a level to get one - and so the preview can answer (issue #129).
+     */
+    LevelShape shape();
+
+    /**
      * Registry access for this dimension, or {@code null} if none is available. Real dimensions
      * always have one (it comes straight off {@link #getWorld()}); {@code NullDimensionInfo} is the
      * one implementor that can have registry access - and so be able to evaluate registry-backed

--- a/src/main/java/dev/krona/urbex/worldgen/LevelShape.java
+++ b/src/main/java/dev/krona/urbex/worldgen/LevelShape.java
@@ -1,0 +1,66 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.varia.Tools;
+import net.minecraft.world.level.LevelReader;
+
+/**
+ * The three numbers planning and generation ask a dimension for: how deep it goes, how high it goes,
+ * and where its water sits.
+ *
+ * <p>All three are fixed for the life of a dimension - {@code minY} and {@code maxY} come from its
+ * dimension type, {@code seaLevel} from its chunk generator - so they are a value resolved once when
+ * the level's runtime is built, not three calls made per block.</p>
+ *
+ * <p>They are also the whole of what the planning path wanted {@code IDimensionInfo.getWorld()} for.
+ * Roughly thirty call sites read {@code provider.getWorld().getMaxY()} or
+ * {@code Tools.getSeaLevel(provider.getWorld())}, each of them holding a whole
+ * {@link net.minecraft.world.level.WorldGenLevel} to reach one {@code int}; and each of them a place
+ * the world-creation preview would have thrown, because its {@code getWorld()} answers {@code null}.
+ * Separating the numbers from the level is what lets the preview answer them honestly instead of
+ * being kept away from the code that asks (issue #129).</p>
+ *
+ * @param minY      the lowest block Y this dimension has
+ * @param maxY      the highest block Y this dimension has, inclusive
+ * @param seaLevel  the chunk generator's sea level
+ */
+public record LevelShape(int minY, int maxY, int seaLevel) {
+
+    /**
+     * The vanilla overworld's shape, which the world-creation preview uses.
+     *
+     * <p>A preview runs before any level exists, so there is nothing to ask. This is a guess, but a
+     * defensible one - the preview draws the overworld - and it is the same guess for every preview,
+     * which is what matters: the alternative is not a better number but an exception, which is what
+     * a null level produced.</p>
+     */
+    public static final LevelShape VANILLA_OVERWORLD = new LevelShape(-64, 319, 63);
+
+    public LevelShape {
+        if (maxY < minY) {
+            throw new IllegalArgumentException("Level shape has maxY " + maxY + " below minY " + minY);
+        }
+    }
+
+    /** Resolves the shape of a real level. */
+    public static LevelShape of(LevelReader level) {
+        return new LevelShape(level.getMinY(), level.getMaxY(), Tools.getSeaLevel(level));
+    }
+
+    /**
+     * One past the highest block: the exclusive upper bound most call sites actually want, and which
+     * every one of them used to spell {@code getMaxY() + 1}.
+     */
+    public int maxBuildHeight() {
+        return maxY + 1;
+    }
+
+    /** The lowest section index, for a loop over sections rather than blocks. */
+    public int minSection() {
+        return minY >> 4;
+    }
+
+    /** The highest section index, inclusive. */
+    public int maxSection() {
+        return maxY >> 4;
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
@@ -16,7 +16,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
-import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Blocks;
@@ -159,7 +158,7 @@ public class Scattered {
                 if (profile.isCavern()) {
                     lowestLevel = profile.GROUNDLEVEL;
                 } else {
-                    lowestLevel = provider.getWorld().getMinY() + 2;  // @todo is this right?
+                    lowestLevel = provider.shape().minY() + 2;  // @todo is this right?
                 }
             }
             generateScatteredBuilding(ctx, feature, info, building, scatteredRandom, lowestLevel, scattered.getTerrainfix());
@@ -247,7 +246,7 @@ public class Scattered {
                 if (!reference.isAllowVoid()) {
                     if (!(feature.profile.isDefault() || feature.profile.isCavern())) {
                         // We are in a world that can have void chunks. Check if this chunk is a void chunk
-                        if (height <= provider.getWorld().getMinY() + 3) {
+                        if (height <= provider.shape().minY() + 3) {
                             return AreaScan.INVALID;
                         }
                     }
@@ -360,7 +359,7 @@ public class Scattered {
     }
 
     private static int scatteredLevel(CityGenerator feature, ScatteredBuilding scattered, int minimum, int maximum, int average) {
-        int seaLevel = ((ServerChunkCache) feature.provider.getWorld().getChunkSource()).getGenerator().getSeaLevel();
+        int seaLevel = feature.provider.shape().seaLevel();
         return pickLevel(scattered.getTerrainheight(), minimum, maximum, average, seaLevel) + scattered.getHeightoffset();
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Stuff.java
@@ -84,7 +84,7 @@ public class Stuff {
      * world that no longer existed.
      */
     private static boolean seesSky(ChunkDriver driver, CityGenerator feature, int x, int y, int z) {
-        int maxY = feature.provider.getWorld().getMaxY();
+        int maxY = feature.provider.shape().maxY();
         for (int yy = y; yy <= maxY; yy++) {
             if (!driver.getBlock(x, yy, z).isAir()) {
                 return false;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -674,7 +674,7 @@ public class ChunkPlan {
 
         groundLevel = override != null ? override.groundLevel() : profile.GROUNDLEVEL;
         int wl = profile.SEALEVEL;
-        waterLevel = wl == -1 ? Tools.getSeaLevel(provider.getWorld()) : wl;
+        waterLevel = wl == -1 ? provider.shape().seaLevel() : wl;
         WorldSettings.RailwayAvoidance avoidance = provider.worldStyles().primary().getWorldSettings().railwayAvoidance();
 
         // In a multi building we copy all information from the top-left chunk
@@ -725,7 +725,7 @@ public class ChunkPlan {
                 f = minfloors;
             }
 
-            int max = provider.getWorld().getMaxY() - 1 - FLOORHEIGHT;
+            int max = provider.shape().maxY() - 1 - FLOORHEIGHT;
             while (getCityGroundLevel() + f * FLOORHEIGHT >= max) {
                 f--;
             }
@@ -1681,8 +1681,8 @@ public class ChunkPlan {
      * Return Integer.MIN_VALUE if the building is degenerate (no floors, no cellars).
      */
     public int getBuildingBottomHeight() {
-        int min = provider.getWorld().getMinY() + 2;
-        int max = provider.getWorld().getMaxY() - 1 - FLOORHEIGHT;
+        int min = provider.shape().minY() + 2;
+        int max = provider.shape().maxY() - 1 - FLOORHEIGHT;
 
         // Locals. This used to decrement the published cellars and floors as it walked, so the answer
         // depended on how many times it had been asked: the first call shrank the building and every
@@ -1782,7 +1782,7 @@ public class ChunkPlan {
             int cz = coord.chunkZ();
 
             // @todo build limit
-            if (h < provider.getWorld().getMaxY() + 1) {
+            if (h < provider.shape().maxBuildHeight()) {
                 // The L0 height at this corner is fixed so we return that
                 desiredMaxHeight1 = new MinMax(
                         h + CityGenerator.getRandomizedOffset(provider.getSeed(), cx, cz, profile.TERRAIN_FIX_LOWER_MIN_OFFSET, profile.TERRAIN_FIX_LOWER_MAX_OFFSET, Rng.Purpose.TERRAIN_FIX_LOWER),
@@ -1836,7 +1836,7 @@ public class ChunkPlan {
         if (desiredTerrainCorrectionHeights == null) {
             MinMax mm = getDesiredMaxHeightL1();
             // @todo build limit
-            if (mm.min < provider.getWorld().getMaxY() + 1) {
+            if (mm.min < provider.shape().maxBuildHeight()) {
                 // The L1 height at this corner is fixed so we return that
                 desiredTerrainCorrectionHeights = new MinMax(mm);
                 return desiredTerrainCorrectionHeights;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
@@ -38,9 +38,9 @@ public class DamageArea {
         this.chunkX = chunkX;
         this.chunkZ = chunkZ;
         this.air = Blocks.AIR.defaultBlockState();
-        chunkBox = new AABB(chunkX << 4, provider.getWorld().getMinY(), chunkZ << 4, (chunkX << 4) + 15, provider.getWorld().getMaxY() + 1, (chunkZ << 4) + 15);
-        this.minSectionY = provider.getWorld().getMinY() >> 4;
-        this.maxSectionY = provider.getWorld().getMaxY() >> 4;
+        chunkBox = new AABB(chunkX << 4, provider.shape().minY(), chunkZ << 4, (chunkX << 4) + 15, provider.shape().maxBuildHeight(), (chunkZ << 4) + 15);
+        this.minSectionY = provider.shape().minSection();
+        this.maxSectionY = provider.shape().maxSection();
 
         int offset = (Math.max(info.profile.EXPLOSION_MAXRADIUS, info.profile.MINI_EXPLOSION_MAXRADIUS)+15) / 16;
         for (int cx = chunkX - offset; cx <= chunkX + offset; cx++) {
@@ -108,7 +108,7 @@ public class DamageArea {
         }
         if (Rng.floatAtPos(seed, x, y, z, Rng.Purpose.DAMAGE) <= damage) {
             BlockState damaged = palette.canBeDamagedToIronBars(b);
-            int waterlevel = Tools.getSeaLevel(provider.getWorld());//profile.GROUNDLEVEL - profile.WATERLEVEL_OFFSET;
+            int waterlevel = provider.shape().seaLevel();//profile.GROUNDLEVEL - profile.WATERLEVEL_OFFSET;
             if (damage < BLOCK_DAMAGE_CHANCE && damaged != null) {
                 if (Rng.floatAtPos(seed, x, y, z, Rng.Purpose.DAMAGE_VARIANT) < .7f) {
                     b = damaged;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/PrimaryBridgePlanner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/PrimaryBridgePlanner.java
@@ -6,7 +6,6 @@ import dev.krona.urbex.plan.RoadType;
 import dev.krona.urbex.plan.grid.GridPurpose;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Rng;
-import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.CityGenerator;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
@@ -313,7 +312,7 @@ public final class PrimaryBridgePlanner {
                     return true;
                 }
                 int sealevel = provider.getProfile().SEALEVEL;
-                int waterLevel = sealevel == -1 ? Tools.getSeaLevel(provider.getWorld()) : sealevel;
+                int waterLevel = sealevel == -1 ? provider.shape().seaLevel() : sealevel;
                 return provider.getHeightmap(coord).getHeight() < waterLevel;
             }
         };

--- a/src/test/java/dev/krona/urbex/worldgen/LevelShapeTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/LevelShapeTest.java
@@ -1,0 +1,50 @@
+package dev.krona.urbex.worldgen;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The arithmetic every call site used to spell out for itself.
+ * <p>
+ * {@code getMaxY() + 1}, {@code getMinY() >> 4} and {@code getMaxY() >> 4} appeared at roughly thirty
+ * places across the generator and the planners. Each was correct; the point of naming them is that
+ * the next one does not have to be re-derived, and that a preview can answer them without a level
+ * (issue #129).
+ */
+class LevelShapeTest {
+
+    @Test
+    void maxBuildHeightIsOnePastTheHighestBlock() {
+        assertEquals(320, new LevelShape(-64, 319, 63).maxBuildHeight());
+    }
+
+    @Test
+    void sectionBoundsRoundTowardsNegativeInfinity() {
+        LevelShape shape = new LevelShape(-64, 319, 63);
+        assertEquals(-4, shape.minSection(), "-64 >> 4, not -64 / 16 rounded towards zero");
+        assertEquals(19, shape.maxSection());
+
+        // The arithmetic shift is what makes a below-zero floor land in the right section: a
+        // division would put -1 in section 0 rather than section -1.
+        assertEquals(-1, new LevelShape(-1, 15, 0).minSection());
+    }
+
+    @Test
+    void theVanillaOverworldShapeIsTheOneTheWorldCreationPreviewDraws() {
+        assertEquals(-64, LevelShape.VANILLA_OVERWORLD.minY());
+        assertEquals(319, LevelShape.VANILLA_OVERWORLD.maxY());
+        assertEquals(63, LevelShape.VANILLA_OVERWORLD.seaLevel());
+        assertEquals(384, LevelShape.VANILLA_OVERWORLD.maxBuildHeight()
+                - LevelShape.VANILLA_OVERWORLD.minY(), "384 blocks tall, as the dimension type says");
+    }
+
+    @Test
+    void anInvertedShapeIsRefusedWhereItIsBuiltRatherThanWhereItIsUsed() {
+        // A shape with maxY below minY makes every loop over it run zero times, silently: no city
+        // content, no exception, no log line. Refusing it at construction is the only place the
+        // numbers are together.
+        assertThrows(IllegalArgumentException.class, () -> new LevelShape(10, 9, 5));
+    }
+}


### PR DESCRIPTION
Roughly thirty call sites across the generator and the planners reached
provider.getWorld() to read one int off it: getMinY(), getMaxY(), or
Tools.getSeaLevel(). All three are fixed for the life of a dimension - the
first two come from its dimension type, the third from its chunk generator -
so they are resolved once now, when the level's runtime is built, and carried
as a LevelShape.

The point is not the call count. It is that "give me a WorldGenLevel" and
"give me the sea level" are different questions, and only one of them the
world-creation preview can be refused. NullDimensionInfo answers getWorld()
with null, so every one of these sites was a place the preview would have
thrown, and the planning code that reaches them is fenced off from it by
getWorld() != null guards rather than by anything about what it computes.
Separating the numbers from the level is what will let those guards go.

LevelShape also names the arithmetic each site was re-deriving:
maxBuildHeight() for the getMaxY() + 1 that fourteen of them wrote out, and
minSection()/maxSection() for the shifts. It refuses an inverted shape at
construction, where the two numbers are together - a maxY below minY makes
every loop over it run zero times, with no exception and no log line.

One incidental removal: Scattered's sea level was an unchecked
ServerChunkCache cast reaching for the generator, which is what
Tools.getSeaLevel does properly.

No behaviour change. The preview reaches none of these sites today; what
changes is that it could.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>