### PR TITLE
refactor: terrain sampling behind a port, and IDimensionInfo stops handing out a level (#129, 129c)

### DIFF
--- a/src/main/java/dev/krona/urbex/commands/CommandDebug.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandDebug.java
@@ -88,7 +88,7 @@ public class CommandDebug implements Command<CommandSourceStack> {
         int explosions = info.getExplosions().size();
         line(context, "explosions = " + explosions);
 
-        ChunkHeightmap heightmap = dimInfo.getFeature().getHeightmap(info.coord, (WorldGenLevel) player.level());
+        ChunkHeightmap heightmap = dimInfo.getHeightmap(info.coord);
         line(context, "Chunk height (heightmap): " + heightmap.getHeight());
 
         line(context, "dimInfo.getProfile().BUILDING_MINFLOORS = " + dimInfo.getProfile().BUILDING_MINFLOORS);

--- a/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
@@ -2,11 +2,10 @@ package dev.krona.urbex.gui;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.gui.preview.PreviewTerrain;
 import dev.krona.urbex.plan.RoadField;
 import dev.krona.urbex.plan.grid.GridRoadField;
 import dev.krona.urbex.plan.grid.GridSettings;
-import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.ChunkHeightmap;
 import dev.krona.urbex.worldgen.DimensionCaches;
 import dev.krona.urbex.setup.WorldStyleMix;
 import dev.krona.urbex.worldgen.IDimensionInfo;
@@ -22,19 +21,10 @@ import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
 import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.util.RandomSource;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.WorldGenLevel;
-import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.Biomes;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -45,85 +35,19 @@ import java.util.Random;
 
 public class NullDimensionInfo implements IDimensionInfo {
 
-    public static final int PREVIEW_WIDTH = 62;
-    public static final int PREVIEW_HEIGHT = 58;
-
     /** What the placeholder world style calls itself, so a load error can name it. */
     private static final Identifier PLACEHOLDER_ID =
             Identifier.fromNamespaceAndPath(Urbex.MODID, "preview_placeholder");
     /** A style the bundled pack actually ships, and qualified; see {@link #placeholderStyle()}. */
     private static final String PLACEHOLDER_OUTSIDE_STYLE = Urbex.MODID + ":standard";
 
-    private final String[] biomeMap = new String[] {
-            "ddddddddddddddddddddddppppppppppppppp==ppppppppppppppppppppppp",
-            "ddddddddddddddddddddpppppppppppppppp==pppppppppppppppppppppppp",
-            "ddddddddddddddddddddpppppppppppppp===ppppppppppppppppppppppppp",
-            "pddddddddddddddddpppppppppppppppppp==ppppppppppppppppppppppppp",
-            "pppdddddddppppppppppppppppppppppppp==ppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppp==pppppppppp----------pppp",
-            "ppppppppppppppppppppppppppppppppppppp==ppppppp--------------pp",
-            "pppppppppppppppppppppppppppppppppppppp==ppppp-----------------",
-            "pppppppppppppppppppppppppppppppppppppp===pppp-----------------",
-            "ppppppppppppppppppppppppppppppppppppppp===ppppp---------------",
-            "pppppppppppppppppppppppppppppppppppppppp==--pp----------------",
-            "pppppppppppppppppppppppppppppppppppppppp*---------------------",
-            "pppppppppppppppppppppppppppppppppppppp****--------------------",
-            "ppppppppppppppppppppppppppppppppppppp***----------------------",
-            "pppppppppppppppppppppppppppppppppppp**------------------------",
-            "ppppppppppppppppppppppppppppppppppppp**-----------------------",
-            "ppppppppppppppppppppppppppppppppppppppp*----------------------",
-            "pppppppppppppppppppppppppppppppppppppp**----------------------",
-            "ppppp###pppppppppppppppppppppppppppppp**----------------------",
-            "ppppp####ppppppp#####pppppppppppppppppp*----------------------",
-            "pppppp#####pp##+++#####ppppppppppppp*****---------------------",
-            "pppppppp#####++++####pppppppppppppp**------pp----p------------",
-            "ppppppppp##++++++###pppppppppppppppp***---pppp--ppp-----------",
-            "ppppppppp###+++++++#####ppppppppppppp---pppppppppppp---------p",
-            "pppppppp##p##+++++++###ppppppppppppppppppppppppppppp---------p",
-            "pppppppppp#####++++####ppppppppppppppppppppppppppppppppp----pp",
-            "pppppppppppp###+++++###ppppppppppppppppppppppppppppppppppppppp",
-            "ppppppppppppp####++++####ppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppp####++######pppppppppppppppppppppppppppppppppppp",
-            "ppppppppppppppp#+++####ppppppppppppppppppppppppppppppppppppppp",
-            "ppppppppppppp####pp#####pppppppppppppppppppppppppppppppppppppp",
-            "pppppppppp#####ppppppppppppppppppppppppppppppppppppppppppppppp",
-            "ppppppppppp###pppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
-            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp"
-    };
-
     private final Preset profile;
     private final WorldStyleField styles;
     private final Random random;
     private final long seed;
 
-    private final RegistryAccess registryAccess;
     private final AssetSnapshot assets;
-    @Nullable
-    private final Registry<Biome> biomeRegistry;
+    private final PreviewTerrain terrain;
     private final CityGenerator feature;
     private final DimensionCaches caches;
     private final RoadField roadField;
@@ -166,9 +90,8 @@ public class NullDimensionInfo implements IDimensionInfo {
         styles = new WorldStyleField(seed, resolvedEntries);
         this.seed = seed;
         random = new Random(seed);
+        terrain = new PreviewTerrain(profile, registryAccess);
         feature = new CityGenerator(this, profile);
-        this.registryAccess = registryAccess;
-        biomeRegistry = registryAccess != null ? registryAccess.lookupOrThrow(Registries.BIOME) : null;
         // The preview's own seed and dimension, so the roads it draws are the roads the world will
         // have. Same construction as DefaultDimensionInfo; there is no server to ask.
         roadField = new GridRoadField(seed, getType().identifier().toString(), GridSettings.fromPreset(profile));
@@ -231,11 +154,6 @@ public class NullDimensionInfo implements IDimensionInfo {
         return seed;
     }
 
-    @Override
-    public WorldGenLevel getWorld() {
-        return null;
-    }
-
     /**
      * The vanilla overworld's, because a preview runs before any level exists and the overworld is
      * what it draws. Every planning rule that reads a height bound or the water line now gets a real
@@ -253,8 +171,8 @@ public class NullDimensionInfo implements IDimensionInfo {
     }
 
     @Override
-    public RegistryAccess registryAccess() {
-        return registryAccess;
+    public PreviewTerrain terrain() {
+        return terrain;
     }
 
     @Override
@@ -292,92 +210,9 @@ public class NullDimensionInfo implements IDimensionInfo {
         return feature;
     }
 
-    @Override
-    public ChunkHeightmap getHeightmap(ChunkCoord coord) {
-        int chunkX = coord.chunkX();
-        int chunkZ = coord.chunkZ();
-        ChunkHeightmap heightmap = new ChunkHeightmap(profile.LANDSCAPE_TYPE, profile.GROUNDLEVEL);
-        char b = getBiomeChar(chunkX, chunkZ);
-        int y = switch (b) {
-            case 'p' -> 65;
-            case '-' -> 60;
-            case '=' -> 65;
-            case '#' -> 95;
-            case '+' -> 125;
-            case '*' -> 65;
-            case 'd' -> 65;
-            default -> 65;
-        };
-        heightmap.update(y);
-        return heightmap;
-    }
-
-    @Override
-    public ChunkHeightmap getHeightmap(int chunkX, int chunkZ) {
-        ChunkCoord coord = new ChunkCoord(getType(), chunkX, chunkZ);
-        return getHeightmap(coord);
-    }
-
+    /** The bitmap character at a chunk, for the renderer that colours the preview map from it. */
     public char getBiomeChar(int chunkX, int chunkZ) {
-        if (chunkX >= 0 && chunkX < PREVIEW_WIDTH && chunkZ >= 0 && chunkZ < PREVIEW_HEIGHT) {
-            return biomeMap[chunkZ].charAt(chunkX);
-        } else {
-            return 'p';
-        }
-    }
-
-//    @Override
-//    public Biome[] getBiomes(int chunkX, int chunkZ) {
-//        Biome[] biomes = new Biome[10*10];
-//        Biome biome = Biomes.PLAINS;
-//        char b = getBiomeChar(chunkX, chunkZ);
-//        switch (b) {
-//            case 'p': biome = Biomes.PLAINS; break;
-//            case '-': biome = Biomes.OCEAN; break;
-//            case '=': biome = Biomes.RIVER; break;
-//            case '#': biome = Biomes.MOUNTAIN_EDGE; break;
-//            case '+': biome = Biomes.MOUNTAINS; break;
-//            case '*': biome = Biomes.BEACH; break;
-//            case 'd': biome = Biomes.DESERT; break;
-//        }
-//        for (int i = 0 ; i < biomes.length ; i++) {
-//            biomes[i] = biome;
-//        }
-//        return biomes;
-//    }
-
-    @Nullable
-    @Override
-    public Holder<Biome> getBiome(BlockPos pos) {
-        if (biomeRegistry == null) {
-            // #67: no registry access means there's no registry to resolve even a plains fallback
-            // from - dereferencing it unconditionally is what used to NPE here. This is not a
-            // legacy shim: there is one constructor, and the GUI passes null to it deliberately
-            // whenever the world-creation context has no biome registry yet, or (in the Customize
-            // screen) no parent screen at all - see CitiesTab.previewRegistries and
-            // CustomizeScreen.previewRegistries. Every caller currently reachable without registry
-            // access (ChunkPlan.getChunkCandidateGui and friends) never dereferences this
-            // result: the registryAccess()-gated rules in City that do read biomes only run when
-            // we're not in this branch.
-            Urbex.LOGGER.warn("NullDimensionInfo.getBiome() called without registry access; returning null.");
-            return null;
-        }
-        ChunkPos cp = ChunkPos.containing(pos);
-        char b = getBiomeChar(cp.x(), cp.z());
-        ResourceKey<Biome> biome = switch (b) {
-            case 'p' -> Biomes.PLAINS;
-            case '-' -> Biomes.OCEAN;
-            case '=' -> Biomes.RIVER;
-            case '#' -> Biomes.STONY_PEAKS;
-            // @todo 1.18
-            case '+' -> Biomes.JAGGED_PEAKS;
-            // @todo 1.18
-            case '*' -> Biomes.BEACH;
-            case 'd' -> Biomes.DESERT;
-            // Plains fallback for anything unmapped, same as the old default branch.
-            default -> Biomes.PLAINS;
-        };
-        return biomeRegistry.getOrThrow(biome);
+        return terrain.biomeChar(chunkX, chunkZ);
     }
 
     @Override

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -69,8 +69,8 @@ public class CityPreview implements AutoCloseable {
         ROADS
     }
 
-    public static final int WIDTH = NullDimensionInfo.PREVIEW_WIDTH;
-    public static final int HEIGHT = NullDimensionInfo.PREVIEW_HEIGHT;
+    public static final int WIDTH = PreviewTerrain.WIDTH;
+    public static final int HEIGHT = PreviewTerrain.HEIGHT;
 
     /** The fixed-height legend strip {@link #render} draws below the map; public so callers that
      *  size a host widget can budget for it (the map itself keeps the {@link #WIDTH}:{@link #HEIGHT}

--- a/src/main/java/dev/krona/urbex/gui/preview/PreviewTerrain.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/PreviewTerrain.java
@@ -1,0 +1,178 @@
+package dev.krona.urbex.gui.preview;
+
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.ChunkHeightmap;
+import dev.krona.urbex.worldgen.TerrainSampler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+
+import javax.annotation.Nullable;
+
+/**
+ * The world-creation preview's terrain: a hand-drawn 62x58 biome bitmap, and heights derived from it.
+ *
+ * <p>The preview draws a fixed landscape - a coastline, a river, a mountain range, a desert - so that
+ * the effect of a preset can be judged against terrain features rather than against whatever the seed
+ * happens to produce. It is not the terrain the world will have, and never was; what it is for is
+ * comparing two presets, or two positions of one slider, on the same ground.</p>
+ *
+ * <p>Extracted from {@code NullDimensionInfo}, which held the bitmap alongside a world style, a
+ * generator, a road field and a preset while answering {@code null} to "what level are you?". The
+ * bitmap is the only part of that the production planner actually needs from a preview (issue
+ * #129).</p>
+ */
+public final class PreviewTerrain implements TerrainSampler {
+
+    public static final int WIDTH = 62;
+    public static final int HEIGHT = 58;
+
+    private static final String[] BIOME_MAP = new String[] {
+            "ddddddddddddddddddddddppppppppppppppp==ppppppppppppppppppppppp",
+            "ddddddddddddddddddddpppppppppppppppp==pppppppppppppppppppppppp",
+            "ddddddddddddddddddddpppppppppppppp===ppppppppppppppppppppppppp",
+            "pddddddddddddddddpppppppppppppppppp==ppppppppppppppppppppppppp",
+            "pppdddddddppppppppppppppppppppppppp==ppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppp==pppppppppp----------pppp",
+            "ppppppppppppppppppppppppppppppppppppp==ppppppp--------------pp",
+            "pppppppppppppppppppppppppppppppppppppp==ppppp-----------------",
+            "pppppppppppppppppppppppppppppppppppppp===pppp-----------------",
+            "ppppppppppppppppppppppppppppppppppppppp===ppppp---------------",
+            "pppppppppppppppppppppppppppppppppppppppp==--pp----------------",
+            "pppppppppppppppppppppppppppppppppppppppp*---------------------",
+            "pppppppppppppppppppppppppppppppppppppp****--------------------",
+            "ppppppppppppppppppppppppppppppppppppp***----------------------",
+            "pppppppppppppppppppppppppppppppppppp**------------------------",
+            "ppppppppppppppppppppppppppppppppppppp**-----------------------",
+            "ppppppppppppppppppppppppppppppppppppppp*----------------------",
+            "pppppppppppppppppppppppppppppppppppppp**----------------------",
+            "ppppp###pppppppppppppppppppppppppppppp**----------------------",
+            "ppppp####ppppppp#####pppppppppppppppppp*----------------------",
+            "pppppp#####pp##+++#####ppppppppppppp*****---------------------",
+            "pppppppp#####++++####pppppppppppppp**------pp----p------------",
+            "ppppppppp##++++++###pppppppppppppppp***---pppp--ppp-----------",
+            "ppppppppp###+++++++#####ppppppppppppp---pppppppppppp---------p",
+            "pppppppp##p##+++++++###ppppppppppppppppppppppppppppp---------p",
+            "pppppppppp#####++++####ppppppppppppppppppppppppppppppppp----pp",
+            "pppppppppppp###+++++###ppppppppppppppppppppppppppppppppppppppp",
+            "ppppppppppppp####++++####ppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppp####++######pppppppppppppppppppppppppppppppppppp",
+            "ppppppppppppppp#+++####ppppppppppppppppppppppppppppppppppppppp",
+            "ppppppppppppp####pp#####pppppppppppppppppppppppppppppppppppppp",
+            "pppppppppp#####ppppppppppppppppppppppppppppppppppppppppppppppp",
+            "ppppppppppp###pppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp"
+    };
+
+    private final Preset preset;
+    @Nullable
+    private final RegistryAccess registryAccess;
+    @Nullable
+    private final Registry<Biome> biomeRegistry;
+
+    public PreviewTerrain(Preset preset, @Nullable RegistryAccess registryAccess) {
+        this.preset = preset;
+        this.registryAccess = registryAccess;
+        this.biomeRegistry = registryAccess != null ? registryAccess.lookupOrThrow(Registries.BIOME) : null;
+    }
+
+    /** The bitmap character at a chunk, for the renderer that colours the map from it. */
+    public char biomeChar(int chunkX, int chunkZ) {
+        if (chunkX >= 0 && chunkX < WIDTH && chunkZ >= 0 && chunkZ < HEIGHT) {
+            return BIOME_MAP[chunkZ].charAt(chunkX);
+        }
+        return 'p';
+    }
+
+    @Override
+    public ChunkHeightmap heightmap(ChunkCoord coord) {
+        ChunkHeightmap heightmap = new ChunkHeightmap(preset.LANDSCAPE_TYPE, preset.GROUNDLEVEL);
+        heightmap.update(groundAt(coord.chunkX(), coord.chunkZ()));
+        return heightmap;
+    }
+
+    /**
+     * The preview's terrain is flat within a chunk, so the four extra samples are the chunk's own
+     * height and the min/max collapse to it. A real generator's four corners disagree; a bitmap's
+     * cannot.
+     */
+    @Override
+    public void sampleAccurateHeight(ChunkHeightmap heightmap, int chunkX, int chunkZ) {
+        int ground = groundAt(chunkX, chunkZ);
+        heightmap.accurateHeights(ground, ground, ground, ground);
+    }
+
+    private int groundAt(int chunkX, int chunkZ) {
+        return switch (biomeChar(chunkX, chunkZ)) {
+            case '-' -> 60;
+            case '#' -> 95;
+            case '+' -> 125;
+            // 'p', '=', '*', 'd' and anything unmapped: the bitmap's baseline.
+            default -> 65;
+        };
+    }
+
+    @Nullable
+    @Override
+    public Holder<Biome> biome(BlockPos pos) {
+        if (biomeRegistry == null) {
+            // #67: no registry access means there is no registry to resolve even a plains fallback
+            // from - dereferencing it unconditionally is what used to NPE here. The GUI passes null
+            // deliberately whenever the world-creation context has no biome registry yet, or (in the
+            // Customize screen) no parent screen at all. Every caller reachable in that state is
+            // gated on registryAccess() and never dereferences this result.
+            Urbex.LOGGER.warn("Preview terrain asked for a biome without registry access; returning null.");
+            return null;
+        }
+        ChunkPos cp = ChunkPos.containing(pos);
+        ResourceKey<Biome> biome = switch (biomeChar(cp.x(), cp.z())) {
+            case '-' -> Biomes.OCEAN;
+            case '=' -> Biomes.RIVER;
+            case '#' -> Biomes.STONY_PEAKS;
+            case '+' -> Biomes.JAGGED_PEAKS;
+            case '*' -> Biomes.BEACH;
+            case 'd' -> Biomes.DESERT;
+            // Plains for 'p' and for anything unmapped, same as the old default branch.
+            default -> Biomes.PLAINS;
+        };
+        return biomeRegistry.getOrThrow(biome);
+    }
+
+    @Nullable
+    @Override
+    public RegistryAccess registryAccess() {
+        return registryAccess;
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkHeightmap.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkHeightmap.java
@@ -1,11 +1,6 @@
 package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.config.LandscapeType;
-import net.minecraft.server.level.ServerChunkCache;
-import net.minecraft.world.level.WorldGenLevel;
-import net.minecraft.world.level.chunk.ChunkGenerator;
-import net.minecraft.world.level.levelgen.Heightmap;
-import net.minecraft.world.level.levelgen.RandomState;
 
 /**
  * A heightmap for a chunk
@@ -64,17 +59,18 @@ public class ChunkHeightmap {
         this.height = height;
     }
 
-    public void calculateAccurateHeight(WorldGenLevel region, int chunkX, int chunkZ) {
-        ServerChunkCache chunkProvider = region.getLevel().getChunkSource();
-        ChunkGenerator generator = chunkProvider.getGenerator();
-        int cx = chunkX << 4;
-        int cz = chunkZ << 4;
-        RandomState randomState = chunkProvider.randomState();
-        // Average of height and 4 other points
-        int height0 = generator.getBaseHeight(cx + 2, cz + 2, Heightmap.Types.OCEAN_FLOOR_WG, region, randomState);
-        int height1 = generator.getBaseHeight(cx + 2, cz + 14, Heightmap.Types.OCEAN_FLOOR_WG, region, randomState);
-        int height2 = generator.getBaseHeight(cx + 14, cz + 2, Heightmap.Types.OCEAN_FLOOR_WG, region, randomState);
-        int height3 = generator.getBaseHeight(cx + 14, cz + 14, Heightmap.Types.OCEAN_FLOOR_WG, region, randomState);
+    /**
+     * Folds four extra sampled heights into this map's min/max, alongside its own.
+     * <p>
+     * Used to be {@code calculateAccurateHeight(WorldGenLevel, chunkX, chunkZ)}, which took a level
+     * only to reach the chunk generator and sample those four points itself. Where the samples come
+     * from is {@link TerrainSampler#sampleAccurateHeight}'s business - a preview has no generator to
+     * ask - and folding them in is this class's (issue #129).
+     * <p>
+     * Reads the raw {@link #height} field rather than {@link #getHeight()}, unchanged: an unsampled
+     * map contributes {@link Short#MIN_VALUE} to the minimum, not its ground level.
+     */
+    public void accurateHeights(int height0, int height1, int height2, int height3) {
         minHeight = Math.min(height, Math.min(height0, Math.min(height1, Math.min(height2, height3))));
         maxHeight = Math.max(height, Math.max(height0, Math.max(height1, Math.max(height2, height3))));
     }

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -34,17 +34,13 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.block.state.properties.RailShape;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 import net.minecraft.world.level.levelgen.GenerationStep;
-import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
 import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
-import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
@@ -235,7 +231,7 @@ public class CityGenerator {
         // value whose presence depends on whether this chunk ran before or after its neighbour
         // read it - the neighbour's border height, and so the terrain, would depend on generation
         // order. See Arilas/urbex#24.
-        ChunkHeightmap heightmap = new ChunkHeightmap(getHeightmap(coord, provider.getWorld()));
+        ChunkHeightmap heightmap = new ChunkHeightmap(provider.getHeightmap(coord));
         ChunkPlan info = ChunkPlan.getChunkPlan(coord, provider);
         // runtime.tags() is read here and nowhere else in this generation: one call, at the start,
         // so a /reload landing mid-chunk cannot be observed halfway through a building (issue #128).
@@ -428,7 +424,7 @@ public class CityGenerator {
     private void doNormalChunk(ChunkGenContext ctx, ChunkPlan info, ChunkHeightmap heightmap, AvoidChunk avoidChunk) {
 //        debugClearChunk(chunkX, chunkZ, primer);
         if ((avoidChunk != AvoidChunk.YES || !Config.AVOID_FLATTENING.get()) && profile.isDefault()) {
-            correctTerrainShape(ctx, provider.getWorld(), info.coord, heightmap);
+            correctTerrainShape(ctx, info.coord, heightmap);
 //            flattenChunkToCityBorder(chunkX, chunkZ);
         }
 
@@ -602,15 +598,15 @@ public class CityGenerator {
      * or up the top layer (6 thick) of the terrain. In a chunk these heights are interpolated
      * (bilinear interpolation).
      */
-    private void correctTerrainShape(ChunkGenContext ctx, WorldGenLevel level, ChunkCoord coord, ChunkHeightmap heightmap) {
+    private void correctTerrainShape(ChunkGenContext ctx, ChunkCoord coord, ChunkHeightmap heightmap) {
         ChunkPlan info = ChunkPlan.getChunkPlan(coord, provider);
         ChunkPlan.MinMax mm00 = info.getDesiredMaxHeightL2();
         ChunkPlan.MinMax mm10 = info.getXmax().getDesiredMaxHeightL2();
         ChunkPlan.MinMax mm01 = info.getZmax().getDesiredMaxHeightL2();
         ChunkPlan.MinMax mm11 = info.getXmax().getZmax().getDesiredMaxHeightL2();
 
-        int min = level.getMinY();
-        int max = level.getMaxY() + 1;
+        int min = provider.shape().minY();
+        int max = provider.shape().maxBuildHeight();
         int heightmapH = Short.MIN_VALUE;
 
         float min00 = mm00.min;
@@ -823,83 +819,31 @@ public class CityGenerator {
      */
     public int getMinHeightAt(ChunkPlan info, int x, int z, ChunkHeightmap heightmap) {
         int height = heightmap.getHeight();
-        WorldGenLevel world = info.provider.getWorld();
         int adjacent;
         if (x == 0) {
             if (z == 0) {
-                adjacent = getHeightmap(info.coord.northWest(), world).getHeight();
+                adjacent = provider.getHeightmap(info.coord.northWest()).getHeight();
             } else if (z == 15) {
-                adjacent = getHeightmap(info.coord.southWest(), world).getHeight();
+                adjacent = provider.getHeightmap(info.coord.southWest()).getHeight();
             } else {
-                adjacent = getHeightmap(info.coord.west(), world).getHeight();
+                adjacent = provider.getHeightmap(info.coord.west()).getHeight();
             }
         } else if (x == 15) {
             if (z == 0) {
-                adjacent = getHeightmap(info.coord.northEast(), world).getHeight();
+                adjacent = provider.getHeightmap(info.coord.northEast()).getHeight();
             } else if (z == 15) {
-                adjacent = getHeightmap(info.coord.southEast(), world).getHeight();
+                adjacent = provider.getHeightmap(info.coord.southEast()).getHeight();
             } else {
-                adjacent = getHeightmap(info.coord.east(), world).getHeight();
+                adjacent = provider.getHeightmap(info.coord.east()).getHeight();
             }
         } else if (z == 0) {
-            adjacent = getHeightmap(info.coord.north(), world).getHeight();
+            adjacent = provider.getHeightmap(info.coord.north()).getHeight();
         } else if (z == 15) {
-            adjacent = getHeightmap(info.coord.south(), world).getHeight();
+            adjacent = provider.getHeightmap(info.coord.south()).getHeight();
         } else {
             return height;
         }
         return Math.min(height, adjacent);
-    }
-
-    public ChunkHeightmap getHeightmap(ChunkCoord chunk, @Nonnull WorldGenLevel world) {
-        int heightSampleSize = Config.HEIGHT_SAMPLE_SIZE.get();
-        // The block this chunk shares a sampled height with, and the coordinate that height is taken
-        // at. Both come from HeightSampleGrid so that the tiling is a partition and the sampled
-        // coordinate is a function of the block rather than of whichever chunk asked first - see the
-        // note there for what the old arithmetic did at the origin, and issue #126.
-        int top = HeightSampleGrid.anchor(chunk.chunkX(), heightSampleSize);
-        int left = HeightSampleGrid.anchor(chunk.chunkZ(), heightSampleSize);
-        ChunkCoord sampler = new ChunkCoord(chunk.dimension(),
-                HeightSampleGrid.sampler(top, heightSampleSize),
-                HeightSampleGrid.sampler(left, heightSampleSize));
-        // No lock. The heightmap is a pure function of the generator and the coordinate, so two
-        // threads that race on the same chunk build two equal heightmaps and one of them is thrown
-        // away; a third thread reading the cache sees whichever was published, and they agree.
-        //
-        // That holds only as long as nobody writes to what this returns. The instance is shared,
-        // so a caller that needs to mutate one - correctTerrainShape's setHeight,
-        // calculateAccurateHeight - must take a copy first (the copy constructor exists for this).
-        // Mutating the published instance would be a data race on a plain int field and, worse,
-        // would make what a neighbouring chunk reads depend on generation order.
-        TimedCache<ChunkCoord, ChunkHeightmap> cachedHeightmaps = provider.caches().heightmap;
-        ChunkHeightmap cached = cachedHeightmaps.get(chunk);
-        if (cached != null) {
-            return cached;
-        }
-        ChunkHeightmap heightmap = new ChunkHeightmap(profile.LANDSCAPE_TYPE, profile.GROUNDLEVEL);
-        generateHeightmap(sampler.chunkX(), sampler.chunkZ(), world, heightmap);
-        if (heightSampleSize > 1) {
-            for (int i = 0; i < heightSampleSize; i++) {
-                for (int j = 0; j < heightSampleSize; j++) {
-                    ChunkCoord sampleKey = new ChunkCoord(chunk.dimension(), top + i, left + j);
-                    cachedHeightmaps.putIfAbsent(sampleKey, new ChunkHeightmap(heightmap));
-                }
-            }
-        } else {
-            cachedHeightmaps.putIfAbsent(chunk, heightmap);
-        }
-        return heightmap;
-    }
-
-    private void generateHeightmap(int chunkX, int chunkZ, WorldGenLevel region, ChunkHeightmap heightmap) {
-        ServerChunkCache chunkProvider = region.getLevel().getChunkSource();
-        ChunkGenerator generator = chunkProvider.getGenerator();
-        int cx = chunkX << 4;
-        int cz = chunkZ << 4;
-        RandomState randomState = chunkProvider.randomState();
-
-        int height = generator.getBaseHeight(cx + 8, cz + 8, Heightmap.Types.OCEAN_FLOOR_WG, region, randomState);
-        heightmap.update(height);
     }
 
     private void doCityChunk(ChunkGenContext ctx, ChunkPlan info, ChunkHeightmap heightmap, ChunkAccess chunk) {

--- a/src/main/java/dev/krona/urbex/worldgen/DefaultDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DefaultDimensionInfo.java
@@ -4,25 +4,11 @@ import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.plan.RoadField;
 import dev.krona.urbex.plan.grid.GridRoadField;
 import dev.krona.urbex.plan.grid.GridSettings;
-import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
 import dev.krona.urbex.setup.WorldStyleMix;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.core.RegistryAccess;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.WorldGenLevel;
-import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeSource;
-import net.minecraft.world.level.biome.Biomes;
-import net.minecraft.world.level.biome.Climate;
-import net.minecraft.world.level.chunk.ChunkGenerator;
-import net.minecraft.world.level.chunk.ChunkSource;
 import org.jetbrains.annotations.Nullable;
 
 public class DefaultDimensionInfo implements IDimensionInfo {
@@ -37,7 +23,7 @@ public class DefaultDimensionInfo implements IDimensionInfo {
     private final WorldStyleField styles;
     private final DimensionCaches caches;
 
-    private final Registry<Biome> biomeRegistry;
+    private final LevelTerrain terrain;
     private final CityGenerator feature;
     private final RoadField roadField;
 
@@ -52,8 +38,11 @@ public class DefaultDimensionInfo implements IDimensionInfo {
         this.profile = preset;
         this.caches = new DimensionCaches(this.world.getSeed());
         styles = WorldStyleField.resolve(assets, this.world.getSeed(), worldStyles);
+        // Before the generator, and no longer on it: sampling the ground height is not generation,
+        // and having the generator own it is half of why the generator and this class have to
+        // construct each other (issue #129).
+        terrain = new LevelTerrain(this.world, preset, caches);
         feature = new CityGenerator(this, preset);
-        biomeRegistry = this.world.registryAccess().lookupOrThrow(Registries.BIOME);
         roadField = new GridRoadField(this.world.getSeed(), getType().identifier().toString(),
                 GridSettings.fromPreset(preset));
     }
@@ -66,11 +55,6 @@ public class DefaultDimensionInfo implements IDimensionInfo {
     @Override
     public AssetSnapshot assets() {
         return assets;
-    }
-
-    @Override
-    public WorldGenLevel getWorld() {
-        return world;
     }
 
     @Override
@@ -109,35 +93,8 @@ public class DefaultDimensionInfo implements IDimensionInfo {
     }
 
     @Override
-    public ChunkHeightmap getHeightmap(int chunkX, int chunkZ) {
-        ChunkCoord coord = new ChunkCoord(getType(), chunkX, chunkZ);
-        return feature.getHeightmap(coord, getWorld());
-    }
-
-    @Override
-    public ChunkHeightmap getHeightmap(ChunkCoord coord) {
-        return feature.getHeightmap(coord, getWorld());
-    }
-
-    //    @Override
-//    public Biome[] getBiomes(int chunkX, int chunkZ) {
-//        AbstractChunkProvider chunkProvider = getWorld().getChunkProvider();
-//        if (chunkProvider instanceof ServerChunkProvider) {
-//            BiomeProvider biomeProvider = ((ServerChunkProvider) chunkProvider).getChunkGenerator().getBiomeProvider();
-//            return biomeProvider.getBiomes((chunkX - 1) * 4 - 2, chunkZ * 4 - 2, 10, 10, false);
-//        }
-//    }
-//
-    @Override
-    public Holder<Biome> getBiome(BlockPos pos) {
-        ChunkSource chunkProvider = getWorld().getChunkSource();
-        if (chunkProvider instanceof ServerChunkCache) {
-            ChunkGenerator generator = ((ServerChunkCache) chunkProvider).getGenerator();
-            BiomeSource biomeProvider = generator.getBiomeSource();
-            Climate.Sampler sampler = ((ServerChunkCache) chunkProvider).randomState().sampler();
-            return biomeProvider.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2, sampler);
-        }
-        return biomeRegistry.getOrThrow(Biomes.PLAINS);
+    public TerrainSampler terrain() {
+        return terrain;
     }
 
     @Nullable

--- a/src/main/java/dev/krona/urbex/worldgen/IDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/IDimensionInfo.java
@@ -9,47 +9,49 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.biome.Biome;
 
 import javax.annotation.Nullable;
 
+/**
+ * What one dimension plans and generates with.
+ *
+ * <p>It no longer hands out a {@code WorldGenLevel}. Everything the planning path asked one for is
+ * a narrower question now - {@link LevelShape} for the height bounds and the water line,
+ * {@link TerrainSampler} for the ground height, the biome and the registries - and none of those has
+ * an answer only a server can give. That is what made {@code getWorld() != null} a planning
+ * condition: five call sites branched on it, meaning "am I the world-creation preview?" (issue
+ * #129).</p>
+ *
+ * <p>Block access during generation goes through the region on the {@link ChunkGenContext}, as it
+ * already did; the dimension's own level is held by its {@link DimensionRuntime}.</p>
+ */
 public interface IDimensionInfo {
 
     long getSeed();
 
     /**
-     * The dimension's own level. Stable for the life of the dimension and safe to hold: this is
-     * <em>not</em> the WorldGenRegion of whatever chunk happens to be generating, which is what it
-     * used to be (via a setWorld() that a per-dimension lock had to guard).
-     * <p>
-     * Use it for level-wide questions - registry access, min/max build height, sea level, the seed.
-     * Reading or writing blocks during generation must go through the region on the
-     * {@link ChunkGenContext} instead; a region only has the chunks around the one being built,
-     * and the level would go looking for the rest.
-     */
-    WorldGenLevel getWorld();
-
-    /**
      * How deep this dimension goes, how high it goes, and where its water sits.
      * <p>
-     * Resolved once, when the dimension's runtime is built. Planning and generation ask this rather
-     * than {@link #getWorld()} for the same three numbers, so the code that needs a bound does not
-     * have to hold a level to get one - and so the preview can answer (issue #129).
+     * Resolved once, when the dimension's runtime is built.
      */
     LevelShape shape();
 
     /**
-     * Registry access for this dimension, or {@code null} if none is available. Real dimensions
-     * always have one (it comes straight off {@link #getWorld()}); {@code NullDimensionInfo} is the
-     * one implementor that can have registry access - and so be able to evaluate registry-backed
-     * worldgen rules - while still having no {@link WorldGenLevel} to hand out, which is what makes
-     * this a separate question from "is {@link #getWorld()} null".
+     * How high the ground is, what biome is where, and which registries to resolve one against.
+     * See {@link TerrainSampler}.
+     */
+    TerrainSampler terrain();
+
+    /**
+     * Registry access for this dimension, or {@code null} if none is available.
+     * <p>
+     * A real dimension's comes straight off its level; the preview has registry access without
+     * having a level at all, which is why this is a question of its own.
      */
     @Nullable
     default RegistryAccess registryAccess() {
-        WorldGenLevel world = getWorld();
-        return world != null ? world.registryAccess() : null;
+        return terrain().registryAccess();
     }
 
     /**
@@ -88,13 +90,20 @@ public interface IDimensionInfo {
 
     CityGenerator getFeature();
 
-    ChunkHeightmap getHeightmap(int chunkX, int chunkZ);
+    default ChunkHeightmap getHeightmap(int chunkX, int chunkZ) {
+        return terrain().heightmap(new ChunkCoord(getType(), chunkX, chunkZ));
+    }
 
-    ChunkHeightmap getHeightmap(ChunkCoord coord);
+    default ChunkHeightmap getHeightmap(ChunkCoord coord) {
+        return terrain().heightmap(coord);
+    }
 
 //    Biome[] getBiomes(int chunkX, int chunkZ);
 
-    Holder<Biome> getBiome(BlockPos pos);
+    @Nullable
+    default Holder<Biome> getBiome(BlockPos pos) {
+        return terrain().biome(pos);
+    }
 
     @Nullable
     ResourceKey<Level> dimension();

--- a/src/main/java/dev/krona/urbex/worldgen/LevelTerrain.java
+++ b/src/main/java/dev/krona/urbex/worldgen/LevelTerrain.java
@@ -1,0 +1,118 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.varia.TimedCache;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.biome.Climate;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.chunk.ChunkSource;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.RandomState;
+
+/**
+ * A loaded level's terrain, sampled from its chunk generator.
+ *
+ * <p>The heightmap half was on {@link CityGenerator} until now, which made the generator and the
+ * dimension mutually constructing: {@code DefaultDimensionInfo} built a {@code CityGenerator} passing
+ * {@code this}, and the generator read the level back out of it to sample a height. Sampling is not
+ * generation - nothing here writes a block or even reads one - so it belongs on the level side of
+ * that pair, and moving it there means the terrain port exists before the generator does (issue
+ * #129).</p>
+ */
+public final class LevelTerrain implements TerrainSampler {
+
+    private final WorldGenLevel level;
+    private final Preset preset;
+    private final TimedCache<ChunkCoord, ChunkHeightmap> cache;
+    private final Registry<Biome> biomeRegistry;
+
+    public LevelTerrain(WorldGenLevel level, Preset preset, DimensionCaches caches) {
+        this.level = level;
+        this.preset = preset;
+        this.cache = caches.heightmap;
+        this.biomeRegistry = level.registryAccess().lookupOrThrow(Registries.BIOME);
+    }
+
+    @Override
+    public ChunkHeightmap heightmap(ChunkCoord chunk) {
+        int heightSampleSize = Config.HEIGHT_SAMPLE_SIZE.get();
+        // The block this chunk shares a sampled height with, and the coordinate that height is taken
+        // at. Both come from HeightSampleGrid so that the tiling is a partition and the sampled
+        // coordinate is a function of the block rather than of whichever chunk asked first - see the
+        // note there for what the old arithmetic did at the origin, and issue #126.
+        int top = HeightSampleGrid.anchor(chunk.chunkX(), heightSampleSize);
+        int left = HeightSampleGrid.anchor(chunk.chunkZ(), heightSampleSize);
+        ChunkCoord sampler = new ChunkCoord(chunk.dimension(),
+                HeightSampleGrid.sampler(top, heightSampleSize),
+                HeightSampleGrid.sampler(left, heightSampleSize));
+        // No lock. The heightmap is a pure function of the generator and the coordinate, so two
+        // threads that race on the same chunk build two equal heightmaps and one of them is thrown
+        // away; a third thread reading the cache sees whichever was published, and they agree.
+        //
+        // That holds only as long as nobody writes to what this returns - see TerrainSampler.
+        ChunkHeightmap cached = cache.get(chunk);
+        if (cached != null) {
+            return cached;
+        }
+        ChunkHeightmap heightmap = new ChunkHeightmap(preset.LANDSCAPE_TYPE, preset.GROUNDLEVEL);
+        heightmap.update(baseHeight((sampler.chunkX() << 4) + 8, (sampler.chunkZ() << 4) + 8));
+        if (heightSampleSize > 1) {
+            for (int i = 0; i < heightSampleSize; i++) {
+                for (int j = 0; j < heightSampleSize; j++) {
+                    ChunkCoord sampleKey = new ChunkCoord(chunk.dimension(), top + i, left + j);
+                    cache.putIfAbsent(sampleKey, new ChunkHeightmap(heightmap));
+                }
+            }
+        } else {
+            cache.putIfAbsent(chunk, heightmap);
+        }
+        return heightmap;
+    }
+
+    @Override
+    public void sampleAccurateHeight(ChunkHeightmap heightmap, int chunkX, int chunkZ) {
+        int cx = chunkX << 4;
+        int cz = chunkZ << 4;
+        heightmap.accurateHeights(
+                baseHeight(cx + 2, cz + 2),
+                baseHeight(cx + 2, cz + 14),
+                baseHeight(cx + 14, cz + 2),
+                baseHeight(cx + 14, cz + 14));
+    }
+
+    /** The generator's own surface height at a block column. No chunk is loaded and no block read. */
+    private int baseHeight(int x, int z) {
+        ServerChunkCache chunkProvider = level.getLevel().getChunkSource();
+        ChunkGenerator generator = chunkProvider.getGenerator();
+        RandomState randomState = chunkProvider.randomState();
+        return generator.getBaseHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, level, randomState);
+    }
+
+    @Override
+    public Holder<Biome> biome(BlockPos pos) {
+        ChunkSource chunkProvider = level.getChunkSource();
+        if (chunkProvider instanceof ServerChunkCache cache) {
+            ChunkGenerator generator = cache.getGenerator();
+            BiomeSource biomeProvider = generator.getBiomeSource();
+            Climate.Sampler sampler = cache.randomState().sampler();
+            return biomeProvider.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2, sampler);
+        }
+        return biomeRegistry.getOrThrow(Biomes.PLAINS);
+    }
+
+    @Override
+    public RegistryAccess registryAccess() {
+        return level.registryAccess();
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/TerrainSampler.java
+++ b/src/main/java/dev/krona/urbex/worldgen/TerrainSampler.java
@@ -1,0 +1,64 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.varia.ChunkCoord;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.world.level.biome.Biome;
+
+import javax.annotation.Nullable;
+
+/**
+ * What planning asks about terrain nobody has placed yet.
+ *
+ * <p>Three questions, and they are the last thing the planning path wanted a
+ * {@link net.minecraft.world.level.WorldGenLevel} for once {@link LevelShape} took the height bounds
+ * away: how high the ground is at a chunk, what biome is at a position, and which registries to
+ * resolve a biome id against. A real dimension answers them from its chunk generator; the
+ * world-creation preview answers them from a bitmap. Neither answer is {@code null}, which is the
+ * point - {@code NullDimensionInfo.getWorld()} returning {@code null} is what forced planning rules
+ * to be written as {@code if (provider.getWorld() != null)} (issue #129).</p>
+ *
+ * <p><strong>Nothing here reads a block.</strong> Every implementation answers from the chunk
+ * generator's own noise, so it is safe to ask about a chunk that has not been generated - which is
+ * exactly what planning does, and what makes the answers order-independent. Reading or writing
+ * actual blocks during generation goes through the region on the {@link ChunkGenContext}.</p>
+ */
+public interface TerrainSampler {
+
+    /**
+     * The heightmap for {@code coord}: a pure function of the chunk generator and the coordinate.
+     *
+     * <p><strong>Shared - do not write to what this returns.</strong> The instance is cached and
+     * handed to every thread generating near that chunk, so a caller that needs to mutate one takes
+     * a copy first ({@link ChunkHeightmap#ChunkHeightmap(ChunkHeightmap)} exists for this). Writing
+     * to the published instance is a data race on a plain {@code int} and, worse, makes what a
+     * neighbouring chunk reads depend on generation order (issue #24).</p>
+     */
+    ChunkHeightmap heightmap(ChunkCoord coord);
+
+    /**
+     * Fills in {@code heightmap}'s min/max by sampling four more points across the chunk.
+     *
+     * <p>Writes to the argument, so it must be a copy - see {@link #heightmap}. Split out of
+     * {@code ChunkHeightmap.calculateAccurateHeight}, which took a level to reach the chunk
+     * generator: sampling is this port's business, and folding the samples in is the heightmap's.
+     * </p>
+     */
+    void sampleAccurateHeight(ChunkHeightmap heightmap, int chunkX, int chunkZ);
+
+    /**
+     * The biome at {@code pos}, or {@code null} when there are no registries to resolve one against.
+     */
+    @Nullable
+    Holder<Biome> biome(BlockPos pos);
+
+    /**
+     * The registries biome-backed planning rules resolve against, or {@code null} if there are none.
+     * <p>
+     * Separate from "is there a level": the world-creation preview has registry access - so it can
+     * evaluate registry-backed worldgen rules - without having a level at all.
+     */
+    @Nullable
+    RegistryAccess registryAccess();
+}

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
@@ -240,9 +240,9 @@ public class Scattered {
                 }
                 // A copy: calculateAccurateHeight writes minHeight/maxHeight, and the cached
                 // instance is shared with every thread generating near this chunk. See #24.
-                ChunkHeightmap hm = new ChunkHeightmap(feature.getHeightmap(coord, provider.getWorld()));
+                ChunkHeightmap hm = new ChunkHeightmap(provider.getHeightmap(coord));
                 int height = hm.getHeight();
-                hm.calculateAccurateHeight(provider.getWorld(), x, z);   // generator-only, no block access
+                provider.terrain().sampleAccurateHeight(hm, x, z);   // generator-only, no block access
                 if (!reference.isAllowVoid()) {
                     if (!(feature.profile.isDefault() || feature.profile.isCavern())) {
                         // We are in a world that can have void chunks. Check if this chunk is a void chunk
@@ -302,7 +302,7 @@ public class Scattered {
                     // goes through BiomeManager, which applies a seeded sub-quart fuzzy offset. The
                     // two disagree near quart boundaries, so swapping them would move output.
                     Holder<Biome> biome = ctx.region.getBiome(info.getCenter(0));
-                    return biome.unwrap().map(ResourceKey::identifier, b -> provider.getWorld().registryAccess().lookupOrThrow(Registries.BIOME).getKey(b));
+                    return biome.unwrap().map(ResourceKey::identifier, b -> provider.registryAccess().lookupOrThrow(Registries.BIOME).getKey(b));
                 }
             };
             ChunkDriver driver = ctx.driver;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -20,7 +20,6 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
 import net.minecraft.tags.BiomeTags;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -808,7 +807,7 @@ public class ChunkPlan {
                     // ChunkPlan is reached from its neighbours' generation and has no region to
                     // ask, and the dimension's own level would go looking for unloaded chunks.
                     Holder<Biome> biome = provider.getBiome(getCenter(0));
-                    return biome.unwrap().map(ResourceKey::identifier, b -> provider.getWorld().registryAccess().lookup(Registries.BIOME).orElseThrow().getKey(b));
+                    return biome.unwrap().map(ResourceKey::identifier, b -> provider.registryAccess().lookup(Registries.BIOME).orElseThrow().getKey(b));
                 }
             };
             String part = building.getRandomPart(rand, conditionContext);
@@ -962,11 +961,14 @@ public class ChunkPlan {
      * This function uses its own cache.
      */
     public static int getCityLevel(ChunkCoord key, IDimensionInfo provider) {
-        if (provider.getWorld() != null) {  // In LC preview we don't want to use the cache as the config isn't loaded yet
-            Integer cached = provider.caches().cityLevel.get(key);
-            if (cached != null) {
-                return cached;
-            }
+        // Unconditional. This used to be gated on provider.getWorld() != null, "In LC preview we
+        // don't want to use the cache as the config isn't loaded yet" - a guard from when the
+        // preview shared the dimension's caches. It has held its own DimensionCaches, built from
+        // its own seed and dropped with it, since #125; and the value cached here is a pure function
+        // of the seed and the preset, both of which are fixed for one preview.
+        Integer cached = provider.caches().cityLevel.get(key);
+        if (cached != null) {
+            return cached;
         }
         int result;
         if (provider.getProfile().isFloating()) {
@@ -976,11 +978,9 @@ public class ChunkPlan {
         } else {
             result = getCityLevelNormal(key, provider, provider.getProfile());
         }
-        if (provider.getWorld() != null) {
-            Integer raced = provider.caches().cityLevel.putIfAbsent(key, result);
-            if (raced != null) {
-                return raced;
-            }
+        Integer raced = provider.caches().cityLevel.putIfAbsent(key, result);
+        if (raced != null) {
+            return raced;
         }
         return result;
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/City.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/City.java
@@ -1,7 +1,6 @@
 package dev.krona.urbex.worldgen.lost;
 
 import dev.krona.urbex.config.Preset;
-import dev.krona.urbex.setup.Config;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Rng;
 import dev.krona.urbex.varia.Tools;
@@ -131,8 +130,7 @@ public class City {
         RandomSource cityStyleRandom = Rng.at(provider.getSeed(), chunkX, chunkZ, Rng.Purpose.CITY_STYLE_LOCAL);
 
         if (profile.CITY_CHANCE < 0) {
-            WorldGenLevel world = provider.getWorld();
-            CityRarityMap rarityMap = provider.caches().getCityRarityMap(world.getSeed(),
+            CityRarityMap rarityMap = provider.caches().getCityRarityMap(provider.getSeed(),
                     profile.CITY_PERLIN_SCALE, profile.CITY_PERLIN_OFFSET, profile.CITY_PERLIN_INNERSCALE);
             float factor = rarityMap.getCityFactor(chunkX, chunkZ);
             if (factor < profile.CITY_STYLE_THRESHOLD) {

--- a/src/test/java/dev/krona/urbex/gui/preview/PreviewTerrainTest.java
+++ b/src/test/java/dev/krona/urbex/gui/preview/PreviewTerrainTest.java
@@ -1,0 +1,97 @@
+package dev.krona.urbex.gui.preview;
+
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.ChunkHeightmap;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The preview answers terrain questions instead of refusing them.
+ * <p>
+ * Every one of these used to go through {@code NullDimensionInfo}, whose {@code getWorld()} is
+ * {@code null} - so planning code that wanted a height or a biome either branched on
+ * {@code getWorld() != null} or threw. The bitmap was always there; what was missing was a way to
+ * ask it that did not also promise a level (issue #129).
+ */
+class PreviewTerrainTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static PreviewTerrain terrain() {
+        return new PreviewTerrain(new Preset(Identifier.fromNamespaceAndPath("urbex", "test")), null);
+    }
+
+    @Test
+    void theBitmapIsPlainsOutsideItsBounds() {
+        PreviewTerrain terrain = terrain();
+        assertEquals('p', terrain.biomeChar(-1, 0));
+        assertEquals('p', terrain.biomeChar(0, -1));
+        assertEquals('p', terrain.biomeChar(PreviewTerrain.WIDTH, 0));
+        assertEquals('p', terrain.biomeChar(0, PreviewTerrain.HEIGHT));
+    }
+
+    @Test
+    void heightFollowsTheBitmapsTerrain() {
+        PreviewTerrain terrain = terrain();
+        // Row 0 of the bitmap opens with desert and carries a river at x=37.
+        assertEquals('d', terrain.biomeChar(0, 0));
+        assertEquals(65, height(terrain, 0, 0), "desert sits at the baseline");
+        assertEquals('=', terrain.biomeChar(37, 0));
+        assertEquals(65, height(terrain, 37, 0), "so does a river");
+        // The mountain range in the lower half: peak interior, then its foothills.
+        assertEquals('+', terrain.biomeChar(15, 21));
+        assertEquals(125, height(terrain, 15, 21));
+        assertEquals('#', terrain.biomeChar(6, 18));
+        assertEquals(95, height(terrain, 6, 18));
+        // And the ocean.
+        assertEquals('-', terrain.biomeChar(55, 7));
+        assertEquals(60, height(terrain, 55, 7));
+    }
+
+    @Test
+    void accurateHeightsCollapseToTheChunksOwnHeight() {
+        PreviewTerrain terrain = terrain();
+        ChunkHeightmap heightmap = terrain.heightmap(new ChunkCoord(Level.OVERWORLD, 15, 21));
+        terrain.sampleAccurateHeight(heightmap, 15, 21);
+
+        assertEquals(125, heightmap.getMinHeight(), "the preview's terrain is flat within a chunk");
+        assertEquals(125, heightmap.getMaxHeight());
+    }
+
+    @Test
+    void aBiomeWithoutRegistriesIsNullRatherThanAThrow() {
+        // The Customize screen opens with no parent screen and so no registry access at all. Every
+        // caller reachable in that state is gated on registryAccess(); what must not happen is an
+        // exception out of a screen the player is looking at (issue #67).
+        assertNull(terrain().biome(new BlockPos(0, 64, 0)));
+        assertNull(terrain().registryAccess());
+    }
+
+    @Test
+    void everyRowOfTheBitmapIsTheDeclaredWidth() {
+        PreviewTerrain terrain = terrain();
+        for (int z = 0; z < PreviewTerrain.HEIGHT; z++) {
+            // Reading the last column of every row throws if a row is short, which is the whole
+            // check: a mis-copied row would silently shift the coastline.
+            assertTrue(terrain.biomeChar(PreviewTerrain.WIDTH - 1, z) != 0);
+        }
+    }
+
+    private static int height(PreviewTerrain terrain, int chunkX, int chunkZ) {
+        return terrain.heightmap(new ChunkCoord(Level.OVERWORLD, chunkX, chunkZ)).getHeight();
+    }
+}


### PR DESCRIPTION
The last thing the planning path wanted a WorldGenLevel for was terrain it had
not placed: how high the ground is at a chunk, what biome is at a position, and
which registries to resolve a biome id against. TerrainSampler is those three
questions. A real dimension answers them from its chunk generator (LevelTerrain),
the world-creation preview from its 62x58 bitmap (PreviewTerrain). Neither
answers null.

With LevelShape (129b) already holding the height bounds and the water line,
that is everything - so IDimensionInfo.getWorld() is gone. It is worth being
explicit about what that method cost, because it was not the level itself:

  - City guarded five datapack maps on getWorld() != null (removed in 129a),
  - ChunkPlan.getCityLevel skipped its cache on it,
  - City.getCityFactor gates two rules on registryAccess() != null for the same
    reason,
  - and the digest of it all was NullDimensionInfo: a class that constructs a
    generator nothing drives and a placeholder world style nothing renders, in
    order to be a dimension convincingly enough to be handed to the planner.

Every one of those branches means "am I the preview?", written as a question
about a level. Planning code cannot be honest about the preview while the
preview's honest answer to "what level are you?" is null.

Three moves make it up:

  - Heightmap sampling and its cache move off CityGenerator onto LevelTerrain.
    Sampling is not generation - it writes no block and reads none - and the
    generator owning it is half of why the generator and DefaultDimensionInfo
    construct each other. LevelTerrain exists before the generator does.
  - ChunkHeightmap.calculateAccurateHeight(level, x, z) becomes
    accurateHeights(h0..h3): where the four samples come from is the port's
    business, folding them in is the heightmap's.
  - The preview bitmap moves out of NullDimensionInfo into PreviewTerrain,
    which is the only part of that class the production planner actually needs.

Two behaviour changes, both preview-only:

  - ChunkPlan.getCityLevel now uses its cache in the preview too. The guard
    dated from when the preview shared the dimension's caches; it has had its
    own DimensionCaches, built from its own seed, since #125, and the cached
    value is a pure function of the seed and the preset.
  - Biome-id resolution in ChunkPlan and Scattered goes through
    provider.registryAccess() rather than provider.getWorld().registryAccess(),
    which is the same object on a real dimension and no longer an NPE on a
    preview.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>