### PR TITLE
refactor: planning reads a value, not a service bag (#129, 129d)

### DIFF
--- a/src/main/java/dev/krona/urbex/commands/CommandCreateBuilding.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandCreateBuilding.java
@@ -7,7 +7,7 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import dev.krona.urbex.worldgen.lost.cityassets.*;
 import net.minecraft.commands.CommandSourceStack;
@@ -52,7 +52,7 @@ public class CommandCreateBuilding implements Command<CommandSourceStack> {
         ServerPlayer player = context.getSource().getPlayerOrException();
         ServerLevel level = (ServerLevel) player.level();
         // The provider first: the building is looked up in this level's compiled assets (issue #128).
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("Urbex does not generate in this dimension!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandCreatePart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandCreatePart.java
@@ -6,7 +6,7 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.Editor;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
@@ -40,7 +40,7 @@ public class CommandCreatePart implements Command<CommandSourceStack> {
         ServerLevel level = (ServerLevel) player.level();
         // The provider first: the part is looked up in this level's compiled assets, so there is
         // nothing to look it up in until the level has one (issue #128).
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("Urbex does not generate in this dimension!").withStyle(ChatFormatting.RED));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandDebug.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandDebug.java
@@ -9,7 +9,7 @@ import dev.krona.urbex.plan.RoadCell;
 import dev.krona.urbex.plan.TertiarySegment;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import dev.krona.urbex.worldgen.lost.PrimaryBridgePlanner;
 import dev.krona.urbex.worldgen.lost.Railway;
@@ -52,12 +52,12 @@ public class CommandDebug implements Command<CommandSourceStack> {
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         ServerPlayer player = context.getSource().getPlayerOrException();
         BlockPos position = player.blockPosition();
-        IDimensionInfo dimInfo = GenerationSession.planningFor((WorldGenLevel) player.level());
+        PlanningContext dimInfo = GenerationSession.planningFor((WorldGenLevel) player.level());
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        ChunkCoord coord = new ChunkCoord(dimInfo.getType(), position.getX() >> 4, position.getZ() >> 4);
+        ChunkCoord coord = new ChunkCoord(dimInfo.dimension(), position.getX() >> 4, position.getZ() >> 4);
         ChunkPlan info = ChunkPlan.getChunkPlan(coord, dimInfo);
         line(context, "profile = " + info.profile.getId());
         line(context, "buildingType = " + info.buildingType.getName());
@@ -88,12 +88,12 @@ public class CommandDebug implements Command<CommandSourceStack> {
         int explosions = info.getExplosions().size();
         line(context, "explosions = " + explosions);
 
-        ChunkHeightmap heightmap = dimInfo.getHeightmap(info.coord);
+        ChunkHeightmap heightmap = dimInfo.heightmap(info.coord);
         line(context, "Chunk height (heightmap): " + heightmap.getHeight());
 
-        line(context, "dimInfo.getProfile().BUILDING_MINFLOORS = " + dimInfo.getProfile().BUILDING_MINFLOORS);
-        line(context, "dimInfo.getProfile().BUILDING_MAXFLOORS = " + dimInfo.getProfile().BUILDING_MAXFLOORS);
-        line(context, "dimInfo.getProfile().CITY_CHANCE = " + dimInfo.getProfile().CITY_CHANCE);
+        line(context, "dimInfo.preset().BUILDING_MINFLOORS = " + dimInfo.preset().BUILDING_MINFLOORS);
+        line(context, "dimInfo.preset().BUILDING_MAXFLOORS = " + dimInfo.preset().BUILDING_MAXFLOORS);
+        line(context, "dimInfo.preset().CITY_CHANCE = " + dimInfo.preset().CITY_CHANCE);
         line(context, "info.isOcean() = " + info.isOcean());
 
         printRoadDebug(context, info, dimInfo);
@@ -108,7 +108,7 @@ public class CommandDebug implements Command<CommandSourceStack> {
      * containing multi-building). Printed only on command - never during ordinary generation - and
      * grouped under three headers so the three kinds of information don't run together.
      */
-    private static void printRoadDebug(CommandContext<CommandSourceStack> context, ChunkPlan info, IDimensionInfo dimInfo) {
+    private static void printRoadDebug(CommandContext<CommandSourceStack> context, ChunkPlan info, PlanningContext dimInfo) {
         RoadCell road = dimInfo.roadField().at(info.coord.chunkX(), info.coord.chunkZ());
 
         line(context, "-- roads: raw vs effective --");
@@ -141,7 +141,7 @@ public class CommandDebug implements Command<CommandSourceStack> {
             line(context, "road.bridgeSpan = " + span.orientation()
                     + " (" + span.fromX() + ", " + span.fromZ() + ") -> (" + span.toX() + ", " + span.toZ() + ")");
         }
-        line(context, "road.conflictPolicy = " + dimInfo.getProfile().MULTI_BUILDING_STREET_CONFLICT);
+        line(context, "road.conflictPolicy = " + dimInfo.preset().MULTI_BUILDING_STREET_CONFLICT);
         if (info.multiBuildingPos.isMulti() && info.multiBuilding != null) {
             line(context, "road.multiBuilding = " + info.multiBuilding.getName());
         } else {

--- a/src/main/java/dev/krona/urbex/commands/CommandEditPart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandEditPart.java
@@ -8,7 +8,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.EditModeData;
 import dev.krona.urbex.editor.Editor;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.commands.CommandSourceStack;
@@ -36,12 +36,12 @@ public class CommandEditPart implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        if (!dimInfo.getProfile().EDITMODE) {
+        if (!dimInfo.preset().EDITMODE) {
             context.getSource().sendFailure(Component.literal("This world was not created with edit mode enabled. This command is not possible!"));
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/commands/CommandExportPart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandExportPart.java
@@ -12,7 +12,7 @@ import com.mojang.serialization.JsonOps;
 import dev.krona.urbex.editor.EditorInfo;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Tools;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import dev.krona.urbex.worldgen.lost.cityassets.CompiledPalette;
@@ -60,7 +60,7 @@ public class CommandExportPart implements Command<CommandSourceStack> {
         BlockPos start = editorInfo.getBottomLocation();
         ServerLevel level = (ServerLevel) player.level();
         // The provider first: the part is looked up in this level's compiled assets (issue #128).
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("Urbex does not generate in this dimension!").withStyle(ChatFormatting.RED));
             return 0;
@@ -73,7 +73,7 @@ public class CommandExportPart implements Command<CommandSourceStack> {
             return 0;
         }
 
-        ChunkCoord coord = new ChunkCoord(dimInfo.getType(), start.getX() >> 4, start.getZ() >> 4);
+        ChunkCoord coord = new ChunkCoord(dimInfo.dimension(), start.getX() >> 4, start.getZ() >> 4);
         ChunkPlan info = ChunkPlan.getChunkPlan(coord, dimInfo);
         CompiledPalette palette = info.getCompiledPalette();
         Palette partPalette = part.getLocalPalette();

--- a/src/main/java/dev/krona/urbex/commands/CommandListParts.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandListParts.java
@@ -7,7 +7,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.EditModeData;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
@@ -35,12 +35,12 @@ public class CommandListParts implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        if (!dimInfo.getProfile().EDITMODE) {
+        if (!dimInfo.preset().EDITMODE) {
             context.getSource().sendFailure(Component.literal("This world was not created with edit mode enabled. This command is not possible!"));
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/commands/CommandLocate.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandLocate.java
@@ -7,7 +7,7 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -58,7 +58,7 @@ public class CommandLocate implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;

--- a/src/main/java/dev/krona/urbex/commands/CommandLocatePart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandLocatePart.java
@@ -8,7 +8,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.EditModeData;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.IdentifierArgument;
@@ -49,12 +49,12 @@ public class CommandLocatePart implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        if (!dimInfo.getProfile().EDITMODE) {
+        if (!dimInfo.preset().EDITMODE) {
             context.getSource().sendFailure(Component.literal("This world was not created with edit mode enabled. This command is not possible!"));
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/commands/CommandMap.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandMap.java
@@ -6,7 +6,7 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -35,7 +35,7 @@ public class CommandMap implements Command<CommandSourceStack> {
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         ServerPlayer player = context.getSource().getPlayerOrException();
         BlockPos position = player.blockPosition();
-        IDimensionInfo dimInfo = GenerationSession.planningFor((WorldGenLevel) player.level());
+        PlanningContext dimInfo = GenerationSession.planningFor((WorldGenLevel) player.level());
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
@@ -45,7 +45,7 @@ public class CommandMap implements Command<CommandSourceStack> {
             for (int z = pos.z() - 20 ; z <= pos.z() + 20 ; z++) {
                 StringBuilder buf = new StringBuilder();
                 for (int x = pos.x() - 20 ; x <= pos.x() + 20 ; x++) {
-                    ChunkCoord coord = new ChunkCoord(dimInfo.getType(), x, z);
+                    ChunkCoord coord = new ChunkCoord(dimInfo.dimension(), x, z);
                     ChunkPlan info = ChunkPlan.getChunkPlan(coord, dimInfo);
                     if (info.isCity && info.hasBuilding) {
                         buf.append("B");

--- a/src/main/java/dev/krona/urbex/commands/CommandResumeEdit.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandResumeEdit.java
@@ -8,7 +8,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.editor.EditModeData;
 import dev.krona.urbex.editor.Editor;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.commands.CommandSourceStack;
@@ -35,12 +35,12 @@ public class CommandResumeEdit implements Command<CommandSourceStack> {
         BlockPos start = player.blockPosition();
 
         ServerLevel level = (ServerLevel) player.level();
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        if (!dimInfo.getProfile().EDITMODE) {
+        if (!dimInfo.preset().EDITMODE) {
             context.getSource().sendFailure(Component.literal("This world was not created with edit mode enabled. This command is not possible!"));
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/commands/CommandSavePreset.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandSavePreset.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.JsonOps;
 import dev.krona.urbex.config.Preset;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.ChatFormatting;
@@ -37,12 +37,12 @@ public class CommandSavePreset implements Command<CommandSourceStack> {
     @Override
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         // The source's own level, not the player's: this has to work from the server console too.
-        IDimensionInfo dimInfo = GenerationSession.planningFor(context.getSource().getLevel());
+        PlanningContext dimInfo = GenerationSession.planningFor(context.getSource().getLevel());
         if (dimInfo == null) {
             context.getSource().sendFailure(Component.literal("No dimension info found!").withStyle(ChatFormatting.RED));
             return 0;
         }
-        Preset preset = dimInfo.getProfile();
+        Preset preset = dimInfo.preset();
         JsonElement json = PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, preset.toDefinition()).getOrThrow();
         Path out = FabricLoader.getInstance().getGameDir().resolve("urbex-export");
         Path target = out.resolve(preset.getId().getPath() + ".json");

--- a/src/main/java/dev/krona/urbex/commands/CommandStats.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandStats.java
@@ -6,7 +6,7 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.krona.urbex.varia.Statistics;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.DimensionRuntime;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -27,9 +27,9 @@ public class CommandStats implements Command<CommandSourceStack> {
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         // The source's own level, not the player's: this has to work from the server console too,
         // which is where the generation timings are actually read from during a headless run.
-        IDimensionInfo dimInfo = GenerationSession.planningFor(context.getSource().getLevel());
-        if (dimInfo != null) {
-            Statistics statistics = dimInfo.getFeature().getStatistics();
+        DimensionRuntime runtime = GenerationSession.runtimeFor(context.getSource().getLevel());
+        if (runtime != null && runtime.isEnabled()) {
+            Statistics statistics = runtime.generator().getStatistics();
             float averageTime = statistics.getAverageTime();
             long minTime = statistics.getMinTime();
             long maxTime = statistics.getMaxTime();

--- a/src/main/java/dev/krona/urbex/commands/ModCommands.java
+++ b/src/main/java/dev/krona/urbex/commands/ModCommands.java
@@ -7,7 +7,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.worldgen.GenerationSession;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.cityassets.Building;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import net.minecraft.commands.CommandSourceStack;
@@ -61,7 +61,7 @@ public class ModCommands {
     @Nonnull
     static SuggestionProvider<CommandSourceStack> getPartSuggestionProvider() {
         return (context, builder) -> {
-            IDimensionInfo provider = GenerationSession.planningFor(context.getSource().getLevel());
+            PlanningContext provider = GenerationSession.planningFor(context.getSource().getLevel());
             if (provider == null) {
                 return builder.buildFuture();
             }
@@ -73,7 +73,7 @@ public class ModCommands {
     @Nonnull
     static SuggestionProvider<CommandSourceStack> getBuildingSuggestionProvider() {
         return (context, builder) -> {
-            IDimensionInfo provider = GenerationSession.planningFor(context.getSource().getLevel());
+            PlanningContext provider = GenerationSession.planningFor(context.getSource().getLevel());
             if (provider == null) {
                 return builder.buildFuture();
             }

--- a/src/main/java/dev/krona/urbex/editor/Editor.java
+++ b/src/main/java/dev/krona/urbex/editor/Editor.java
@@ -1,7 +1,7 @@
 package dev.krona.urbex.editor;
 
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import dev.krona.urbex.worldgen.lost.cityassets.CompiledPalette;
@@ -16,8 +16,8 @@ import net.minecraft.world.level.block.state.BlockState;
 
 public class Editor {
 
-    public static void startEditing(BuildingPart part, ServerPlayer player, BlockPos start, ServerLevel level, IDimensionInfo dimInfo, boolean clear) {
-        ChunkCoord coord = new ChunkCoord(dimInfo.getType(), start.getX() >> 4, start.getZ() >> 4);
+    public static void startEditing(BuildingPart part, ServerPlayer player, BlockPos start, ServerLevel level, PlanningContext dimInfo, boolean clear) {
+        ChunkCoord coord = new ChunkCoord(dimInfo.dimension(), start.getX() >> 4, start.getZ() >> 4);
         ChunkPlan info = ChunkPlan.getChunkPlan(coord, dimInfo);
         CompiledPalette palette = info.getCompiledPalette();
         Palette partPalette = part.getLocalPalette();

--- a/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/gui/NullDimensionInfo.java
@@ -3,13 +3,13 @@ package dev.krona.urbex.gui;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.gui.preview.PreviewTerrain;
-import dev.krona.urbex.plan.RoadField;
 import dev.krona.urbex.plan.grid.GridRoadField;
 import dev.krona.urbex.plan.grid.GridSettings;
 import dev.krona.urbex.worldgen.DimensionCaches;
 import dev.krona.urbex.setup.WorldStyleMix;
 import dev.krona.urbex.worldgen.IDimensionInfo;
 import dev.krona.urbex.worldgen.LevelShape;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.WorldStyleField;
 import dev.krona.urbex.worldgen.CityGenerator;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetCompiler;
@@ -23,7 +23,6 @@ import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
 import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 
 import javax.annotation.Nullable;
@@ -41,16 +40,10 @@ public class NullDimensionInfo implements IDimensionInfo {
     /** A style the bundled pack actually ships, and qualified; see {@link #placeholderStyle()}. */
     private static final String PLACEHOLDER_OUTSIDE_STYLE = Urbex.MODID + ":standard";
 
-    private final Preset profile;
-    private final WorldStyleField styles;
     private final Random random;
-    private final long seed;
-
-    private final AssetSnapshot assets;
     private final PreviewTerrain terrain;
+    private final PlanningContext planning;
     private final CityGenerator feature;
-    private final DimensionCaches caches;
-    private final RoadField roadField;
 
     /**
      * The preview's dimension info. Takes the whole {@link WorldStyleMix} the player chose, so a
@@ -61,14 +54,13 @@ public class NullDimensionInfo implements IDimensionInfo {
      * placeholder for that entry alone, rather than taking the whole preview with it.
      */
     public NullDimensionInfo(Preset profile, WorldStyleMix worldStyles, long seed, @Nullable RegistryAccess registryAccess) {
-        this.profile = profile;
-        this.caches = new DimensionCaches(seed);
+        DimensionCaches caches = new DimensionCaches(seed);
         // The preview compiles its own snapshot and owns it, rather than reaching for the server's.
         // It has no session - it runs on the client, on the world-creation screen, before any server
         // exists - and must not acquire one. Diagnostics are discarded on purpose: a broken pack is
         // the world load's business to refuse, and a preview that threw would leave the player unable
         // to see why. Individual ids still fall back to the placeholder below.
-        this.assets = registryAccess == null
+        AssetSnapshot assets = registryAccess == null
                 ? AssetSnapshot.empty()
                 : AssetCompiler.compile(registryAccess, new AssetDiagnostics());
         List<WorldStyleField.Weighted> resolvedEntries = new ArrayList<>(worldStyles.entries().size());
@@ -87,14 +79,27 @@ public class NullDimensionInfo implements IDimensionInfo {
             resolvedEntries.add(new WorldStyleField.Weighted(entry.weight(),
                     resolved != null ? resolved : new WorldStyle(PLACEHOLDER_ID, List.of(placeholderStyle()))));
         }
-        styles = new WorldStyleField(seed, resolvedEntries);
-        this.seed = seed;
         random = new Random(seed);
         terrain = new PreviewTerrain(profile, registryAccess);
-        feature = new CityGenerator(this, profile);
-        // The preview's own seed and dimension, so the roads it draws are the roads the world will
-        // have. Same construction as DefaultDimensionInfo; there is no server to ask.
-        roadField = new GridRoadField(seed, getType().identifier().toString(), GridSettings.fromPreset(profile));
+        planning = new PlanningContext(
+                seed,
+                // The overworld, which is what the preview draws.
+                Level.OVERWORLD,
+                profile,
+                assets,
+                new WorldStyleField(seed, resolvedEntries),
+                // The preview's own seed and dimension, so the roads it draws are the roads the
+                // world will have. Same construction as DefaultDimensionInfo; there is no server to
+                // ask.
+                new GridRoadField(seed, Level.OVERWORLD.identifier().toString(),
+                        GridSettings.fromPreset(profile)),
+                caches,
+                // The vanilla overworld's shape: a preview runs before any level exists, so there is
+                // nothing to ask, and every planning rule that reads a height bound or the water
+                // line gets a real answer rather than an NPE off a null level (issue #129).
+                LevelShape.VANILLA_OVERWORLD,
+                terrain);
+        feature = new CityGenerator(planning, profile);
     }
 
     /**
@@ -149,60 +154,14 @@ public class NullDimensionInfo implements IDimensionInfo {
         return Optional.of(new Mergeable<>(true, Collections.emptyList()));
     }
 
-    @Override
-    public long getSeed() {
-        return seed;
-    }
-
-    /**
-     * The vanilla overworld's, because a preview runs before any level exists and the overworld is
-     * what it draws. Every planning rule that reads a height bound or the water line now gets a real
-     * answer here rather than an NPE off the null level above (issue #129).
-     */
-    @Override
-    public LevelShape shape() {
-        return LevelShape.VANILLA_OVERWORLD;
-    }
-
-    @Nullable
-    @Override
-    public AssetSnapshot assets() {
-        return assets;
-    }
-
-    @Override
-    public PreviewTerrain terrain() {
-        return terrain;
-    }
-
-    @Override
-    public DimensionCaches caches() {
-        return caches;
-    }
-
-    @Override
-    public RoadField roadField() {
-        return roadField;
-    }
-
-    @Override
-    public ResourceKey<Level> getType() {
-        return Level.OVERWORLD;
-    }
-
-    @Override
-    public Preset getProfile() {
-        return profile;
-    }
-
-    @Override
-    public WorldStyleField worldStyles() {
-        return styles;
-    }
-
     /** The config preview renderer's own source. Nothing here places generated blocks. */
     public Random getRandom() {
         return random;
+    }
+
+    @Override
+    public PlanningContext planning() {
+        return planning;
     }
 
     @Override
@@ -215,10 +174,4 @@ public class NullDimensionInfo implements IDimensionInfo {
         return terrain.biomeChar(chunkX, chunkZ);
     }
 
-    @Override
-    public ResourceKey<Level> dimension() {
-        // Agrees with getType(): both name the overworld. dimension() used to return null here,
-        // which disagreed with getType() and tripped up anything that assumed the two matched (#67).
-        return Level.OVERWORLD;
-    }
 }

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -8,6 +8,7 @@ import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.setup.WorldStyleMix;
 import dev.krona.urbex.gui.NullDimensionInfo;
 import dev.krona.urbex.plan.RoadType;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import dev.krona.urbex.worldgen.lost.ChunkCandidate;
@@ -49,7 +50,7 @@ import java.util.Random;
  *       chunk generates.</li>
  * </ul>
  * "Honest" relative to the old editor's preview map renderer: that preview always ran
- * with {@code IDimensionInfo.getWorld() == null}, which silently skipped the worldstyle
+ * with {@code PlanningContext.getWorld() == null}, which silently skipped the worldstyle
  * city-chance multiplier and the CITY_MINHEIGHT/MAXHEIGHT gate in {@code City.getCityFactor} (both
  * guarded on {@code getWorld() != null}). This preview is built with real registry access, so those
  * guards - now keyed on {@code registryAccess() != null} - evaluate the same rules a real dimension
@@ -294,10 +295,11 @@ public class CityPreview implements AutoCloseable {
             case '*', 'd' -> 0xffcccc55;
             default -> 0xff005500;
         };
-        ChunkCoord coord = new ChunkCoord(diminfo.dimension(), x, z);
-        ChunkCandidate candidate = ChunkPlan.getChunkCandidateGui(coord, diminfo);
+        PlanningContext planning = diminfo.planning();
+        ChunkCoord coord = planning.coord(x, z);
+        ChunkCandidate candidate = ChunkPlan.getChunkCandidateGui(coord, planning);
         if (candidate.isCity()) {
-            return ChunkPlan.hasBuildingGui(x, z, diminfo, candidate) ? BUILDING_COLOR : CITY_COLOR;
+            return ChunkPlan.hasBuildingGui(x, z, planning, candidate) ? BUILDING_COLOR : CITY_COLOR;
         }
         return terrainColor;
     }
@@ -310,14 +312,15 @@ public class CityPreview implements AutoCloseable {
      * chunks blended over. Highway-over-rail is a distinct grey so an interchange is visible.
      */
     private void renderTransport(NullDimensionInfo diminfo, Preset profile) {
+        PlanningContext planning = diminfo.planning();
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {
                 int base = soften(sampleColor(diminfo, x, z));
-                ChunkCoord c = new ChunkCoord(diminfo.dimension(), x, z);
-                boolean hasRail = Railway.getRailChunkType(c, diminfo, profile).getType() != RailChunkType.NONE;
+                ChunkCoord c = planning.coord(x, z);
+                boolean hasRail = Railway.getRailChunkType(c, planning, profile).getType() != RailChunkType.NONE;
                 int overlay = hasRail ? RAIL_OVERLAY : 0;
-                int levelX = Highway.getXHighwayLevel(c, diminfo, profile);
-                int levelZ = Highway.getZHighwayLevel(c, diminfo, profile);
+                int levelX = Highway.getXHighwayLevel(c, planning, profile);
+                int levelZ = Highway.getZHighwayLevel(c, planning, profile);
                 if (levelX >= 0 || levelZ >= 0) {
                     overlay = hasRail ? HIGHWAY_OVER_RAIL_OVERLAY : HIGHWAY_OVERLAY;
                 }
@@ -359,11 +362,12 @@ public class CityPreview implements AutoCloseable {
      * as a guarantee.
      */
     private void renderRoads(NullDimensionInfo diminfo, Preset profile) {
+        PlanningContext planning = diminfo.planning();
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {
                 int base = soften(sampleColor(diminfo, x, z));
-                ChunkCoord c = new ChunkCoord(diminfo.dimension(), x, z);
-                RoadType type = ChunkPlan.effectiveRoadType(c, diminfo, profile);
+                ChunkCoord c = planning.coord(x, z);
+                RoadType type = ChunkPlan.effectiveRoadType(c, planning, profile);
                 colors[z * WIDTH + x] = blend(base, roadColour(type));
             }
         }

--- a/src/main/java/dev/krona/urbex/setup/MixCheck.java
+++ b/src/main/java/dev/krona/urbex/setup/MixCheck.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.setup;
 import dev.krona.urbex.worldgen.GenerationSession;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.gen.Scattered;
 import dev.krona.urbex.worldgen.lost.City;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
@@ -75,7 +75,7 @@ public final class MixCheck {
     }
 
     private static void census(ServerLevel level, int radius, int offset, boolean requireAll) {
-        IDimensionInfo provider = GenerationSession.planningFor(level);
+        PlanningContext provider = GenerationSession.planningFor(level);
         if (provider == null) {
             report(FAIL + " (no Urbex preset configured for the overworld)");
             return;
@@ -99,7 +99,7 @@ public final class MixCheck {
 
         for (int cx = offset - radius; cx <= offset + radius; cx++) {
             for (int cz = offset - radius; cz <= offset + radius; cz++) {
-                ChunkCoord coord = new ChunkCoord(provider.getType(), cx, cz);
+                ChunkCoord coord = new ChunkCoord(provider.dimension(), cx, cz);
 
                 chunkStyles.merge(provider.worldStyles().atChunk(provider, coord).getName(), 1, Integer::sum);
 

--- a/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
+++ b/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
@@ -4,7 +4,7 @@ import dev.krona.urbex.worldgen.GenerationSession;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.*;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import dev.krona.urbex.worldgen.lost.cityassets.PredefinedCity;
@@ -75,11 +75,11 @@ public class SpawnPlacement {
     public static boolean onCreateSpawnPoint(ServerLevel serverLevel, ServerLevelData settings) {
         LevelAccessor world = serverLevel;
         {
-            IDimensionInfo dimensionInfo = GenerationSession.planningFor(serverLevel);
+            PlanningContext dimensionInfo = GenerationSession.planningFor(serverLevel);
             if (dimensionInfo == null) {
                 return false;
             }
-            Preset profile = dimensionInfo.getProfile();
+            Preset profile = dimensionInfo.preset();
 
             Predicate<BlockPos> isSuitable = pos -> true;
             boolean needsCheck = false;
@@ -111,7 +111,7 @@ public class SpawnPlacement {
                 Set<String> buildings = Set.copyOf(profile.FORCE_SPAWN_BUILDINGS);
                 Set<String> parts = Set.copyOf(profile.FORCE_SPAWN_PARTS);
                 isSuitable = isSuitable.and(blockPos -> {
-                    ChunkCoord coord = new ChunkCoord(dimensionInfo.getType(), blockPos.getX() >> 4, blockPos.getZ() >> 4);
+                    ChunkCoord coord = new ChunkCoord(dimensionInfo.dimension(), blockPos.getX() >> 4, blockPos.getZ() >> 4);
                     ChunkPlan info = ChunkPlan.getChunkPlan(coord, dimensionInfo);
                     if (info == null) {
                         return false;
@@ -166,8 +166,8 @@ public class SpawnPlacement {
         return false;
     }
 
-    private static boolean isOutsideBuilding(IDimensionInfo provider, BlockPos pos) {
-        ChunkCoord coord = new ChunkCoord(provider.getType(), pos.getX() >> 4, pos.getZ() >> 4);
+    private static boolean isOutsideBuilding(PlanningContext provider, BlockPos pos) {
+        ChunkCoord coord = new ChunkCoord(provider.dimension(), pos.getX() >> 4, pos.getZ() >> 4);
         ChunkPlan info = ChunkPlan.getChunkPlan(coord, provider);
         return !(info.isCity() && info.hasBuilding);
     }
@@ -182,10 +182,10 @@ public class SpawnPlacement {
         return dx * dx + dz * dz;
     }
 
-    private static BlockPos findSafeSpawnPoint(Level world, IDimensionInfo provider, @Nonnull Predicate<BlockPos> isSuitable,
+    private static BlockPos findSafeSpawnPoint(Level world, PlanningContext provider, @Nonnull Predicate<BlockPos> isSuitable,
                                     @Nonnull ServerLevelData serverLevelData) {
-        Random rand = new Random(provider.getSeed());
-        int radius = provider.getProfile().SPAWN_CHECK_RADIUS;
+        Random rand = new Random(provider.seed());
+        int radius = provider.preset().SPAWN_CHECK_RADIUS;
         int attempts = 0;
 //        int bottom = world.getWorldType().getMinimumSpawnHeight(world);
         while (true) {
@@ -198,8 +198,8 @@ public class SpawnPlacement {
                     continue;
                 }
 
-                ChunkCoord coord = new ChunkCoord(provider.getType(), x >> 4, z >> 4);
-                Preset profile = provider.getProfile();
+                ChunkCoord coord = new ChunkCoord(provider.dimension(), x >> 4, z >> 4);
+                Preset profile = provider.preset();
 
                 for (int y = profile.GROUNDLEVEL-5 ; y < 125 ; y++) {
                     BlockPos pos = new BlockPos(x, y, z);
@@ -209,8 +209,8 @@ public class SpawnPlacement {
                     }
                 }
             }
-            radius += provider.getProfile().SPAWN_RADIUS_INCREASE;
-            if (attempts > provider.getProfile().SPAWN_CHECK_ATTEMPTS) {
+            radius += provider.preset().SPAWN_RADIUS_INCREASE;
+            if (attempts > provider.preset().SPAWN_CHECK_ATTEMPTS) {
                 Urbex.setup.getLogger().error("Can't find a valid spawn position!");
                 throw new RuntimeException("Can't find a valid spawn position!");
             }

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
@@ -29,7 +29,7 @@ public final class ChunkGenContext {
     public final WorldGenRegion region;
     public final ChunkAccess chunk;
     public final ChunkCoord coord;
-    public final IDimensionInfo provider;
+    public final PlanningContext provider;
     public final Preset profile;
     public final ChunkPlan info;
     public final CompiledPalette palette;
@@ -67,7 +67,7 @@ public final class ChunkGenContext {
     public final long seed;
 
     public ChunkGenContext(WorldGenRegion region, ChunkAccess chunk, ChunkCoord coord,
-                           IDimensionInfo provider, Preset profile, ChunkPlan info,
+                           PlanningContext provider, Preset profile, ChunkPlan info,
                            LevelTaskQueue levelTasks, TagSnapshot tags) {
         this.levelTasks = levelTasks;
         this.tags = tags;
@@ -82,7 +82,7 @@ public final class ChunkGenContext {
         this.driver = new ChunkDriver();
         this.driver.setPrimer(region, chunk);
         this.buffers = new NoiseBuffers();
-        this.seed = provider.getSeed();
+        this.seed = provider.seed();
         this.lightTodo = new LightTodoQueue(coord.chunkX(), coord.chunkZ());
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
@@ -67,7 +67,7 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
             // Urbex does not generate in this dimension. A published decision, not a missing one.
             return false;
         }
-        IDimensionInfo diminfo = runtime.planning();
+        PlanningContext diminfo = runtime.planning();
         ChunkPos center = chunk.getPos();
         Holder<Biome> biome = region.getBiome(center.getMiddleBlockPosition(60));
         if (biome.is(UrbexTags.IS_VOID)) {
@@ -79,14 +79,14 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
         // No lock. The terrain feature holds no per-chunk state any more (that is on the
         // ChunkGenContext built inside generate()), the caches it reaches are concurrent,
         // and the region arrives as an argument instead of being written onto the shared
-        // IDimensionInfo. So Urbex generation runs on the worker pool in parallel with the
+        // PlanningContext. So Urbex generation runs on the worker pool in parallel with the
         // rest of worldgen again, as it did before the driver became shared.
         CityGenerator feature = runtime.generator();
         try {
             feature.generate(runtime, region, chunk);
         } catch (Exception e) {
             Urbex.getLogger().error("Error generating chunk {},{} (preset={}, dimension={})",
-                    chunkX, chunkZ, diminfo.getProfile().getId(), diminfo.getType().identifier(), e);
+                    chunkX, chunkZ, diminfo.preset().getId(), diminfo.dimension().identifier(), e);
             ErrorLogger.logChunkInfo(chunkX, chunkZ, diminfo);
             ErrorLogger.report("There was an error generating a chunk. See log for details!");
         }

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -74,19 +74,19 @@ public class CityGenerator {
     private final BlockState[] randomDirt;
     private final Set<BlockState> randomDirtSet;
 
-    public final IDimensionInfo provider;
+    public final PlanningContext provider;
     public final Preset profile;
 
     private final Statistics statistics = new Statistics();
     private final Map<Block, BlockEntityType> typeCache = new ConcurrentHashMap<>();
 
-    public CityGenerator(IDimensionInfo provider, Preset profile) {
+    public CityGenerator(PlanningContext provider, Preset profile) {
         this.provider = provider;
         this.profile = profile;
 //        int waterLevel = provider.getWorld() == null ? 65 : Tools.getSeaLevel(provider.getWorld());// profile.GROUNDLEVEL - profile.WATERLEVEL_OFFSET;
         // Four independent noise fields, each seeded from the world seed alone. They describe the
         // whole dimension rather than one chunk, so they take a fixed coordinate and are built once.
-        long seed = provider.getSeed();
+        long seed = provider.seed();
         this.rubbleNoise = new NoiseGeneratorPerlin(Rng.at(seed, 0, 0, Rng.Purpose.NOISE), 4);
         this.leavesNoise = new NoiseGeneratorPerlin(Rng.at(seed, 1, 0, Rng.Purpose.NOISE), 4);
         this.ruinNoise = new NoiseGeneratorPerlin(Rng.at(seed, 2, 0, Rng.Purpose.NOISE), 4);
@@ -222,7 +222,7 @@ public class CityGenerator {
         int chunkX = chunk.getPos().x();
         int chunkZ = chunk.getPos().z();
 
-        ChunkCoord coord = new ChunkCoord(provider.getType(), chunkX, chunkZ);
+        ChunkCoord coord = new ChunkCoord(provider.dimension(), chunkX, chunkZ);
 
         // A copy, because correctTerrainShape() below writes the corrected surface back into it.
         // The instance in caches().heightmap is shared with every other thread generating a chunk
@@ -231,7 +231,7 @@ public class CityGenerator {
         // value whose presence depends on whether this chunk ran before or after its neighbour
         // read it - the neighbour's border height, and so the terrain, would depend on generation
         // order. See Arilas/urbex#24.
-        ChunkHeightmap heightmap = new ChunkHeightmap(provider.getHeightmap(coord));
+        ChunkHeightmap heightmap = new ChunkHeightmap(provider.heightmap(coord));
         ChunkPlan info = ChunkPlan.getChunkPlan(coord, provider);
         // runtime.tags() is read here and nowhere else in this generation: one call, at the start,
         // so a /reload landing mid-chunk cannot be observed halfway through a building (issue #128).
@@ -263,7 +263,7 @@ public class CityGenerator {
         // If this chunk has a building or street but we're in a floating profile and
         // we happen to have a void chunk we detect that here and go back to normal chunk generation
         // anyway
-        if (doCity && provider.getProfile().CITY_AVOID_VOID && provider.getProfile().isFloating()) {
+        if (doCity && provider.preset().CITY_AVOID_VOID && provider.preset().isFloating()) {
             boolean v = isVoid(ctx, 2, 2) || isVoid(ctx, 2, 14) || isVoid(ctx, 14, 2) || isVoid(ctx, 14, 14) || isVoid(ctx, 8, 8);
             doCity = !v;
         }
@@ -802,7 +802,7 @@ public class CityGenerator {
     }
 
 
-    public static boolean isWaterBiome(IDimensionInfo provider, ChunkCoord coord) {
+    public static boolean isWaterBiome(PlanningContext provider, ChunkCoord coord) {
         BiomeInfo biomeInfo = BiomeInfo.getBiomeInfo(provider, coord);
         Holder<Biome> mainBiome = biomeInfo.getMainBiome();
         return isWaterBiome(mainBiome);
@@ -822,24 +822,24 @@ public class CityGenerator {
         int adjacent;
         if (x == 0) {
             if (z == 0) {
-                adjacent = provider.getHeightmap(info.coord.northWest()).getHeight();
+                adjacent = provider.heightmap(info.coord.northWest()).getHeight();
             } else if (z == 15) {
-                adjacent = provider.getHeightmap(info.coord.southWest()).getHeight();
+                adjacent = provider.heightmap(info.coord.southWest()).getHeight();
             } else {
-                adjacent = provider.getHeightmap(info.coord.west()).getHeight();
+                adjacent = provider.heightmap(info.coord.west()).getHeight();
             }
         } else if (x == 15) {
             if (z == 0) {
-                adjacent = provider.getHeightmap(info.coord.northEast()).getHeight();
+                adjacent = provider.heightmap(info.coord.northEast()).getHeight();
             } else if (z == 15) {
-                adjacent = provider.getHeightmap(info.coord.southEast()).getHeight();
+                adjacent = provider.heightmap(info.coord.southEast()).getHeight();
             } else {
-                adjacent = provider.getHeightmap(info.coord.east()).getHeight();
+                adjacent = provider.heightmap(info.coord.east()).getHeight();
             }
         } else if (z == 0) {
-            adjacent = provider.getHeightmap(info.coord.north()).getHeight();
+            adjacent = provider.heightmap(info.coord.north()).getHeight();
         } else if (z == 15) {
-            adjacent = provider.getHeightmap(info.coord.south()).getHeight();
+            adjacent = provider.heightmap(info.coord.south()).getHeight();
         } else {
             return height;
         }
@@ -1921,7 +1921,7 @@ public class CityGenerator {
             tag.putString("id", "minecraft:mob_spawner");
             // Keyed on the spawner's own position: which mob a spawner gets must not depend on
             // how many spawners this chunk happened to place before it.
-            RandomSource spawnerRandom = Rng.atPos(provider.getSeed(), pos.getX(), pos.getY(), pos.getZ(), Rng.Purpose.SPAWNERS);
+            RandomSource spawnerRandom = Rng.atPos(provider.seed(), pos.getX(), pos.getY(), pos.getZ(), Rng.Purpose.SPAWNERS);
             Identifier randomValue = getRandomSpawnerMob(world.getLevel(), spawnerRandom, provider, info,
                     new ChunkPlan.ConditionTodo(mobid, part.getName(), info), pos);
             CompoundTag sd = new CompoundTag();
@@ -1939,7 +1939,7 @@ public class CityGenerator {
     private void handleLoot(ChunkGenContext ctx, ChunkPlan info, IBuildingPart part,
                             BlockState block, Palette.Info marker) {
         BlockPos pos = ctx.driver.getCurrentCopy();
-        if (!SpecialMarkerPolicy.populateLoot(provider.getSeed(), pos, info.profile)) {
+        if (!SpecialMarkerPolicy.populateLoot(provider.seed(), pos, info.profile)) {
             return;
         }
         ctx.addPostTodo(pos, inWorld -> {
@@ -1969,7 +1969,7 @@ public class CityGenerator {
                         // The todo runs later, on the server thread, long after this context is gone.
                         // Key the tree it grows on the sapling's position so it is the same tree no
                         // matter when the todo is drained.
-                        RandomSource growthRandom = Rng.atPos(provider.getSeed(), pos.getX(), pos.getY(), pos.getZ(), Rng.Purpose.VEGETATION_GROWTH);
+                        RandomSource growthRandom = Rng.atPos(provider.seed(), pos.getX(), pos.getY(), pos.getZ(), Rng.Purpose.VEGETATION_GROWTH);
                         ctx.addLevelTask(pos, level -> {
                             // Not available yet is not the same as nothing to do. This used to
                             // return either way and the queue counted it done, so a tree whose
@@ -2035,10 +2035,10 @@ public class CityGenerator {
     }
 
 
-    public static Identifier getRandomSpawnerMob(Level world, RandomSource random, IDimensionInfo diminfo, ChunkPlan info, ChunkPlan.ConditionTodo todo, BlockPos pos) {
+    public static Identifier getRandomSpawnerMob(Level world, RandomSource random, PlanningContext diminfo, ChunkPlan info, ChunkPlan.ConditionTodo todo, BlockPos pos) {
         String condition = todo.getCondition();
         Condition cnd = diminfo.assets().conditions().getOrThrow(condition);
-        int level = (pos.getY() - diminfo.getProfile().GROUNDLEVEL) / FLOORHEIGHT;
+        int level = (pos.getY() - diminfo.preset().GROUNDLEVEL) / FLOORHEIGHT;
         int floor = (pos.getY() - info.getCityGroundLevel()) / FLOORHEIGHT;
         String belowFloor = ConditionContext.NO_PART;
         ConditionContext conditionContext = new ConditionContext(level, floor, info.cellars, info.getNumFloors(),
@@ -2061,19 +2061,19 @@ public class CityGenerator {
         if (te instanceof RandomizableContainerBlockEntity) {
             // Runs from a post-todo, after generation of this chunk has finished, so it cannot
             // borrow the context's streams. The chest's own position addresses it instead.
-            RandomSource lootRandom = Rng.atPos(provider.getSeed(), pos.getX(), pos.getY(), pos.getZ(), Rng.Purpose.LOOT);
+            RandomSource lootRandom = Rng.atPos(provider.seed(), pos.getX(), pos.getY(), pos.getZ(), Rng.Purpose.LOOT);
             createLoot(info, lootRandom, world, pos, condition, this.provider);
         } else if (te == null) {
             ModSetup.getLogger().error("Error setting loot at {},{},{}", pos.getX(), pos.getY(), pos.getZ());
         }
     }
 
-    public static void createLoot(ChunkPlan info, RandomSource random, LevelAccessor world, BlockPos pos, ChunkPlan.ConditionTodo todo, IDimensionInfo diminfo) {
+    public static void createLoot(ChunkPlan info, RandomSource random, LevelAccessor world, BlockPos pos, ChunkPlan.ConditionTodo todo, PlanningContext diminfo) {
         BlockEntity tileentity = world.getBlockEntity(pos);
         if (tileentity instanceof RandomizableContainerBlockEntity rcbe) {
             if (todo != null) {
                 String lootTable = todo.getCondition();
-                int level = (pos.getY() - diminfo.getProfile().GROUNDLEVEL) / FLOORHEIGHT;
+                int level = (pos.getY() - diminfo.preset().GROUNDLEVEL) / FLOORHEIGHT;
                 int floor = (pos.getY() - info.getCityGroundLevel()) / FLOORHEIGHT;
                 ConditionContext conditionContext = new ConditionContext(level, floor, info.cellars, info.getNumFloors(),
                         todo.getPart(), ConditionContext.NO_PART, todo.getBuilding(), info.coord) {

--- a/src/main/java/dev/krona/urbex/worldgen/DefaultDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DefaultDimensionInfo.java
@@ -1,105 +1,58 @@
 package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.config.Preset;
-import dev.krona.urbex.plan.RoadField;
 import dev.krona.urbex.plan.grid.GridRoadField;
 import dev.krona.urbex.plan.grid.GridSettings;
-import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
 import dev.krona.urbex.setup.WorldStyleMix;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.world.level.Level;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
 import net.minecraft.world.level.WorldGenLevel;
-import org.jetbrains.annotations.Nullable;
 
+/**
+ * Builds one loaded level's planning inputs and its generator.
+ *
+ * <p>What is left of a class that used to be the planning inputs. Every field it held is a component
+ * of the {@link PlanningContext} it assembles now, and the assembly is the whole of its body - which
+ * is what breaks the cycle it was the other half of: {@code new CityGenerator(this, preset)} handed a
+ * half-constructed object to a collaborator that read a level back out of it, so neither type could
+ * be built without the other (issue #129).</p>
+ */
 public class DefaultDimensionInfo implements IDimensionInfo {
 
-    // The dimension's ServerLevel, not the region of whichever chunk is generating. Final, so it
-    // cannot be swapped out from under a worker thread, which is what the per-dimension lock in
-    // CityFeature.place used to be protecting.
-    private final WorldGenLevel world;
-    private final LevelShape shape;
-    private final AssetSnapshot assets;
-    private final Preset profile;
-    private final WorldStyleField styles;
-    private final DimensionCaches caches;
-
-    private final LevelTerrain terrain;
+    private final PlanningContext planning;
     private final CityGenerator feature;
-    private final RoadField roadField;
 
     public DefaultDimensionInfo(WorldGenLevel world, AssetSnapshot assets, Preset preset,
                                 WorldStyleMix worldStyles) {
-        this.world = world.getLevel();
-        // Resolved here, on the thread that loads the level, rather than per call from generation:
-        // the dimension type fixes the two bounds and the chunk generator fixes the sea level, and
-        // neither can change while the level is loaded.
-        this.shape = LevelShape.of(this.world);
-        this.assets = assets;
-        this.profile = preset;
-        this.caches = new DimensionCaches(this.world.getSeed());
-        styles = WorldStyleField.resolve(assets, this.world.getSeed(), worldStyles);
-        // Before the generator, and no longer on it: sampling the ground height is not generation,
-        // and having the generator own it is half of why the generator and this class have to
-        // construct each other (issue #129).
-        terrain = new LevelTerrain(this.world, preset, caches);
-        feature = new CityGenerator(this, preset);
-        roadField = new GridRoadField(this.world.getSeed(), getType().identifier().toString(),
-                GridSettings.fromPreset(preset));
+        // The dimension's ServerLevel, not the region of whichever chunk is generating. Final, so it
+        // cannot be swapped out from under a worker thread, which is what the per-dimension lock in
+        // CityFeature.place used to be protecting.
+        WorldGenLevel level = world.getLevel();
+        long seed = level.getSeed();
+        DimensionCaches caches = new DimensionCaches(seed);
+        planning = new PlanningContext(
+                seed,
+                level.getLevel().dimension(),
+                preset,
+                assets,
+                WorldStyleField.resolve(assets, seed, worldStyles),
+                new GridRoadField(seed, level.getLevel().dimension().identifier().toString(),
+                        GridSettings.fromPreset(preset)),
+                caches,
+                // Resolved here, on the thread that loads the level, rather than per call from
+                // generation: the dimension type fixes the two bounds and the chunk generator fixes
+                // the sea level, and neither can change while the level is loaded.
+                LevelShape.of(level),
+                new LevelTerrain(level, preset, caches));
+        feature = new CityGenerator(planning, preset);
     }
 
     @Override
-    public long getSeed() {
-        return world.getSeed();
-    }
-
-    @Override
-    public AssetSnapshot assets() {
-        return assets;
-    }
-
-    @Override
-    public LevelShape shape() {
-        return shape;
-    }
-
-    @Override
-    public DimensionCaches caches() {
-        return caches;
-    }
-
-    @Override
-    public RoadField roadField() {
-        return roadField;
-    }
-
-    @Override
-    public ResourceKey<Level> getType() {
-        return world.getLevel().dimension();
-    }
-
-    @Override
-    public Preset getProfile() {
-        return profile;
-    }
-
-    @Override
-    public WorldStyleField worldStyles() {
-        return styles;
+    public PlanningContext planning() {
+        return planning;
     }
 
     @Override
     public CityGenerator getFeature() {
         return feature;
-    }
-
-    @Override
-    public TerrainSampler terrain() {
-        return terrain;
-    }
-
-    @Nullable
-    @Override
-    public ResourceKey<Level> dimension() {
-        return world.getLevel().dimension();
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
@@ -128,7 +128,7 @@ public final class DigestRunner {
             for (ChunkPos pos : chunks) {
                 level.getChunk(pos.x(), pos.z(), ChunkStatus.FULL, true);
                 if (expireEvery > 0 && ++driven % expireEvery == 0) {
-                    IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+                    PlanningContext dimInfo = GenerationSession.planningFor(level);
                     if (dimInfo != null) {
                         dimInfo.caches().clear();
                     }
@@ -196,7 +196,7 @@ public final class DigestRunner {
 
     /**
      * How many of the sampled chunks carry a planned primary bridge deck. Read-only: queries the
-     * same {@link IDimensionInfo} real generation used for these chunks, after generation, so it
+     * same {@link PlanningContext} real generation used for these chunks, after generation, so it
      * costs no extra draw and cannot perturb either digest. Zero whenever no Urbex profile is
      * configured for this dimension - the driver-writes check already fails that case loudly.
      */
@@ -246,7 +246,7 @@ public final class DigestRunner {
      * stayed order-dependent unobserved (issue #126).
      */
     private static int countRailCollisionChunks(ServerLevel level, List<ChunkPos> chunkPositions) {
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             return 0;
         }
@@ -266,7 +266,7 @@ public final class DigestRunner {
     }
 
     private static int countBridgeChunks(ServerLevel level, List<ChunkPos> chunkPositions) {
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             return 0;
         }
@@ -282,12 +282,12 @@ public final class DigestRunner {
 
     /**
      * How many of the sampled chunks carry a sloped minor road. Read-only: queries the same
-     * {@link IDimensionInfo} real generation used for these chunks, after generation, so it costs
+     * {@link PlanningContext} real generation used for these chunks, after generation, so it costs
      * no extra draw and cannot perturb either digest. Zero whenever no Urbex profile is configured
      * for this dimension - the driver-writes check already fails that case loudly.
      */
     private static int countSlopeChunks(ServerLevel level, List<ChunkPos> chunkPositions) {
-        IDimensionInfo dimInfo = GenerationSession.planningFor(level);
+        PlanningContext dimInfo = GenerationSession.planningFor(level);
         if (dimInfo == null) {
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
@@ -27,13 +27,14 @@ import javax.annotation.Nullable;
  * itself, which is how a worker could have the asset registries cleared underneath it and save an
  * undecorated chunk (issue #125).</p>
  *
- * <p>{@code planning} is {@code null} for a level Urbex does not generate in. That is a cached
+ * <p>{@code dimension} is {@code null} for a level Urbex does not generate in. That is a cached
  * answer, not an absent one: the alternative is re-deriving "this dimension has no preset" from the
  * config on every chunk of every vanilla dimension.</p>
  *
- * <p>The record is the phase-1 shape from the milestone plan, deliberately not the final one:
- * {@code planning} holds today's {@link IDimensionInfo} until #129 replaces it with an explicit
- * planning context. {@link #caches()} and {@link #generator()} read like the components they will
+ * <p>{@code dimension} is what is left of the phase-1 shape: it holds the {@link IDimensionInfo}
+ * that pairs this level's {@link PlanningContext} with its {@link CityGenerator}, and goes when the
+ * preview stops needing an implementation of that interface, leaving the two as real components.
+ * {@link #planning()}, {@link #caches()} and {@link #generator()} read like the components they will
  * become while still delegating to the one object that owns them today - two record components
  * holding the same objects would be two owners of one thing, which is the mistake this whole epic
  * is about. {@code tasks} is a real component, because nothing else owns it.</p>
@@ -43,11 +44,11 @@ import javax.annotation.Nullable;
  * rather than a {@link TagSnapshot} so that a {@code /reload} can swap the epoch without rebuilding
  * anything here - which is the whole of what a reload changes (issue #128).</p>
  */
-public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo planning, LevelTaskQueue tasks,
+public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo dimension, LevelTaskQueue tasks,
                                @Nullable TagEpoch tagEpoch) {
 
-    public DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo planning, @Nullable TagEpoch tagEpoch) {
-        this(level, planning, new LevelTaskQueue(level.dimension().identifier().toString()), tagEpoch);
+    public DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo dimension, @Nullable TagEpoch tagEpoch) {
+        this(level, dimension, new LevelTaskQueue(level.dimension().identifier().toString()), tagEpoch);
     }
 
     /**
@@ -60,17 +61,22 @@ public record DimensionRuntime(ServerLevel level, @Nullable IDimensionInfo plann
     }
 
     public boolean isEnabled() {
-        return planning != null;
+        return dimension != null;
+    }
+
+    /** Everything a chunk of this level is planned against. Never call on a disabled runtime. */
+    public PlanningContext planning() {
+        return dimension.planning();
     }
 
     /** The per-level caches. Never call on a disabled runtime. */
     public DimensionCaches caches() {
-        return planning.caches();
+        return dimension.planning().caches();
     }
 
     /** The generator this level's chunks are driven by. Never call on a disabled runtime. */
     public CityGenerator generator() {
-        return planning.getFeature();
+        return dimension.getFeature();
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/ErrorLogger.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ErrorLogger.java
@@ -47,11 +47,11 @@ public class ErrorLogger {
         }
     }
 
-    public static void logChunkInfo(int chunkX, int chunkZ, IDimensionInfo provider) {
+    public static void logChunkInfo(int chunkX, int chunkZ, PlanningContext provider) {
         Logger logger = Urbex.getLogger();
         try {
-            ChunkCoord coord = new ChunkCoord(provider.getType(), chunkX, chunkZ);
-            logger.info("IsCity: " + ChunkPlan.isCityRaw(coord, provider, provider.getProfile()));
+            ChunkCoord coord = new ChunkCoord(provider.dimension(), chunkX, chunkZ);
+            logger.info("IsCity: " + ChunkPlan.isCityRaw(coord, provider, provider.preset()));
             ChunkCandidate candidate = ChunkPlan.getChunkCandidate(coord, provider);
             logger.info("    Level: " + candidate.cityLevel());
             if (candidate.multiBuilding() != null) {

--- a/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
+++ b/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
@@ -169,9 +169,9 @@ public final class GenerationSession {
      * contract and none of its side effects: it builds nothing, loads nothing and resets nothing.</p>
      */
     @Nullable
-    public static IDimensionInfo planningFor(ServerLevelAccessor level) {
+    public static PlanningContext planningFor(ServerLevelAccessor level) {
         DimensionRuntime runtime = runtimeFor(level);
-        return runtime == null ? null : runtime.planning();
+        return runtime == null || !runtime.isEnabled() ? null : runtime.planning();
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/IDimensionInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/IDimensionInfo.java
@@ -1,110 +1,22 @@
 package dev.krona.urbex.worldgen;
 
-import dev.krona.urbex.config.Preset;
-import dev.krona.urbex.plan.RoadField;
-import dev.krona.urbex.varia.ChunkCoord;
-import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.RegistryAccess;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.biome.Biome;
-
-import javax.annotation.Nullable;
-
 /**
- * What one dimension plans and generates with.
+ * What pairs a dimension's planning inputs with the generator that draws them.
  *
- * <p>It no longer hands out a {@code WorldGenLevel}. Everything the planning path asked one for is
- * a narrower question now - {@link LevelShape} for the height bounds and the water line,
- * {@link TerrainSampler} for the ground height, the biome and the registries - and none of those has
- * an answer only a server can give. That is what made {@code getWorld() != null} a planning
- * condition: five call sites branched on it, meaning "am I the world-creation preview?" (issue
- * #129).</p>
+ * <p>Two methods, down from thirteen. Everything planning reads is a {@link PlanningContext} now - a
+ * value, with no level, no generator, and one dimension key rather than two - and this is all that is
+ * left of the service bag (issue #129).</p>
  *
- * <p>Block access during generation goes through the region on the {@link ChunkGenContext}, as it
- * already did; the dimension's own level is held by its {@link DimensionRuntime}.</p>
+ * <p>Pairing those two is {@link DimensionRuntime}'s job, so this interface goes when the
+ * world-creation preview stops needing an implementation of it. It is deliberately not deleted in
+ * the same change that moved every call site off it: one is a mechanical migration the compiler
+ * checks exhaustively, the other decides who owns what.</p>
  */
 public interface IDimensionInfo {
 
-    long getSeed();
+    /** Everything a chunk here is planned against. */
+    PlanningContext planning();
 
-    /**
-     * How deep this dimension goes, how high it goes, and where its water sits.
-     * <p>
-     * Resolved once, when the dimension's runtime is built.
-     */
-    LevelShape shape();
-
-    /**
-     * How high the ground is, what biome is where, and which registries to resolve one against.
-     * See {@link TerrainSampler}.
-     */
-    TerrainSampler terrain();
-
-    /**
-     * Registry access for this dimension, or {@code null} if none is available.
-     * <p>
-     * A real dimension's comes straight off its level; the preview has registry access without
-     * having a level at all, which is why this is a question of its own.
-     */
-    @Nullable
-    default RegistryAccess registryAccess() {
-        return terrain().registryAccess();
-    }
-
-    /**
-     * The compiled assets this dimension generates from.
-     * <p>
-     * One snapshot per world load, shared by every level in that world - the asset registries are
-     * frozen when the world loads, so there is nothing per-level about what they compile to. Every
-     * asset lookup goes through here rather than through a static registry, which is what makes
-     * "compilation finished before generation started" a fact rather than a hope (issue #128).
-     */
-    AssetSnapshot assets();
-
-    /** The per-dimension caches. Dropped with the dimension. */
-    DimensionCaches caches();
-
-    /**
-     * Where the roads are. Built once per dimension from the seed, the dimension id and the
-     * profile's grid settings, so every query is a pure function of the coordinate and two chunks
-     * generated in either order see the same road.
-     */
-    RoadField roadField();
-
-    ResourceKey<Level> getType();
-
-    Preset getProfile();
-
-    /**
-     * The world styles this dimension generates from, and which one applies where.
-     * <p>
-     * Replaces the old single {@code getWorldStyle()} deliberately. A world style is not one scope
-     * - a city's {@code citystyles} against a highway network's {@code parts} - and once a world can
-     * mix several, a call site that silently took a dimension-wide style would be wrong without
-     * saying so. Ask the field for the scope you mean.
-     */
-    WorldStyleField worldStyles();
-
+    /** The generator those plans are drawn by. */
     CityGenerator getFeature();
-
-    default ChunkHeightmap getHeightmap(int chunkX, int chunkZ) {
-        return terrain().heightmap(new ChunkCoord(getType(), chunkX, chunkZ));
-    }
-
-    default ChunkHeightmap getHeightmap(ChunkCoord coord) {
-        return terrain().heightmap(coord);
-    }
-
-//    Biome[] getBiomes(int chunkX, int chunkZ);
-
-    @Nullable
-    default Holder<Biome> getBiome(BlockPos pos) {
-        return terrain().biome(pos);
-    }
-
-    @Nullable
-    ResourceKey<Level> dimension();
 }

--- a/src/main/java/dev/krona/urbex/worldgen/PlanningContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/PlanningContext.java
@@ -1,0 +1,91 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.plan.RoadField;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+
+import javax.annotation.Nullable;
+
+/**
+ * Everything a chunk is planned against, and nothing else.
+ *
+ * <p>Planning is a pure function of a coordinate and this record: two chunks planned in either order,
+ * on any thread, in a server or in the world-creation preview, see the same answer. That is what
+ * makes the plan cacheable and the digest stable, and it is a property of what planning is <em>able
+ * to reach</em> rather than a discipline anyone maintains.</p>
+ *
+ * <p>What it replaces is {@code IDimensionInfo}: a thirteen-method interface that also handed out the
+ * dimension's {@link net.minecraft.world.level.WorldGenLevel}, its {@link CityGenerator}, and two
+ * different methods returning the same dimension key. The generator is the reason it could not be a
+ * value - {@code DefaultDimensionInfo} constructed a {@code CityGenerator} passing {@code this}, and
+ * the generator read the level back out of it - so the two could not be built independently and
+ * neither could be built in a test without the other (issue #129).</p>
+ *
+ * <p>A {@code PlanningContext} is a composition-root value, not an argument every helper should take
+ * wholesale. Planners and renderers keep accepting the collaborators they actually read; this is what
+ * the composition root has to hand out to build them.</p>
+ *
+ * @param seed        the dimension's seed. Every RNG address in planning starts here.
+ * @param dimension   which dimension this is - part of every {@link ChunkCoord}, so two dimensions
+ *                    sharing a seed do not share cached plans.
+ * @param preset      the resolved preset, immutable for the runtime epoch that published this.
+ * @param assets      the compiled assets, one snapshot per world load.
+ * @param worldStyles which world style governs where, when the world mixes several.
+ * @param roadField   where the roads are: a pure function of seed, dimension id and grid settings.
+ * @param caches      the per-dimension memo tables. Every entry is a pure function of the above.
+ * @param shape       how deep and how high the dimension goes, and where its water sits.
+ * @param terrain     the ground height and the biome, sampled without reading a block.
+ */
+public record PlanningContext(
+        long seed,
+        ResourceKey<Level> dimension,
+        Preset preset,
+        AssetSnapshot assets,
+        WorldStyleField worldStyles,
+        RoadField roadField,
+        DimensionCaches caches,
+        LevelShape shape,
+        TerrainSampler terrain) {
+
+    /**
+     * The heightmap at {@code coord}. Shared and not to be written to - see
+     * {@link TerrainSampler#heightmap}.
+     */
+    public ChunkHeightmap heightmap(ChunkCoord coord) {
+        return terrain.heightmap(coord);
+    }
+
+    /** The heightmap at a chunk of this dimension. */
+    public ChunkHeightmap heightmap(int chunkX, int chunkZ) {
+        return terrain.heightmap(new ChunkCoord(dimension, chunkX, chunkZ));
+    }
+
+    /** The biome at {@code pos}, or null when there are no registries to resolve one against. */
+    @Nullable
+    public Holder<Biome> biome(BlockPos pos) {
+        return terrain.biome(pos);
+    }
+
+    /**
+     * The registries biome-backed planning rules resolve against, or null if there are none.
+     * <p>
+     * The preview has these without having a level, which is why several rules are gated on this
+     * rather than on anything about a server.
+     */
+    @Nullable
+    public RegistryAccess registryAccess() {
+        return terrain.registryAccess();
+    }
+
+    /** A coordinate in this dimension. */
+    public ChunkCoord coord(int chunkX, int chunkZ) {
+        return new ChunkCoord(dimension, chunkX, chunkZ);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/StructureSuppressor.java
+++ b/src/main/java/dev/krona/urbex/worldgen/StructureSuppressor.java
@@ -27,15 +27,15 @@ public class StructureSuppressor {
         if (!Config.STRUCTURES_YIELD_TO_CITIES.get()) {
             return false;
         }
-        IDimensionInfo diminfo = GenerationSession.planningFor(level);
+        PlanningContext diminfo = GenerationSession.planningFor(level);
         if (diminfo == null) {
             return false;   // No Urbex profile for this dimension, or the level is not loaded
         }
 
-        // No lock and no setWorld: the city caches are concurrent now, and IDimensionInfo's level
+        // No lock and no setWorld: the city caches are concurrent now, and PlanningContext's level
         // is final. Structure placement runs on the worker pool too, so this used to be one of the
         // threads contending for the per-dimension monitor.
-        ChunkCoord coord = new ChunkCoord(diminfo.getType(), chunkPos.x(), chunkPos.z());
+        ChunkCoord coord = new ChunkCoord(diminfo.dimension(), chunkPos.x(), chunkPos.z());
         if (!ChunkPlan.isCity(coord, diminfo)) {
             return false;
         }

--- a/src/main/java/dev/krona/urbex/worldgen/WorldStyleField.java
+++ b/src/main/java/dev/krona/urbex/worldgen/WorldStyleField.java
@@ -21,7 +21,7 @@ import java.util.List;
  * A world style is not one scope. Its {@code citystyles} and {@code outsidestyle} describe a city;
  * its highway and railway {@code parts} describe a network that runs between cities for hundreds of
  * chunks. Mixing forces that distinction to become explicit, so this class offers one accessor per
- * scope and {@link IDimensionInfo} hands out the field rather than a single style - a call site has
+ * scope and {@link PlanningContext} hands out the field rather than a single style - a call site has
  * to say which scope it means, and the compiler makes it.
  * <p>
  * <b>The single-style fast path is the point.</b> With one entry every accessor returns that style
@@ -141,7 +141,7 @@ public final class WorldStyleField {
      * {@link #PERLIN_REGION_CHUNKS}.
      */
     @Nonnull
-    public WorldStyle atChunk(IDimensionInfo provider, ChunkCoord coord) {
+    public WorldStyle atChunk(PlanningContext provider, ChunkCoord coord) {
         if (single) {
             return primary;
         }
@@ -151,8 +151,8 @@ public final class WorldStyleField {
         return provider.caches().worldStyle.getOrCompute(coord, k -> atChunkInt(provider, coord));
     }
 
-    private WorldStyle atChunkInt(IDimensionInfo provider, ChunkCoord coord) {
-        Preset profile = provider.getProfile();
+    private WorldStyle atChunkInt(PlanningContext provider, ChunkCoord coord) {
+        Preset profile = provider.preset();
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
         if (profile.CITY_CHANCE < 0) {
@@ -163,7 +163,7 @@ public final class WorldStyleField {
         int offset = (profile.CITY_MAXRADIUS + 15) / 16;
         for (int cx = chunkX - offset; cx <= chunkX + offset; cx++) {
             for (int cz = chunkZ - offset; cz <= chunkZ + offset; cz++) {
-                ChunkCoord c = new ChunkCoord(provider.getType(), cx, cz);
+                ChunkCoord c = new ChunkCoord(provider.dimension(), cx, cz);
                 if (!City.isCityCenter(c, provider)) {
                     continue;
                 }

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Railways.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Railways.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.worldgen.gen;
 import dev.krona.urbex.worldgen.ChunkDriver;
 import dev.krona.urbex.worldgen.ChunkGenContext;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.CityGenerator;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import dev.krona.urbex.worldgen.lost.RailChunkType;
@@ -27,7 +27,7 @@ public class Railways {
     }
 
     public static void generateRailways(ChunkGenContext ctx, CityGenerator feature, ChunkPlan info, Railway.RailChunkInfo railInfo, ChunkHeightmap heightmap) {
-        IDimensionInfo provider = feature.provider;
+        PlanningContext provider = feature.provider;
         ChunkDriver driver = ctx.driver;
         BlockState liquid = feature.liquid;
         BlockState air = Blocks.AIR.defaultBlockState();

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
@@ -6,7 +6,7 @@ import dev.krona.urbex.varia.Rng;
 import dev.krona.urbex.worldgen.ChunkDriver;
 import dev.krona.urbex.worldgen.ChunkGenContext;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.CityGenerator;
 import dev.krona.urbex.worldgen.lost.*;
 import dev.krona.urbex.worldgen.lost.cityassets.*;
@@ -47,7 +47,7 @@ public class Scattered {
      * {@code 1} when the primary style declares no {@code scattered} block at all, so the anchor
      * maths stays well defined; the caller checks for null settings before generating anything.
      */
-    private static int primaryAreasize(IDimensionInfo provider) {
+    private static int primaryAreasize(PlanningContext provider) {
         ScatteredSettings settings = provider.worldStyles().primary().getScatteredSettings();
         return settings == null ? 1 : settings.getAreasize();
     }
@@ -58,26 +58,26 @@ public class Scattered {
      * Public because the caller has to know which area a chunk is in <em>before</em> it can ask
      * which world style governs that area, and every chunk of one area has to get the same answer.
      */
-    public static ChunkCoord areaAnchor(IDimensionInfo provider, ChunkCoord coord) {
+    public static ChunkCoord areaAnchor(PlanningContext provider, ChunkCoord coord) {
         int areasize = primaryAreasize(provider);
         // Add a large amount so the division is over positive coordinates.
         int ax = (coord.chunkX() + 2000000) / areasize;
         int az = (coord.chunkZ() + 2000000) / areasize;
-        return new ChunkCoord(provider.getType(), ax * areasize - 2000000, az * areasize - 2000000);
+        return new ChunkCoord(provider.dimension(), ax * areasize - 2000000, az * areasize - 2000000);
     }
 
     public static void generateScattered(ChunkGenContext ctx, CityGenerator feature, ChunkPlan info, ScatteredSettings scatteredSettings) {
         int chunkX = info.coord.chunkX();
         int chunkZ = info.coord.chunkZ();
-        IDimensionInfo provider = feature.provider;
+        PlanningContext provider = feature.provider;
 
         // First normalize the coordinates to scatter area sized coordinates. Add a large amount to make sure the coordinates are positive
         int ax = (chunkX + 2000000) / scatteredSettings.getAreasize();
         int az = (chunkZ + 2000000) / scatteredSettings.getAreasize();
 
-        RandomSource scatteredRandom = Rng.at(provider.getSeed(), ax, az, Rng.Purpose.SCATTERED);
+        RandomSource scatteredRandom = Rng.at(provider.seed(), ax, az, Rng.Purpose.SCATTERED);
 
-        if (scatteredRandom.nextFloat() >= (scatteredSettings.getChance() * provider.getProfile().SCATTERED_CHANCE_MULTIPLIER)) {
+        if (scatteredRandom.nextFloat() >= (scatteredSettings.getChance() * provider.preset().SCATTERED_CHANCE_MULTIPLIER)) {
             // No scattered structure in this area
             return;
         }
@@ -86,7 +86,7 @@ public class Scattered {
         // on the area's anchor chunk, never the chunk that happens to be generating: every
         // chunk of the area must compute the same filtered list and draw the same reference,
         // or a multi-chunk building disagrees with itself about where it stands (issue #38).
-        ChunkCoord areaAnchor = new ChunkCoord(provider.getType(),
+        ChunkCoord areaAnchor = new ChunkCoord(provider.dimension(),
                 ax * scatteredSettings.getAreasize() - 2000000,
                 az * scatteredSettings.getAreasize() - 2000000);
         ScatteredReference reference = selectRandomScattered(feature, areaAnchor, scatteredSettings, scatteredRandom);
@@ -154,7 +154,7 @@ public class Scattered {
             Building building = provider.assets().buildings().getOrThrow(buildingName);
             int lowestLevel = scatteredLevel(feature, scattered, minheight, maxheight, avgheight);
             if (lowestLevel < -4000) {
-                Preset profile = feature.provider.getProfile();
+                Preset profile = feature.provider.preset();
                 if (profile.isCavern()) {
                     lowestLevel = profile.GROUNDLEVEL;
                 } else {
@@ -216,13 +216,13 @@ public class Scattered {
      * caching it per area sound.
      */
     private static AreaScan scanArea(CityGenerator feature, ScatteredReference reference, int tlChunkX, int tlChunkZ, int w, int h) {
-        IDimensionInfo provider = feature.provider;
+        PlanningContext provider = feature.provider;
         int minheight = Integer.MAX_VALUE;
         int maxheight = Integer.MIN_VALUE;
         int avgheight = 0;
         for (int x = tlChunkX; x < tlChunkX + w; x++) {
             for (int z = tlChunkZ; z < tlChunkZ + h; z++) {
-                ChunkCoord coord = new ChunkCoord(provider.getType(), x, z);
+                ChunkCoord coord = new ChunkCoord(provider.dimension(), x, z);
                 if (!isValidScatterBiome(feature, reference, coord)) {
                     return AreaScan.INVALID;
                 }
@@ -240,7 +240,7 @@ public class Scattered {
                 }
                 // A copy: calculateAccurateHeight writes minHeight/maxHeight, and the cached
                 // instance is shared with every thread generating near this chunk. See #24.
-                ChunkHeightmap hm = new ChunkHeightmap(provider.getHeightmap(coord));
+                ChunkHeightmap hm = new ChunkHeightmap(provider.heightmap(coord));
                 int height = hm.getHeight();
                 provider.terrain().sampleAccurateHeight(hm, x, z);   // generator-only, no block access
                 if (!reference.isAllowVoid()) {
@@ -268,7 +268,7 @@ public class Scattered {
     }
 
     private static void generateScatteredBuilding(ChunkGenContext ctx, CityGenerator feature, ChunkPlan info, Building building, RandomSource rand, int lowestLevel, ScatteredBuilding.TerrainFix terrainFix) {
-        IDimensionInfo provider = feature.provider;
+        PlanningContext provider = feature.provider;
 
         int height = lowestLevel;
         int floors;
@@ -297,7 +297,7 @@ public class Scattered {
                 @Override
                 public Identifier getBiome() {
                     // ctx.region, not provider.getWorld(): the region is what this used to be, back
-                    // when IDimensionInfo held a mutable world reference. Not provider.getBiome()
+                    // when PlanningContext held a mutable world reference. Not provider.biome()
                     // either - that asks the biome source directly, while WorldGenLevel.getBiome
                     // goes through BiomeManager, which applies a seeded sub-quart fuzzy offset. The
                     // two disagree near quart boundaries, so swapping them would move output.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/BiomeInfo.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/BiomeInfo.java
@@ -4,7 +4,7 @@ import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.setup.Config;
 import dev.krona.urbex.varia.TimedCache;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
@@ -17,17 +17,17 @@ public class BiomeInfo {
         this.mainBiome = mainBiome;
     }
 
-    public static BiomeInfo getBiomeInfo(IDimensionInfo provider, ChunkCoord coord) {
+    public static BiomeInfo getBiomeInfo(PlanningContext provider, ChunkCoord coord) {
         BiomeInfo info = provider.caches().biomeInfo.get(coord);
         if (info != null) {
             return info;
         }
-        ChunkHeightmap heightmap = provider.getHeightmap(coord);
+        ChunkHeightmap heightmap = provider.heightmap(coord);
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
         // Fully built before it is published, so the mainBiome can be final and a reader can never
         // catch it half-constructed.
-        info = new BiomeInfo(provider.getBiome(new BlockPos((chunkX << 4) + 8, heightmap.getHeight(), (chunkZ << 4) + 8)));
+        info = new BiomeInfo(provider.biome(new BlockPos((chunkX << 4) + 8, heightmap.getHeight(), (chunkZ << 4) + 8)));
         BiomeInfo raced = provider.caches().biomeInfo.putIfAbsent(coord, info);
         return raced != null ? raced : info;
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkContentResolver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkContentResolver.java
@@ -95,7 +95,7 @@ public final class ChunkContentResolver {
      * short-circuits: a chunk whose building-chance roll fails never asks whether it sits on a
      * highway. Evaluating these eagerly would consult {@link Highway} and {@link Railway} for chunks
      * that never do so today - {@code Railway}'s chunk types are mutable state, and the highway
-     * extent scan is expensive. It also keeps the resolver free of {@code IDimensionInfo}: the
+     * extent scan is expensive. It also keeps the resolver free of {@code PlanningContext}: the
      * decision is a pure function of these values, so a test can supply them directly.
      *
      * @param hasPredefinedBuilding        a predefined building starts at this chunk's top-left

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -8,7 +8,7 @@ import dev.krona.urbex.plan.RoadType;
 import dev.krona.urbex.setup.Config;
 import dev.krona.urbex.varia.*;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.CityGenerator;
 import dev.krona.urbex.worldgen.lost.cityassets.*;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
@@ -33,7 +33,7 @@ import static dev.krona.urbex.worldgen.CityGenerator.FLOORHEIGHT;
 public class ChunkPlan {
 
     public final ChunkCoord coord;
-    public final IDimensionInfo provider;
+    public final PlanningContext provider;
     public final Preset profile;
     public final int groundLevel;
     public final int waterLevel;
@@ -298,25 +298,25 @@ public class ChunkPlan {
     }
 
     // Version for usage inside the gui
-    public static boolean hasBuildingGui(int chunkX, int chunkZ, IDimensionInfo provider, ChunkCandidate candidate) {
-//        Random rand = getBuildingRandom(chunkX, chunkZ, provider.getSeed());
+    public static boolean hasBuildingGui(int chunkX, int chunkZ, PlanningContext provider, ChunkCandidate candidate) {
+//        Random rand = getBuildingRandom(chunkX, chunkZ, provider.seed());
 //        rand.nextFloat();       // Compatibility?
 
         return candidate.couldHaveBuilding();
     }
 
-    public static ChunkCandidate getChunkCandidateGui(ChunkCoord key, IDimensionInfo provider) {
+    public static ChunkCandidate getChunkCandidateGui(ChunkCoord key, PlanningContext provider) {
 //        ChunkCandidate cached = CITY_INFO_MAP.get(key);
 //        if (cached != null) {
 //            return cached;
 //        }
         int chunkX = key.chunkX();
         int chunkZ = key.chunkZ();
-        Preset profile = provider.getProfile();
+        Preset profile = provider.preset();
 
         boolean isCity = isCityRaw(key, provider, profile);
         int cityLevel = getCityLevelGui(key, provider);
-        RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.getSeed(), Rng.Purpose.BUILDING);
+        RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
         boolean couldHaveBuilding = isCity && rand.nextFloat() < profile.BUILDING_CHANCE;
         // The preview resolves neither a multi-building section nor a style, exactly as before -
         // those three stay null here rather than being computed for a screen that does not use them.
@@ -329,14 +329,14 @@ public class ChunkPlan {
      * them simply loses the putIfAbsent below. Locking here would be a deadlock waiting to happen -
      * this method reaches its neighbours' city styles, which reach back here.
      */
-    public static ChunkCandidate getChunkCandidate(ChunkCoord coord, IDimensionInfo provider) {
+    public static ChunkCandidate getChunkCandidate(ChunkCoord coord, PlanningContext provider) {
         ChunkCandidate cached = provider.caches().candidate.get(coord);
         if (cached != null) {
             return cached;
         }
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
-        Preset profile = provider.getProfile();
+        Preset profile = provider.preset();
 
         // Computed into locals and constructed once at the end. This used to assemble a mutable
         // object field by field and hand the half-built thing to its own helpers; the record cannot
@@ -354,7 +354,7 @@ public class ChunkPlan {
             cityLevel = profile.MULTI_USE_CORNER ? getTopLeftCityLevel(multiPos, coord, provider)
                     : getAverageCityLevel(multiPos, coord, provider);
         }
-        RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.getSeed(), Rng.Purpose.BUILDING);
+        RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
         boolean couldHaveBuilding = ChunkContentResolver.couldHaveBuilding(profile,
                 isCity, multiPos, cityLevel, rand,
                 chunkFacts(coord, provider, profile));
@@ -424,7 +424,7 @@ public class ChunkPlan {
     /**
      * Don't use the cache as we're busy building the cache.
      */
-    public static boolean isCityRaw(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static boolean isCityRaw(ChunkCoord coord, PlanningContext provider, Preset profile) {
         if (isVoidChunk(coord, provider)) {
             // If we have a void chunk then no city here
             return false;
@@ -434,7 +434,7 @@ public class ChunkPlan {
         return cityFactor > profile.CITY_THRESHOLD;
     }
 
-    public static boolean isCity(ChunkCoord coord, IDimensionInfo provider) {
+    public static boolean isCity(ChunkCoord coord, PlanningContext provider) {
         return getChunkCandidate(coord, provider).isCity();
     }
 
@@ -448,7 +448,7 @@ public class ChunkPlan {
      * still being computed, so it may not read anything that depends on a building decision - its
      * own or a neighbour's - or the decision graph stops being acyclic.
      */
-    public static RoadType effectiveRoadType(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static RoadType effectiveRoadType(ChunkCoord coord, PlanningContext provider, Preset profile) {
         // The city test comes first, and it is not a matter of taste. Every chunk in the world builds
         // a ChunkPlan, and the great majority of them are wilderness; asking the road field first
         // would build the block layout five times over - once for this chunk and once per neighbour
@@ -479,7 +479,7 @@ public class ChunkPlan {
      * {@link Railway} for a chunk whose building roll already failed would be new work, and
      * {@code Railway}'s chunk types are mutable state.
      */
-    private static ChunkContentResolver.ChunkFacts chunkFacts(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    private static ChunkContentResolver.ChunkFacts chunkFacts(ChunkCoord coord, PlanningContext provider, Preset profile) {
         return new ChunkContentResolver.ChunkFacts(
                 () -> City.getPredefinedBuildingAtTopLeft(provider, coord) != null,
                 () -> City.getPredefinedStreetAt(provider, coord) != null,
@@ -502,7 +502,7 @@ public class ChunkPlan {
         static final MultiSection NONE = new MultiSection(MultiPos.SINGLE, null);
     }
 
-    private static MultiSection multiBuildingSection(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    private static MultiSection multiBuildingSection(ChunkCoord coord, PlanningContext provider, Preset profile) {
         // If a chunk is occupied according to City then there is a predefined building or street here.
         // Try to look for it
         if (City.isChunkOccupied(provider, coord)) {
@@ -536,7 +536,7 @@ public class ChunkPlan {
         return getChunkPlan(key, provider);
     }
 
-    private static int getAverageCityLevel(MultiPos mp, ChunkCoord coord, IDimensionInfo provider) {
+    private static int getAverageCityLevel(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
         int level = 0;
         int topX = coord.chunkX() - mp.x();
         int topZ = coord.chunkZ() - mp.z();
@@ -549,7 +549,7 @@ public class ChunkPlan {
         return level / (mp.w() * mp.h());
     }
 
-    private static int getTopLeftCityLevel(MultiPos mp, ChunkCoord coord, IDimensionInfo provider) {
+    private static int getTopLeftCityLevel(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
         int topX = coord.chunkX() - mp.x();
         int topZ = coord.chunkZ() - mp.z();
         ChunkCoord key = new ChunkCoord(provider.dimension(), topX, topZ);
@@ -561,20 +561,20 @@ public class ChunkPlan {
      * that needs the top-left's building type, and only when {@code mp} is not itself the top left -
      * the caller has no half-built object to hand back for that case any more, and does not need one.
      */
-    private static ChunkCandidate getTopLeftCityInfo(MultiPos mp, ChunkCoord coord, IDimensionInfo provider) {
+    private static ChunkCandidate getTopLeftCityInfo(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
         ChunkCoord key = coord.offset(-mp.x(), -mp.z());
         return getChunkCandidate(key, provider);
     }
 
-    public static boolean hasHighway(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static boolean hasHighway(ChunkCoord coord, PlanningContext provider, Preset profile) {
         return Highway.getXHighwayLevel(coord, provider, profile) >= 0 || Highway.getZHighwayLevel(coord, provider, profile) >= 0;
     }
 
-    public static boolean hasRailway(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static boolean hasRailway(ChunkCoord coord, PlanningContext provider, Preset profile) {
         return Railway.getRailChunkType(coord, provider, profile).getType() != RailChunkType.NONE;
     }
 
-    public static boolean hasRailwayAtSurface(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static boolean hasRailwayAtSurface(ChunkCoord coord, PlanningContext provider, Preset profile) {
         RailChunkType type = Railway.getRailChunkType(coord, provider, profile).getType();
         return type.isSurface() || type.isStation();
     }
@@ -591,7 +591,7 @@ public class ChunkPlan {
         }
 
         // Get the (possbily cached) heightmap for this chunk
-        ChunkHeightmap heightmap = provider.getHeightmap(coord);
+        ChunkHeightmap heightmap = provider.heightmap(coord);
         // The height at which the highway would be + a threshold of 3
         int highwayHeight = groundLevel + level * FLOORHEIGHT + 3;
         // If there are many places in the chunk above this height we will need a tunnel
@@ -603,7 +603,7 @@ public class ChunkPlan {
      * neighbours', so populating inside the map's bin lock deadlocks. Racing threads both build one
      * and one of them is thrown away - identical, because it is a pure function of seed + coord.
      */
-    public static ChunkPlan getChunkPlan(ChunkCoord key, IDimensionInfo provider) {
+    public static ChunkPlan getChunkPlan(ChunkCoord key, PlanningContext provider) {
         ChunkPlan info = provider.caches().chunkPlan.get(key);
         if (info != null) {
             return info;
@@ -637,16 +637,16 @@ public class ChunkPlan {
      * of that shape would have picked here. Nothing reads back what the command draws, so the change
      * is only visible as which parts the preview stacks.
      */
-    public static ChunkPlan detachedForEditing(ChunkCoord key, IDimensionInfo provider,
+    public static ChunkPlan detachedForEditing(ChunkCoord key, PlanningContext provider,
                                                   BuildingOverride override) {
         return new ChunkPlan(key, provider, override);
     }
 
-    private ChunkPlan(ChunkCoord key, IDimensionInfo provider, @Nullable BuildingOverride override) {
+    private ChunkPlan(ChunkCoord key, PlanningContext provider, @Nullable BuildingOverride override) {
         this.provider = provider;
         this.coord = key;
 
-        profile = provider.getProfile();
+        profile = provider.preset();
 
         ChunkCandidate candidate = getChunkCandidate(key, provider);
 
@@ -658,14 +658,14 @@ public class ChunkPlan {
         multiBuilding = candidate.multiBuilding();
         multiBuildingPos = candidate.multiPos();
 
-        RandomSource rand = getBuildingRandom(coord.chunkX(), coord.chunkZ(), provider.getSeed(), Rng.Purpose.BUILDING_LAYOUT);
+        RandomSource rand = getBuildingRandom(coord.chunkX(), coord.chunkZ(), provider.seed(), Rng.Purpose.BUILDING_LAYOUT);
 
         CityStyle cs = candidate.cityStyle();
 
         isCity = candidate.isCity();
         effectiveRoad = effectiveRoadType(key, provider, profile);
 
-        ChunkContent content = ChunkContentResolver.resolve(profile, provider.getSeed(), rand,
+        ChunkContent content = ChunkContentResolver.resolve(profile, provider.seed(), rand,
                 isCity, candidate.couldHaveBuilding(), effectiveRoad, multiBuildingPos, coord,
                 neighbour -> getChunkCandidate(neighbour, provider).buildingType().getPrefersLonely(),
                 candidate.buildingType().getName());
@@ -801,12 +801,12 @@ public class ChunkPlan {
 
                 @Override
                 public Identifier getBiome() {
-                    // provider.getBiome() asks the biome source directly, where the old
+                    // provider.biome() asks the biome source directly, where the old
                     // getWorld().getBiome() went via BiomeManager and its seeded sub-quart fuzzy
                     // offset - so the two can disagree right at a quart boundary. Forced: a cached
                     // ChunkPlan is reached from its neighbours' generation and has no region to
                     // ask, and the dimension's own level would go looking for unloaded chunks.
-                    Holder<Biome> biome = provider.getBiome(getCenter(0));
+                    Holder<Biome> biome = provider.biome(getCenter(0));
                     return biome.unwrap().map(ResourceKey::identifier, b -> provider.registryAccess().lookup(Registries.BIOME).orElseThrow().getKey(b));
                 }
             };
@@ -947,9 +947,9 @@ public class ChunkPlan {
      * Return true if this is a void chunk (only for floating island worldtype). This does
      * not use the cache so it is safe to use when the cache is building
      */
-    public static boolean isVoidChunk(ChunkCoord coord, IDimensionInfo provider) {
-        if (provider.getProfile().isFloating()) {
-            return provider.getHeightmap(coord).getHeight() <= 0;
+    public static boolean isVoidChunk(ChunkCoord coord, PlanningContext provider) {
+        if (provider.preset().isFloating()) {
+            return provider.heightmap(coord).getHeight() <= 0;
         } else {
             return false;
         }
@@ -960,7 +960,7 @@ public class ChunkPlan {
      * This function does not use the cache. So safe to use when the cache is building
      * This function uses its own cache.
      */
-    public static int getCityLevel(ChunkCoord key, IDimensionInfo provider) {
+    public static int getCityLevel(ChunkCoord key, PlanningContext provider) {
         // Unconditional. This used to be gated on provider.getWorld() != null, "In LC preview we
         // don't want to use the cache as the config isn't loaded yet" - a guard from when the
         // preview shared the dimension's caches. It has held its own DimensionCaches, built from
@@ -971,12 +971,12 @@ public class ChunkPlan {
             return cached;
         }
         int result;
-        if (provider.getProfile().isFloating()) {
+        if (provider.preset().isFloating()) {
             result = getCityLevelFloating(key, provider);
-        } else if (provider.getProfile().isCavern()) {
+        } else if (provider.preset().isCavern()) {
             result =  getCityLevelCavern(key, provider);
         } else {
-            result = getCityLevelNormal(key, provider, provider.getProfile());
+            result = getCityLevelNormal(key, provider, provider.preset());
         }
         Integer raced = provider.caches().cityLevel.putIfAbsent(key, result);
         if (raced != null) {
@@ -985,26 +985,26 @@ public class ChunkPlan {
         return result;
     }
 
-    public static int getCityLevelGui(ChunkCoord key, IDimensionInfo provider) {
+    public static int getCityLevelGui(ChunkCoord key, PlanningContext provider) {
         int result;
-        if (provider.getProfile().isFloating()) {
+        if (provider.preset().isFloating()) {
             result = getCityLevelFloating(key, provider);
-        } else if (provider.getProfile().isCavern()) {
+        } else if (provider.preset().isCavern()) {
             result =  getCityLevelCavern(key, provider);
         } else {
-            result = getCityLevelNormal(key, provider, provider.getProfile());
+            result = getCityLevelNormal(key, provider, provider.preset());
         }
         return result;
     }
 
-    private static int getCityLevelCavern(ChunkCoord coord, IDimensionInfo provider) {
+    private static int getCityLevelCavern(ChunkCoord coord, PlanningContext provider) {
         // @todo for now
         return getCityLevelFloating(coord, provider);
     }
 
 
-    private static int getCityLevelNormal(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
-        ChunkHeightmap heightmap = provider.getHeightmap(coord);
+    private static int getCityLevelNormal(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        ChunkHeightmap heightmap = provider.heightmap(coord);
         int height = heightmap.getHeight();
         if (profile.USE_AVG_HEIGHTMAP && Config.HEIGHT_SAMPLE_SIZE.get() > 2) {
             int sampleSize = Config.HEIGHT_SAMPLE_SIZE.get();
@@ -1023,19 +1023,19 @@ public class ChunkPlan {
             int avgHeightmap = height;
             int counter = 1;
             if (isCityRaw(left, provider, profile)) {
-                avgHeightmap += provider.getHeightmap(left).getHeight();
+                avgHeightmap += provider.heightmap(left).getHeight();
                 counter++;
             }
             if (isCityRaw(right, provider, profile)) {
-                avgHeightmap += provider.getHeightmap(right).getHeight();
+                avgHeightmap += provider.heightmap(right).getHeight();
                 counter++;
             }
             if (isCityRaw(up, provider, profile)) {
-                avgHeightmap += provider.getHeightmap(up).getHeight();
+                avgHeightmap += provider.heightmap(up).getHeight();
                 counter++;
             }
             if (isCityRaw(down, provider, profile)) {
-                avgHeightmap += provider.getHeightmap(down).getHeight();
+                avgHeightmap += provider.heightmap(down).getHeight();
                 counter++;
             }
             avgHeightmap /= counter;
@@ -1044,9 +1044,9 @@ public class ChunkPlan {
         return getLevelBasedOnHeight(height, profile);
     }
 
-    private static int getCityLevelFloating(ChunkCoord coord, IDimensionInfo provider) {
-        int h = provider.getHeightmap(coord).getHeight();
-        return getLevelBasedOnHeight(h, provider.getProfile());
+    private static int getCityLevelFloating(ChunkCoord coord, PlanningContext provider) {
+        int h = provider.heightmap(coord).getHeight();
+        return getLevelBasedOnHeight(h, provider.preset());
     }
 
     private static int getLevelBasedOnHeight(int height, Preset profile) {
@@ -1263,14 +1263,14 @@ public class ChunkPlan {
         return result;
     }
 
-    public BuildingPart hasBridge(IDimensionInfo provider, Orientation orientation) {
+    public BuildingPart hasBridge(PlanningContext provider, Orientation orientation) {
         return switch (orientation) {
             case X -> hasXBridge(provider);
             case Z -> hasZBridge(provider);
         };
     }
 
-    public boolean hasBridge(IDimensionInfo provider) {
+    public boolean hasBridge(PlanningContext provider) {
         if (hasXBridge(provider) != null) {
             return true;
         }
@@ -1281,7 +1281,7 @@ public class ChunkPlan {
     }
 
     // To prevent adjacent bridges of the same direction we give the bridges at even chunk Z coordinates higher priority
-    public BuildingPart hasXBridge(IDimensionInfo provider) {
+    public BuildingPart hasXBridge(PlanningContext provider) {
         if (xBridgeTypeCalculated) {
             return xBridgeType;
         }
@@ -1293,7 +1293,7 @@ public class ChunkPlan {
         return result;
     }
 
-    private BuildingPart computeXBridge(IDimensionInfo provider) {
+    private BuildingPart computeXBridge(PlanningContext provider) {
         PrimaryBridgePlanner.BridgeSpan planned = getPlannedBridge();
         if (planned != null) {
             // A planned span settles this chunk for both orientations. Falling through to the
@@ -1351,7 +1351,7 @@ public class ChunkPlan {
     }
 
     // To prevent adjacent bridges of the same direction we give the bridges at even chunk X coordinates higher priority
-    public BuildingPart hasZBridge(IDimensionInfo provider) {
+    public BuildingPart hasZBridge(PlanningContext provider) {
         if (zBridgeTypeCalculated) {
             return zBridgeType;
         }
@@ -1361,7 +1361,7 @@ public class ChunkPlan {
         return result;
     }
 
-    private BuildingPart computeZBridge(IDimensionInfo provider) {
+    private BuildingPart computeZBridge(PlanningContext provider) {
         PrimaryBridgePlanner.BridgeSpan planned = getPlannedBridge();
         if (planned != null) {
             return planned.orientation() == Orientation.Z
@@ -1437,7 +1437,7 @@ public class ChunkPlan {
     }
 
 
-    private boolean isSuitableForBridge(IDimensionInfo provider, ChunkPlan i) {
+    private boolean isSuitableForBridge(PlanningContext provider, ChunkPlan i) {
         if (i.getPlannedBridge() != null) {
             // A planned span owns this chunk. An opportunistic bridge must not run through it -
             // it would stamp its own part over the planned deck on its way past.
@@ -1785,23 +1785,23 @@ public class ChunkPlan {
             if (h < provider.shape().maxBuildHeight()) {
                 // The L0 height at this corner is fixed so we return that
                 desiredMaxHeight1 = new MinMax(
-                        h + CityGenerator.getRandomizedOffset(provider.getSeed(), cx, cz, profile.TERRAIN_FIX_LOWER_MIN_OFFSET, profile.TERRAIN_FIX_LOWER_MAX_OFFSET, Rng.Purpose.TERRAIN_FIX_LOWER),
-                        h + CityGenerator.getRandomizedOffset(provider.getSeed(), cx, cz, profile.TERRAIN_FIX_UPPER_MIN_OFFSET, profile.TERRAIN_FIX_UPPER_MAX_OFFSET, Rng.Purpose.TERRAIN_FIX_UPPER));
+                        h + CityGenerator.getRandomizedOffset(provider.seed(), cx, cz, profile.TERRAIN_FIX_LOWER_MIN_OFFSET, profile.TERRAIN_FIX_LOWER_MAX_OFFSET, Rng.Purpose.TERRAIN_FIX_LOWER),
+                        h + CityGenerator.getRandomizedOffset(provider.seed(), cx, cz, profile.TERRAIN_FIX_UPPER_MIN_OFFSET, profile.TERRAIN_FIX_UPPER_MAX_OFFSET, Rng.Purpose.TERRAIN_FIX_UPPER));
                 return desiredMaxHeight1;
             }
 
             MinMax minMax = new MinMax();
 
-            getXmin().getZmin().updateMinMaxL1(minMax, 25 + CityGenerator.getHeightOffsetL1(provider.getSeed(), cx - 1, cz - 1));
-            getXmin().updateMinMaxL1(minMax, 20 + CityGenerator.getHeightOffsetL1(provider.getSeed(), cx - 1, cz));
-            getXmin().getZmax().updateMinMaxL1(minMax, 25 + CityGenerator.getHeightOffsetL1(provider.getSeed(), cx - 1, cz + 1));
+            getXmin().getZmin().updateMinMaxL1(minMax, 25 + CityGenerator.getHeightOffsetL1(provider.seed(), cx - 1, cz - 1));
+            getXmin().updateMinMaxL1(minMax, 20 + CityGenerator.getHeightOffsetL1(provider.seed(), cx - 1, cz));
+            getXmin().getZmax().updateMinMaxL1(minMax, 25 + CityGenerator.getHeightOffsetL1(provider.seed(), cx - 1, cz + 1));
 
-            getZmin().updateMinMaxL1(minMax, 20 + CityGenerator.getHeightOffsetL1(provider.getSeed(), cx, cz - 1));
-            getZmax().updateMinMaxL1(minMax, 20 + CityGenerator.getHeightOffsetL1(provider.getSeed(), cx, cz + 1));
+            getZmin().updateMinMaxL1(minMax, 20 + CityGenerator.getHeightOffsetL1(provider.seed(), cx, cz - 1));
+            getZmax().updateMinMaxL1(minMax, 20 + CityGenerator.getHeightOffsetL1(provider.seed(), cx, cz + 1));
 
-            getXmax().getZmin().updateMinMaxL1(minMax, 25 + CityGenerator.getHeightOffsetL1(provider.getSeed(), cx + 1, cz - 1));
-            getXmax().updateMinMaxL1(minMax, 20 + CityGenerator.getHeightOffsetL1(provider.getSeed(), cx + 1, cz));
-            getXmax().getZmax().updateMinMaxL1(minMax, 25 + CityGenerator.getHeightOffsetL1(provider.getSeed(), cx + 1, cz + 1));
+            getXmax().getZmin().updateMinMaxL1(minMax, 25 + CityGenerator.getHeightOffsetL1(provider.seed(), cx + 1, cz - 1));
+            getXmax().updateMinMaxL1(minMax, 20 + CityGenerator.getHeightOffsetL1(provider.seed(), cx + 1, cz));
+            getXmax().getZmax().updateMinMaxL1(minMax, 25 + CityGenerator.getHeightOffsetL1(provider.seed(), cx + 1, cz + 1));
 
             desiredMaxHeight1 = minMax;
         }
@@ -1847,16 +1847,16 @@ public class ChunkPlan {
 
             MinMax minMax = new MinMax();
 
-            getXmin().getZmin().updateMinMaxL2(minMax, 25 + CityGenerator.getHeightOffsetL2(provider.getSeed(), cx - 1, cz - 1));
-            getXmin().updateMinMaxL2(minMax, 20 + CityGenerator.getHeightOffsetL2(provider.getSeed(), cx - 1, cz));
-            getXmin().getZmax().updateMinMaxL2(minMax, 25 + CityGenerator.getHeightOffsetL2(provider.getSeed(), cx - 1, cz + 1));
+            getXmin().getZmin().updateMinMaxL2(minMax, 25 + CityGenerator.getHeightOffsetL2(provider.seed(), cx - 1, cz - 1));
+            getXmin().updateMinMaxL2(minMax, 20 + CityGenerator.getHeightOffsetL2(provider.seed(), cx - 1, cz));
+            getXmin().getZmax().updateMinMaxL2(minMax, 25 + CityGenerator.getHeightOffsetL2(provider.seed(), cx - 1, cz + 1));
 
-            getZmin().updateMinMaxL2(minMax, 20 + CityGenerator.getHeightOffsetL2(provider.getSeed(), cx, cz - 1));
-            getZmax().updateMinMaxL2(minMax, 20 + CityGenerator.getHeightOffsetL2(provider.getSeed(), cx, cz + 1));
+            getZmin().updateMinMaxL2(minMax, 20 + CityGenerator.getHeightOffsetL2(provider.seed(), cx, cz - 1));
+            getZmax().updateMinMaxL2(minMax, 20 + CityGenerator.getHeightOffsetL2(provider.seed(), cx, cz + 1));
 
-            getXmax().getZmin().updateMinMaxL2(minMax, 25 + CityGenerator.getHeightOffsetL2(provider.getSeed(), cx + 1, cz - 1));
-            getXmax().updateMinMaxL2(minMax, 20 + CityGenerator.getHeightOffsetL2(provider.getSeed(), cx + 1, cz));
-            getXmax().getZmax().updateMinMaxL2(minMax, 25 + CityGenerator.getHeightOffsetL2(provider.getSeed(), cx + 1, cz + 1));
+            getXmax().getZmin().updateMinMaxL2(minMax, 25 + CityGenerator.getHeightOffsetL2(provider.seed(), cx + 1, cz - 1));
+            getXmax().updateMinMaxL2(minMax, 20 + CityGenerator.getHeightOffsetL2(provider.seed(), cx + 1, cz));
+            getXmax().getZmax().updateMinMaxL2(minMax, 25 + CityGenerator.getHeightOffsetL2(provider.seed(), cx + 1, cz + 1));
             desiredTerrainCorrectionHeights = minMax;
         }
         return desiredTerrainCorrectionHeights;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/City.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/City.java
@@ -5,7 +5,7 @@ import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Rng;
 import dev.krona.urbex.varia.Tools;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.cityassets.*;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedStreet;
@@ -29,28 +29,28 @@ public class City {
      * "ready" over an empty map (issue #67) - plus a {@code cleanPredefinedCache()} three unrelated
      * call sites had to remember, one of them the preview, clearing maps live worldgen was reading.
      */
-    private static PredefinedIndex predefined(IDimensionInfo provider) {
+    private static PredefinedIndex predefined(PlanningContext provider) {
         return provider.assets().predefined();
     }
 
-    public static PredefinedCity getPredefinedCity(IDimensionInfo provider, ChunkCoord coord) {
+    public static PredefinedCity getPredefinedCity(PlanningContext provider, ChunkCoord coord) {
         return predefined(provider).cityAt(coord);
     }
 
-    public static PredefinedBuilding getPredefinedBuildingAtTopLeft(IDimensionInfo provider, ChunkCoord coord) {
+    public static PredefinedBuilding getPredefinedBuildingAtTopLeft(PlanningContext provider, ChunkCoord coord) {
         return predefined(provider).buildingAt(coord);
     }
 
-    public static PredefinedIndex.BuildingAt getPredefinedBuilding(IDimensionInfo provider, ChunkCoord coord) {
+    public static PredefinedIndex.BuildingAt getPredefinedBuilding(PlanningContext provider, ChunkCoord coord) {
         return predefined(provider).buildingCovering(coord);
     }
 
-    public static PredefinedStreet getPredefinedStreet(IDimensionInfo provider, ChunkCoord coord) {
+    public static PredefinedStreet getPredefinedStreet(PlanningContext provider, ChunkCoord coord) {
         return predefined(provider).streetCovering(coord);
     }
 
     // Return true if a chunk is occupied (by a predefined building or street)
-    public static boolean isChunkOccupied(IDimensionInfo provider, ChunkCoord coord) {
+    public static boolean isChunkOccupied(PlanningContext provider, ChunkCoord coord) {
         return predefined(provider).isOccupied(coord);
     }
 
@@ -60,34 +60,34 @@ public class City {
      * Separate from {@link #getPredefinedStreet}: this one answers about the chunk the street was
      * declared on, that one about any chunk the street covers.
      */
-    public static PredefinedStreet getPredefinedStreetAt(IDimensionInfo provider, ChunkCoord coord) {
+    public static PredefinedStreet getPredefinedStreetAt(PlanningContext provider, ChunkCoord coord) {
         return predefined(provider).streetAt(coord);
     }
 
 
-    public static boolean isCityCenter(ChunkCoord coord, IDimensionInfo provider) {
+    public static boolean isCityCenter(ChunkCoord coord, PlanningContext provider) {
         PredefinedCity city = getPredefinedCity(provider, coord);
         if (city != null) {
             return true;
         }
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
-        RandomSource cityCenterRandom = Rng.at(provider.getSeed(), chunkX, chunkZ, Rng.Purpose.CITY_CENTER);
-        return cityCenterRandom.nextDouble() < provider.getProfile().CITY_CHANCE;
+        RandomSource cityCenterRandom = Rng.at(provider.seed(), chunkX, chunkZ, Rng.Purpose.CITY_CENTER);
+        return cityCenterRandom.nextDouble() < provider.preset().CITY_CHANCE;
     }
 
     /**
      * Return the radius of the city with the given center
      */
-    public static float getCityRadius(ChunkCoord coord, IDimensionInfo provider) {
+    public static float getCityRadius(ChunkCoord coord, PlanningContext provider) {
         PredefinedCity city = getPredefinedCity(provider, coord);
         if (city != null) {
             return city.getRadius();
         }
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
-        RandomSource cityRadiusRandom = Rng.at(provider.getSeed(), chunkX, chunkZ, Rng.Purpose.CITY_RADIUS);
-        Preset profile = provider.getProfile();
+        RandomSource cityRadiusRandom = Rng.at(provider.seed(), chunkX, chunkZ, Rng.Purpose.CITY_RADIUS);
+        Preset profile = provider.preset();
         int cityRange = profile.CITY_MAXRADIUS - profile.CITY_MINRADIUS;
         if (cityRange < 1) {
             cityRange = 1;
@@ -96,7 +96,7 @@ public class City {
     }
 
     // Call this on a city center to get the style of that city
-    public static String getCityStyleForCityCenter(ChunkCoord coord, IDimensionInfo provider) {
+    public static String getCityStyleForCityCenter(ChunkCoord coord, PlanningContext provider) {
         PredefinedCity city = getPredefinedCity(provider, coord);
         if (city != null) {
             if (city.getCityStyle() != null) {
@@ -106,7 +106,7 @@ public class City {
         }
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
-        RandomSource cityStyleForCenterRandom = Rng.at(provider.getSeed(), chunkX, chunkZ, Rng.Purpose.CITY_STYLE);
+        RandomSource cityStyleForCenterRandom = Rng.at(provider.seed(), chunkX, chunkZ, Rng.Purpose.CITY_STYLE);
         // The centre's own world style, drawn at the centre: this is what makes one city internally
         // coherent when a world mixes several datapacks, since every chunk of that city asks here.
         return provider.worldStyles().atCityCenter(coord)
@@ -114,23 +114,23 @@ public class City {
     }
 
     // Calculate the citystyle based on all surrounding cities
-    public static CityStyle getCityStyle(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static CityStyle getCityStyle(ChunkCoord coord, PlanningContext provider, Preset profile) {
         // getOrCompute, not computeIfAbsent: this is reached from ChunkPlan
         // .getChunkCandidate, which calls it in a 3x3 loop over the neighbours, and computing
         // inside a ConcurrentHashMap bin lock deadlocks on that.
         return provider.caches().cityStyle.getOrCompute(coord, k -> getCityStyleInt(coord, provider, profile));
     }
 
-    private static CityStyle getCityStyleInt(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    private static CityStyle getCityStyleInt(ChunkCoord coord, PlanningContext provider, Preset profile) {
         List<Pair<Float, String>> styles = new ArrayList<>();
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
         // Not CITY_STYLE: getCityStyleForCityCenter draws from that address for this same chunk,
         // and this method calls it, so one purpose would make the blend agree with the centre.
-        RandomSource cityStyleRandom = Rng.at(provider.getSeed(), chunkX, chunkZ, Rng.Purpose.CITY_STYLE_LOCAL);
+        RandomSource cityStyleRandom = Rng.at(provider.seed(), chunkX, chunkZ, Rng.Purpose.CITY_STYLE_LOCAL);
 
         if (profile.CITY_CHANCE < 0) {
-            CityRarityMap rarityMap = provider.caches().getCityRarityMap(provider.getSeed(),
+            CityRarityMap rarityMap = provider.caches().getCityRarityMap(provider.seed(),
                     profile.CITY_PERLIN_SCALE, profile.CITY_PERLIN_OFFSET, profile.CITY_PERLIN_INNERSCALE);
             float factor = rarityMap.getCityFactor(chunkX, chunkZ);
             if (factor < profile.CITY_STYLE_THRESHOLD) {
@@ -142,7 +142,7 @@ public class City {
             int offset = (profile.CITY_MAXRADIUS + 15) / 16;
             for (int cx = chunkX - offset; cx <= chunkX + offset; cx++) {
                 for (int cz = chunkZ - offset; cz <= chunkZ + offset; cz++) {
-                    ChunkCoord c = new ChunkCoord(provider.getType(), cx, cz);
+                    ChunkCoord c = new ChunkCoord(provider.dimension(), cx, cz);
                     if (isCityCenter(c, provider)) {
                         float radius = getCityRadius(c, provider);
                         float sqdist = (cx * 16 - (chunkX << 4)) * (cx * 16 - (chunkX << 4)) + (cz * 16 - (chunkZ << 4)) * (cz * 16 - (chunkZ << 4));
@@ -178,8 +178,8 @@ public class City {
         return provider.assets().cityStyles().get(cityStyleName);
     }
 
-    public static float getCityFactor(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
-        ResourceKey<Level> type = provider.getType();
+    public static float getCityFactor(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        ResourceKey<Level> type = provider.dimension();
         // If we have a predefined building here we force a high city factor
 
         PredefinedBuilding predefinedBuilding = getPredefinedBuildingAtTopLeft(provider, coord);
@@ -208,7 +208,7 @@ public class City {
         int chunkZ = coord.chunkZ();
         float factor = 0;
         if (profile.CITY_CHANCE < 0) {
-            CityRarityMap rarityMap = provider.caches().getCityRarityMap(provider.getSeed(),
+            CityRarityMap rarityMap = provider.caches().getCityRarityMap(provider.seed(),
                     profile.CITY_PERLIN_SCALE, profile.CITY_PERLIN_OFFSET, profile.CITY_PERLIN_INNERSCALE);
             factor = rarityMap.getCityFactor(chunkX, chunkZ);
         } else {
@@ -233,7 +233,7 @@ public class City {
             // rather than a real WorldGenLevel so the world-creation preview (registry access
             // present, world null) applies this too - real worldgen always has both, so this is
             // unchanged there.
-            ChunkHeightmap heightmap = provider.getHeightmap(coord);
+            ChunkHeightmap heightmap = provider.heightmap(coord);
             if (heightmap == null) {
                 return 0;
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
@@ -5,7 +5,7 @@ import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.GeometryTools;
 import dev.krona.urbex.varia.Rng;
 import dev.krona.urbex.varia.Tools;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.TagSnapshot;
 import dev.krona.urbex.worldgen.lost.cityassets.CompiledPalette;
 import net.minecraft.core.BlockPos;
@@ -32,8 +32,8 @@ public class DamageArea {
 
     private final BlockState air;
 
-    public DamageArea(int chunkX, int chunkZ, IDimensionInfo provider, ChunkPlan info) {
-        this.seed = provider.getSeed();
+    public DamageArea(int chunkX, int chunkZ, PlanningContext provider, ChunkPlan info) {
+        this.seed = provider.seed();
         this.profile = info.profile;
         this.chunkX = chunkX;
         this.chunkZ = chunkZ;
@@ -45,7 +45,7 @@ public class DamageArea {
         int offset = (Math.max(info.profile.EXPLOSION_MAXRADIUS, info.profile.MINI_EXPLOSION_MAXRADIUS)+15) / 16;
         for (int cx = chunkX - offset; cx <= chunkX + offset; cx++) {
             for (int cz = chunkZ - offset; cz <= chunkZ + offset; cz++) {
-                ChunkCoord coord = new ChunkCoord(provider.getType(), cx, cz);
+                ChunkCoord coord = new ChunkCoord(provider.dimension(), cx, cz);
                 if ((!info.profile.EXPLOSIONS_IN_CITIES_ONLY) || ChunkPlan.isCity(coord, provider)) {
                     Explosion explosion = getExplosionAt(coord, provider);
                     if (explosion != null) {
@@ -98,7 +98,7 @@ public class DamageArea {
      * the chunk's {@link ChunkPlan} and outlives any one generation, so a tag epoch stored here
      * would be the wrong one for every chunk after the next {@code /reload} (issue #128).
      */
-    public BlockState damageBlock(BlockState b, IDimensionInfo provider, TagSnapshot tags, int x, int y, int z, float damage, CompiledPalette palette, BlockState liquidChar) {
+    public BlockState damageBlock(BlockState b, PlanningContext provider, TagSnapshot tags, int x, int y, int z, float damage, CompiledPalette palette, BlockState liquidChar) {
         if (tags.isNotBreakable(b)) {
             return b;
         }
@@ -127,7 +127,7 @@ public class DamageArea {
         return dmin <= radius * radius;
     }
 
-    private Explosion getExplosionAt(ChunkCoord coord, IDimensionInfo provider) {
+    private Explosion getExplosionAt(ChunkCoord coord, PlanningContext provider) {
         RandomSource randomExplosion = Rng.at(seed, coord.chunkX(), coord.chunkZ(), Rng.Purpose.EXPLOSION);
         if (randomExplosion.nextFloat() < profile.EXPLOSION_CHANCE) {
             return new Explosion(Tools.randomBetween(randomExplosion, profile.EXPLOSION_MINRADIUS, profile.EXPLOSION_MAXRADIUS),
@@ -138,7 +138,7 @@ public class DamageArea {
         return null;
     }
 
-    private Explosion getMiniExplosionAt(ChunkCoord coord, IDimensionInfo provider) {
+    private Explosion getMiniExplosionAt(ChunkCoord coord, PlanningContext provider) {
         RandomSource randomMiniExplosion = Rng.at(seed, coord.chunkX(), coord.chunkZ(), Rng.Purpose.EXPLOSION_MINI);
         if (randomMiniExplosion.nextFloat() < profile.MINI_EXPLOSION_CHANCE) {
             return new Explosion(Tools.randomBetween(randomMiniExplosion, profile.MINI_EXPLOSION_MINRADIUS, profile.MINI_EXPLOSION_MAXRADIUS),

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Highway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Highway.java
@@ -3,7 +3,7 @@ package dev.krona.urbex.worldgen.lost;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.varia.ChunkCoord;
 
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 
 
 import java.util.Map;
@@ -27,7 +27,7 @@ public class Highway {
      */
     static final int MAX_HIGHWAY_SCAN = 10_000;
 
-    public static boolean hasHighway(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static boolean hasHighway(ChunkCoord coord, PlanningContext provider, Preset profile) {
         if (getXHighwayLevel(coord, provider, profile) >= 0) {
             return true;
         }
@@ -41,7 +41,7 @@ public class Highway {
      * Returns -1 if there is no highway in X direction that goes through this chunk.
      * Returns 0 or 1 if there is a highway (at that city level) going through this chunk.
      */
-    public static int getXHighwayLevel(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static int getXHighwayLevel(ChunkCoord coord, PlanningContext provider, Preset profile) {
         return getHighwayLevel(provider, profile, provider.caches().xHighwayLevel,
                 cp -> hasXHighway(provider, cp, profile), Orientation.X, coord);
     }
@@ -50,12 +50,12 @@ public class Highway {
      * Returns -1 if there is no highway in Z direction that goes through this chunk.
      * Returns 0 or 1 if there is a highway (at that city level) going through this chunk.
      */
-    public static int getZHighwayLevel(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static int getZHighwayLevel(ChunkCoord coord, PlanningContext provider, Preset profile) {
         return getHighwayLevel(provider, profile, provider.caches().zHighwayLevel,
                 cp -> hasZHighway(provider, cp, profile), Orientation.Z, coord);
     }
 
-    private static int getHighwayLevel(IDimensionInfo provider, Preset profile, Map<ChunkCoord, Integer> cache, Function<ChunkCoord, Boolean> hasHighway, Orientation orientation, ChunkCoord cp) {
+    private static int getHighwayLevel(PlanningContext provider, Preset profile, Map<ChunkCoord, Integer> cache, Function<ChunkCoord, Boolean> hasHighway, Orientation orientation, ChunkCoord cp) {
         Integer known = cache.get(cp);
         if (known != null) {
             return known;
@@ -151,12 +151,12 @@ public class Highway {
         return c;
     }
 
-    private static boolean hasXHighway(IDimensionInfo provider, ChunkCoord cp, Preset profile) {
+    private static boolean hasXHighway(PlanningContext provider, ChunkCoord cp, Preset profile) {
         return provider.caches().highwayPerlinX.getValue(cp.chunkX() / profile.HIGHWAY_MAINPERLIN_SCALE, cp.chunkZ() / profile.HIGHWAY_SECONDARYPERLIN_SCALE)
                 > profile.HIGHWAY_PERLIN_FACTOR;
     }
 
-    private static boolean hasZHighway(IDimensionInfo provider, ChunkCoord cp, Preset profile) {
+    private static boolean hasZHighway(PlanningContext provider, ChunkCoord cp, Preset profile) {
         return provider.caches().highwayPerlinZ.getValue(cp.chunkX() / profile.HIGHWAY_SECONDARYPERLIN_SCALE, cp.chunkZ() / profile.HIGHWAY_MAINPERLIN_SCALE)
                 > profile.HIGHWAY_PERLIN_FACTOR;
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
@@ -8,7 +8,7 @@ import dev.krona.urbex.varia.Counter;
 import dev.krona.urbex.varia.Rng;
 import dev.krona.urbex.varia.TimedCache;
 import dev.krona.urbex.varia.Tools;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.cityassets.Building;
 import dev.krona.urbex.worldgen.lost.cityassets.CityStyle;
 import dev.krona.urbex.worldgen.lost.cityassets.MultiBuilding;
@@ -51,7 +51,7 @@ public class MultiChunk {
      * Not synchronized, and getOrCompute rather than computeIfAbsent: calculateBuildings() reaches
      * back into the city caches, which reach back here.
      */
-    public static MultiChunk getOrCreate(IDimensionInfo provider, ChunkCoord coord) {
+    public static MultiChunk getOrCreate(PlanningContext provider, ChunkCoord coord) {
         // primary(), unlike the rest of multisettings below: areasize defines the grid getMultiCoord
         // divides by, so it cannot be read from an area that grid has not identified yet.
         int areasize = provider.worldStyles().primary().getMultiSettings().areasize();
@@ -69,8 +69,8 @@ public class MultiChunk {
                 Math.floorDiv(coord.chunkZ(), areasize));
     }
 
-    private MultiChunk calculateBuildings(IDimensionInfo provider) {
-        RandomSource rand = Rng.at(provider.getSeed(), mc.chunkX(), mc.chunkZ(), Rng.Purpose.MULTI);
+    private MultiChunk calculateBuildings(PlanningContext provider) {
+        RandomSource rand = Rng.at(provider.seed(), mc.chunkX(), mc.chunkZ(), Rng.Purpose.MULTI);
 
         // Determine how many multibuildings we want to place in this multichunk
         // Drawn at this area's own anchor rather than world-wide: how many multi-buildings an area
@@ -115,7 +115,7 @@ public class MultiChunk {
         Counter<CityStyle> cityStyleCounter = new Counter<>();
         for (int x = 0 ; x < areasize ; x++) {
             for (int z = 0 ; z < areasize ; z++) {
-                CityStyle cityStyle = City.getCityStyle(topleft.offset(x, z), provider, provider.getProfile());
+                CityStyle cityStyle = City.getCityStyle(topleft.offset(x, z), provider, provider.preset());
                 if (cityStyle == null) {
                     throw new RuntimeException("Cannot find city style for chunk: " + topleft.offset(x, z));
                 }
@@ -171,7 +171,7 @@ public class MultiChunk {
             for (int att = 0 ; att < attempts ; att++) {
                 int x = rand.nextInt(areasize - dimX + 1);
                 int z = rand.nextInt(areasize - dimZ + 1);
-                if (canPlaceBuilding(topleft, provider, provider.getProfile(), ch.style(), mb, cityLevel, maxCellars, x, z)) {
+                if (canPlaceBuilding(topleft, provider, provider.preset(), ch.style(), mb, cityLevel, maxCellars, x, z)) {
                     placeBuilding(mb, x, z);
                     break;
                 }
@@ -206,7 +206,7 @@ public class MultiChunk {
         }
     }
 
-    private boolean canPlaceBuilding(ChunkCoord topleft, IDimensionInfo provider, Preset profile, CityStyle buildingCityStyle, MultiBuilding building,
+    private boolean canPlaceBuilding(ChunkCoord topleft, PlanningContext provider, Preset profile, CityStyle buildingCityStyle, MultiBuilding building,
                                      int cityLevel, int maxCellars, int x, int z) {
         int partlevel = provider.worldStyles().primary().getWorldSettings().railPartHeight6();
         int correctStyle = 0;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/PrimaryBridgePlanner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/PrimaryBridgePlanner.java
@@ -7,7 +7,7 @@ import dev.krona.urbex.plan.grid.GridPurpose;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Rng;
 import dev.krona.urbex.worldgen.CityGenerator;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import dev.krona.urbex.worldgen.lost.cityassets.CityStyle;
 import net.minecraft.util.RandomSource;
@@ -77,10 +77,10 @@ public final class PrimaryBridgePlanner {
      * The span claiming {@code coord}, if any. Empty for every chunk that is not open water on a
      * primary line, which is nearly all of them, and the first test is the cheap one.
      */
-    public static Optional<BridgeSpan> spanAt(ChunkCoord coord, IDimensionInfo provider) {
+    public static Optional<BridgeSpan> spanAt(ChunkCoord coord, PlanningContext provider) {
         // Dimension-wide, not per-chunk: a span's length limit and acceptance chance must be the
         // same number for every chunk in it.
-        Preset profile = provider.getProfile();
+        Preset profile = provider.preset();
         float chance = profile.PLANNED_PRIMARY_BRIDGE_CHANCE;
         int maxGapLength = profile.PLANNED_PRIMARY_BRIDGE_MAX_LENGTH;
         if (chance <= 0.0f) {
@@ -90,7 +90,7 @@ public final class PrimaryBridgePlanner {
         if (!isGap(coord, facts)) {
             return Optional.empty();
         }
-        long seed = provider.getSeed();
+        long seed = provider.seed();
         BridgeSpan horizontal = acceptedSpan(coord, Orientation.X, facts, seed, maxGapLength, chance);
         BridgeSpan vertical = acceptedSpan(coord, Orientation.Z, facts, seed, maxGapLength, chance);
         // At most one of these can survive: each one's own chunk is a crossing the other contests,
@@ -111,10 +111,10 @@ public final class PrimaryBridgePlanner {
      * shift what any other decision sees.
      */
     @Nullable
-    public static BuildingPart deckPart(BridgeSpan span, ChunkCoord anyChunkInSpan, IDimensionInfo provider) {
+    public static BuildingPart deckPart(BridgeSpan span, ChunkCoord anyChunkInSpan, PlanningContext provider) {
         ChunkCoord anchor = new ChunkCoord(anyChunkInSpan.dimension(), span.fromX(), span.fromZ());
-        CityStyle style = City.getCityStyle(anchor, provider, provider.getProfile());
-        RandomSource rand = Rng.at(provider.getSeed(), anchor.chunkX(), anchor.chunkZ(), Rng.Purpose.LARGE_BRIDGE);
+        CityStyle style = City.getCityStyle(anchor, provider, provider.preset());
+        RandomSource rand = Rng.at(provider.seed(), anchor.chunkX(), anchor.chunkZ(), Rng.Purpose.LARGE_BRIDGE);
         String name = style.getRandomLargeBridge(rand, anchor);
         return name == null ? null : provider.assets().parts().getOrWarn(name);
     }
@@ -281,7 +281,7 @@ public final class PrimaryBridgePlanner {
         return true;
     }
 
-    private static ChunkFacts worldFacts(IDimensionInfo provider) {
+    private static ChunkFacts worldFacts(PlanningContext provider) {
         return new ChunkFacts() {
             @Override
             public boolean isRawPrimary(ChunkCoord coord) {
@@ -290,12 +290,12 @@ public final class PrimaryBridgePlanner {
 
             @Override
             public boolean isCity(ChunkCoord coord) {
-                return ChunkPlan.isCityRaw(coord, provider, provider.getProfile());
+                return ChunkPlan.isCityRaw(coord, provider, provider.preset());
             }
 
             @Override
             public boolean isEffectivePrimary(ChunkCoord coord) {
-                Preset profile = provider.getProfile();
+                Preset profile = provider.preset();
                 return ChunkPlan.effectiveRoadType(coord, provider, profile) == RoadType.PRIMARY;
             }
 
@@ -311,9 +311,9 @@ public final class PrimaryBridgePlanner {
                 if (CityGenerator.isWaterBiome(provider, coord)) {
                     return true;
                 }
-                int sealevel = provider.getProfile().SEALEVEL;
+                int sealevel = provider.preset().SEALEVEL;
                 int waterLevel = sealevel == -1 ? provider.shape().seaLevel() : sealevel;
-                return provider.getHeightmap(coord).getHeight() < waterLevel;
+                return provider.heightmap(coord).getHeight() < waterLevel;
             }
         };
     }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
@@ -4,7 +4,7 @@ import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Rng;
 import net.minecraft.util.RandomSource;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
 import dev.krona.urbex.worldgen.lost.regassets.data.WorldSettings;
 
@@ -93,12 +93,12 @@ public class Railway {
     /**
      * The station grid repeats every 9 chunks. There is never a station at every 18/18 multiple chunk
      */
-    private static RailChunkInfo getRailChunkTypeInternal(ChunkCoord key, IDimensionInfo provider) {
+    private static RailChunkInfo getRailChunkTypeInternal(ChunkCoord key, PlanningContext provider) {
         int chunkX = key.chunkX();
         int chunkZ = key.chunkZ();
-        RandomSource randomRailChunkType = Rng.at(provider.getSeed(), chunkX, chunkZ, Rng.Purpose.RAILWAY);
+        RandomSource randomRailChunkType = Rng.at(provider.seed(), chunkX, chunkZ, Rng.Purpose.RAILWAY);
 
-        Preset profile = provider.getProfile();
+        Preset profile = provider.preset();
         RailwayParts railwayParts = provider.worldStyles().primary().getPartSelector().railwayParts();
 
         // @todo make all settings based on rand below configurable
@@ -287,7 +287,7 @@ public class Railway {
         return RailChunkInfo.NOTHING;
     }
 
-    private static RailChunkInfo getStationType(ChunkCoord coord, IDimensionInfo provider, Preset profile, float r, int rails, List<String> part) {
+    private static RailChunkInfo getStationType(ChunkCoord coord, PlanningContext provider, Preset profile, float r, int rails, List<String> part) {
         int cityLevel = ChunkPlan.getCityLevel(coord, provider);
         if (cityLevel > 2 || !profile.RAILWAY_SURFACE_STATIONS_ENABLED) {
             // We are too high here. We need an underground station
@@ -315,7 +315,7 @@ public class Railway {
         return r < .5f ? new RailChunkInfo(STATION_SURFACE, BI, cityLevel, rails, part) : new RailChunkInfo(STATION_UNDERGROUND, BI, RAILWAY_LEVEL_OFFSET, rails);
     }
 
-    public static RailChunkInfo getRailChunkType(ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    public static RailChunkInfo getRailChunkType(ChunkCoord coord, PlanningContext provider, Preset profile) {
         Map<ChunkCoord, RailChunkInfo> cache = provider.caches().railInfo;
         RailChunkInfo known = cache.get(coord);
         if (known != null) {
@@ -357,13 +357,13 @@ public class Railway {
      * railway when the world style is <em>not</em> {@code BLOCK_RAILWAY}, so under the one policy
      * that consults this the building's depth owes the railway nothing.</p>
      */
-    public static boolean buildingBlocksRail(ChunkCoord coord, IDimensionInfo provider) {
+    public static boolean buildingBlocksRail(ChunkCoord coord, PlanningContext provider) {
         WorldSettings.RailwayAvoidance avoidance =
                 provider.worldStyles().primary().getWorldSettings().railwayAvoidance();
         if (avoidance != WorldSettings.RailwayAvoidance.BLOCK_RAILWAY) {
             return false;
         }
-        RailChunkInfo railInfo = getRailChunkType(coord, provider, provider.getProfile());
+        RailChunkInfo railInfo = getRailChunkType(coord, provider, provider.preset());
         if (railInfo == RailChunkInfo.NOTHING) {
             return false;
         }
@@ -376,7 +376,7 @@ public class Railway {
         return lowestLevel <= railInfo.getLevel() + partlevel - 1;
     }
 
-    private static RailChunkInfo testAdjacentRailChunk(float r, RailChunkInfo adjacent, RailDirection direction, ChunkCoord coord, IDimensionInfo provider, Preset profile) {
+    private static RailChunkInfo testAdjacentRailChunk(float r, RailChunkInfo adjacent, RailDirection direction, ChunkCoord coord, PlanningContext provider, Preset profile) {
         switch (adjacent.getType()) {
             case NONE:
                 return RailChunkInfo.NOTHING;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Style.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Style.java
@@ -25,7 +25,7 @@ public class Style {
      * @param palettes the compiled palettes this style's {@code randompalettes} name. Resolved here
      *                 rather than on the first chunk that needs one: the lookup used to happen inside
      *                 {@link #getRandomPalette}, from a worldgen worker, which is why that method took
-     *                 an {@code IDimensionInfo} it otherwise had no use for (issue #128).
+     *                 a {@code PlanningContext} it otherwise had no use for (issue #128).
      */
     public Style(Identifier id, AssetIndex<Palette> palettes, List<StyleDefinition> chainRootFirst) {
         name = id;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/WorldStyle.java
@@ -2,7 +2,7 @@ package dev.krona.urbex.worldgen.lost.cityassets;
 
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.varia.Tools;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.UrbexTags;
 import dev.krona.urbex.worldgen.lost.BiomeInfo;
 import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
@@ -189,7 +189,7 @@ public class WorldStyle {
         return worldSettings;
     }
 
-    public float getCityChanceMultiplier(IDimensionInfo provider, ChunkCoord coord) {
+    public float getCityChanceMultiplier(PlanningContext provider, ChunkCoord coord) {
         Holder<Biome> biome = BiomeInfo.getBiomeInfo(provider, coord).getMainBiome();
         for (Pair<Predicate<Holder<Biome>>, Float> pair : cityBiomeMultiplier) {
             if (pair.getLeft().test(biome)) {
@@ -199,7 +199,7 @@ public class WorldStyle {
         return 1.0f;
     }
 
-    public String getRandomCityStyle(IDimensionInfo provider, ChunkCoord coord, RandomSource random) {
+    public String getRandomCityStyle(PlanningContext provider, ChunkCoord coord, RandomSource random) {
         Holder<Biome> biome = BiomeInfo.getBiomeInfo(provider, coord).getMainBiome();
         List<Pair<Float, String>> ct = new ArrayList<>();
         for (Pair<Predicate<Holder<Biome>>, Pair<Float, String>> pair : cityStyleSelector) {

--- a/src/test/java/dev/krona/urbex/gui/NullDimensionInfoPlaceholderTest.java
+++ b/src/test/java/dev/krona/urbex/gui/NullDimensionInfoPlaceholderTest.java
@@ -57,12 +57,12 @@ class NullDimensionInfoPlaceholderTest {
     void thePreviewBuildsWithoutRegistryAccess() {
         NullDimensionInfo diminfo = assertDoesNotThrow(NullDimensionInfoPlaceholderTest::placeholderPreview,
                 "the preview must fall back to the placeholder world style, not throw");
-        assertNotNull(diminfo.worldStyles().primary(), "the placeholder world style must be built");
+        assertNotNull(diminfo.planning().worldStyles().primary(), "the placeholder world style must be built");
     }
 
     @Test
     void thePlaceholderDeclaresEveryFieldRequiredAfterResolution() {
-        WorldStyle style = placeholderPreview().worldStyles().primary();
+        WorldStyle style = placeholderPreview().planning().worldStyles().primary();
 
         // outsidestyle and citystyles are required by WorldStyle itself; parts is required and then
         // required component by component by PartSelector.requireComplete. Reaching this line at all
@@ -91,7 +91,7 @@ class NullDimensionInfoPlaceholderTest {
 
     @Test
     void thePlaceholderNamesNoUnqualifiedAsset() {
-        WorldStyle style = placeholderPreview().worldStyles().primary();
+        WorldStyle style = placeholderPreview().planning().worldStyles().primary();
         // A bare name would throw out of DataTools.fromName the moment anything resolved it, which is
         // the load error this branch introduced for datapacks - src/main must not write one either.
         Identifier outside = assertDoesNotThrow(() -> DataTools.fromName(style.getOutsideStyle()),

--- a/src/test/java/dev/krona/urbex/worldgen/TestWorldStyles.java
+++ b/src/test/java/dev/krona/urbex/worldgen/TestWorldStyles.java
@@ -1,0 +1,66 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
+import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
+import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
+import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
+import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
+import net.minecraft.resources.Identifier;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A world style for tests that are about something else.
+ * <p>
+ * Every {@code PlanningContext} needs a {@link WorldStyleField}, and a field needs at least one
+ * style - correctly, since a dimension with no world style has nothing to generate. Building one
+ * means declaring everything {@link WorldStyle} requires after its {@code extends} chain resolves:
+ * {@code outsidestyle}, {@code citystyles} and each of the twenty-two wiring components
+ * {@code PartSelector.requireComplete} checks. That is twenty-five lines of {@code Optional.empty()}
+ * no test wants to carry a copy of.
+ * <p>
+ * The ids are deliberately not the bundled pack's, so a test that accidentally depends on one names
+ * {@code urbextest:*} in its failure rather than looking like a real style. Nothing here declares a
+ * part, because a test using this is not rendering one.
+ */
+public final class TestWorldStyles {
+
+    private TestWorldStyles() {
+    }
+
+    /** A field of one style, which every accessor answers without drawing from {@code Rng}. */
+    public static WorldStyleField singleStyleField(long seed) {
+        return new WorldStyleField(seed, List.of(new WorldStyleField.Weighted(1.0f, minimal("only"))));
+    }
+
+    /** One minimal resolvable world style, named {@code urbextest:<path>}. */
+    public static WorldStyle minimal(String path) {
+        WorldStyleDefinition declaration = new WorldStyleDefinition(
+                Optional.empty(),
+                // No display name: these exist to be told apart by id, and getName() is what the
+                // field's primary tie-break reads.
+                Optional.empty(),
+                Optional.of("urbex:standard"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(new PartSelector.Decl(
+                        Optional.of(new HighwayParts.Decl(
+                                noParts(), noParts(), noParts(), noParts(), noParts(), noParts())),
+                        Optional.of(new RailwayParts.Decl(
+                                noParts(), noParts(), noParts(), noParts(), noParts(), noParts(),
+                                noParts(), noParts(), noParts(), noParts(), noParts(), noParts(),
+                                noParts(), noParts(), noParts(), noParts())))),
+                Optional.of(new Mergeable<>(true, Collections.emptyList())),
+                Optional.empty(),
+                Optional.empty());
+        return new WorldStyle(Identifier.fromNamespaceAndPath("urbextest", path), List.of(declaration));
+    }
+
+    private static Optional<Mergeable<String>> noParts() {
+        return Optional.of(new Mergeable<>(true, Collections.emptyList()));
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/WorldStyleFieldTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/WorldStyleFieldTest.java
@@ -2,21 +2,13 @@ package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
-import dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition;
-import dev.krona.urbex.worldgen.lost.regassets.data.HighwayParts;
-import dev.krona.urbex.worldgen.lost.regassets.data.Mergeable;
-import dev.krona.urbex.worldgen.lost.regassets.data.PartSelector;
-import dev.krona.urbex.worldgen.lost.regassets.data.RailwayParts;
 import net.minecraft.SharedConstants;
-import net.minecraft.resources.Identifier;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.world.level.Level;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -42,53 +34,19 @@ class WorldStyleFieldTest {
         Bootstrap.bootStrap();
     }
 
-    /**
-     * A minimal resolvable world style, built by hand rather than from a registry - the same shape
-     * {@code NullDimensionInfo}'s preview placeholder uses, which is the only other place in the
-     * tree that constructs a {@code WorldStyleDefinition} directly. Declares everything
-     * {@code WorldStyle} requires after resolution and nothing else.
-     */
-    private static WorldStyle style(String path) {
-        WorldStyleDefinition re = new WorldStyleDefinition(
-                Optional.empty(),
-                // No display name: these exist to be told apart by id, and getName() is what the
-                // field's primary tie-break and this test's assertions read.
-                Optional.empty(),
-                Optional.of("urbex:standard"),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.of(new PartSelector.Decl(
-                        Optional.of(new HighwayParts.Decl(
-                                noParts(), noParts(), noParts(), noParts(), noParts(), noParts())),
-                        Optional.of(new RailwayParts.Decl(
-                                noParts(), noParts(), noParts(), noParts(), noParts(), noParts(),
-                                noParts(), noParts(), noParts(), noParts(), noParts(), noParts(),
-                                noParts(), noParts(), noParts(), noParts())))),
-                Optional.of(new Mergeable<>(true, Collections.emptyList())),
-                Optional.empty(),
-                Optional.empty()
-        );
-        return new WorldStyle(Identifier.fromNamespaceAndPath("urbextest", path), List.of(re));
-    }
-
-    private static Optional<Mergeable<String>> noParts() {
-        return Optional.of(new Mergeable<>(true, Collections.emptyList()));
-    }
-
     private static ChunkCoord coord(int x, int z) {
         return new ChunkCoord(Level.OVERWORLD, x, z);
     }
 
     private static WorldStyleField mixed() {
         return new WorldStyleField(SEED, List.of(
-                new WorldStyleField.Weighted(0.1f, style("light")),
-                new WorldStyleField.Weighted(0.9f, style("heavy"))));
+                new WorldStyleField.Weighted(0.1f, TestWorldStyles.minimal("light")),
+                new WorldStyleField.Weighted(0.9f, TestWorldStyles.minimal("heavy"))));
     }
 
     @Test
     void oneStyleAlwaysAnswersItselfWithoutDrawing() {
-        WorldStyle only = style("light");
+        WorldStyle only = TestWorldStyles.minimal("light");
         WorldStyleField field = WorldStyleField.single(SEED, only);
         assertTrue(field.isSingle());
         assertSame(only, field.primary());
@@ -118,8 +76,8 @@ class WorldStyleFieldTest {
     void differentSeedsDrawDifferently() {
         WorldStyleField a = mixed();
         WorldStyleField b = new WorldStyleField(SEED + 1, List.of(
-                new WorldStyleField.Weighted(0.1f, style("light")),
-                new WorldStyleField.Weighted(0.9f, style("heavy"))));
+                new WorldStyleField.Weighted(0.1f, TestWorldStyles.minimal("light")),
+                new WorldStyleField.Weighted(0.9f, TestWorldStyles.minimal("heavy"))));
         int differences = 0;
         for (int x = -30; x <= 30; x++) {
             for (int z = -30; z <= 30; z++) {
@@ -159,8 +117,8 @@ class WorldStyleFieldTest {
     void equalWeightsBreakTheTieOnTheIdNotOnListOrder() {
         // Mirrors WorldStyleMix.primary: the field is built from a list that can arrive in registry
         // iteration order, so a positional tie-break would depend on file names.
-        WorldStyle light = style("light");
-        WorldStyle heavy = style("heavy");
+        WorldStyle light = TestWorldStyles.minimal("light");
+        WorldStyle heavy = TestWorldStyles.minimal("heavy");
         assertEquals("urbextest:heavy", new WorldStyleField(SEED, List.of(
                 new WorldStyleField.Weighted(1.0f, light),
                 new WorldStyleField.Weighted(1.0f, heavy))).primary().getName());

--- a/src/test/java/dev/krona/urbex/worldgen/lost/ChunkPlanTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/ChunkPlanTest.java
@@ -2,27 +2,40 @@ package dev.krona.urbex.worldgen.lost;
 
 import dev.krona.urbex.config.LandscapeType;
 import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.plan.RoadField;
 import dev.krona.urbex.plan.RoadType;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.DimensionCaches;
+import dev.krona.urbex.worldgen.LevelShape;
+import dev.krona.urbex.worldgen.PlanningContext;
+import dev.krona.urbex.worldgen.TerrainSampler;
+import dev.krona.urbex.worldgen.TestWorldStyles;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
 import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Proxy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * {@link ChunkPlan#effectiveRoadType} must return {@link RoadType#NONE} for a non-city chunk
  * without ever consulting the road field - {@code isCityRaw} gates it. This is exercised through
- * the void-chunk branch of {@code isCityRaw} (a floating-landscape profile whose heightmap reports
+ * the void-chunk branch of {@code isCityRaw} (a floating-landscape preset whose heightmap reports
  * ground level 0), the cheapest way to force a non-city verdict without faking the whole
  * city-factor radius scan.
+ * <p>
+ * The road field is a stub that throws, which is what makes "without consulting it" an assertion
+ * rather than a comment. Until #129 the whole planning context had to be a
+ * {@code java.lang.reflect.Proxy} over {@code IDimensionInfo} to say that much, because the
+ * interface also handed out a level and a generator and there was no smaller thing to build.
  * <p>
  * Bootstrapped because {@code ChunkCoord}/{@code Level.OVERWORLD} need the vanilla registries.
  */
@@ -36,35 +49,52 @@ class ChunkPlanTest {
 
     @Test
     void effectiveRoadTypeIsNoneForANonCityChunkWithoutConsultingTheRoadField() {
-        Preset profile = new Preset(Identifier.fromNamespaceAndPath("urbex", "test-void"));
-        profile.LANDSCAPE_TYPE = LandscapeType.FLOATING;
+        Preset preset = new Preset(Identifier.fromNamespaceAndPath("urbex", "test-void"));
+        preset.LANDSCAPE_TYPE = LandscapeType.FLOATING;
         ChunkCoord coord = new ChunkCoord(Level.OVERWORLD, 3, 4);
-        ChunkHeightmap groundLevelZero = new ChunkHeightmap(LandscapeType.FLOATING, 0);
 
-        IDimensionInfo fakeProvider = (IDimensionInfo) Proxy.newProxyInstance(
-                IDimensionInfo.class.getClassLoader(),
-                new Class<?>[]{IDimensionInfo.class},
-                (proxy, method, args) -> {
-                    return switch (method.getName()) {
-                        case "getProfile" -> profile;
-                        case "getHeightmap" -> groundLevelZero;
-                        case "toString" -> "fake-void-provider";
-                        case "hashCode" -> System.identityHashCode(proxy);
-                        case "equals" -> proxy == args[0];
-                        default -> {
-                            if (method.getDeclaringClass() == Object.class) {
-                                yield null;
-                            }
-                            // Anything past isVoidChunk - the road field, the city style, a
-                            // neighbour probe - means the early return did not fire.
-                            throw new AssertionError("Unexpected call to " + method
-                                    + " on the fake IDimensionInfo - effectiveRoadType should have "
-                                    + "returned NONE from isCityRaw's void-chunk check before reaching it");
-                        }
-                    };
-                });
+        PlanningContext planning = new PlanningContext(
+                1234L, Level.OVERWORLD, preset, AssetSnapshot.empty(),
+                TestWorldStyles.singleStyleField(1234L),
+                refusingRoadField(),
+                new DimensionCaches(1234L),
+                LevelShape.VANILLA_OVERWORLD,
+                groundLevelZero());
 
-        assertEquals(RoadType.NONE, ChunkPlan.effectiveRoadType(coord, fakeProvider, profile),
+        assertEquals(RoadType.NONE, ChunkPlan.effectiveRoadType(coord, planning, preset),
                 "a void (non-city) chunk must report no road, without ever reading the road field");
+    }
+
+    /** Everything below sea level, so {@code isVoidChunk} answers yes for every chunk. */
+    private static TerrainSampler groundLevelZero() {
+        return new TerrainSampler() {
+            @Override
+            public ChunkHeightmap heightmap(ChunkCoord coord) {
+                return new ChunkHeightmap(LandscapeType.FLOATING, 0);
+            }
+
+            @Override
+            public void sampleAccurateHeight(ChunkHeightmap heightmap, int chunkX, int chunkZ) {
+                throw new AssertionError("effectiveRoadType has no reason to sample accurate heights");
+            }
+
+            @Override
+            public Holder<Biome> biome(BlockPos pos) {
+                throw new AssertionError("effectiveRoadType has no reason to read a biome");
+            }
+
+            @Override
+            public RegistryAccess registryAccess() {
+                return null;
+            }
+        };
+    }
+
+    /** Reaching the road field at all means the early return did not fire. */
+    private static RoadField refusingRoadField() {
+        return (chunkX, chunkZ) -> {
+            throw new AssertionError("effectiveRoadType read the road field for a void chunk; "
+                    + "isCityRaw's void check should have returned NONE first");
+        };
     }
 }


### PR DESCRIPTION
PlanningContext is everything a chunk is planned against: seed, dimension,
preset, compiled assets, world styles, road field, caches, level shape,
terrain sampler. Nine components, all of them already what planning read.
IDimensionInfo is down from thirteen methods to two.

What the record buys is not tidiness, it is that planning can no longer reach
anything a preview does not have. Two chunks planned in either order, on any
thread, in a server or on the world-creation screen, see the same answer -
because of what planning is able to reach, rather than because everyone has
been careful.

It also breaks the construction cycle. DefaultDimensionInfo built its
CityGenerator with `new CityGenerator(this, preset)`, handing a
half-constructed object to a collaborator that read a level back out of it;
neither type could be built without the other, and a test that wanted a
planner had to conjure a whole dimension. The generator takes a finished
PlanningContext now, and the two are built in order.

ChunkPlanTest is what that looks like from a test: it was a
java.lang.reflect.Proxy over IDimensionInfo that threw from every method it
did not anticipate, because there was no smaller thing to hand a planner. It
builds a real PlanningContext now, with a road field that throws - so "returns
NONE without consulting the road field" is an assertion rather than a comment.

Mechanical apart from the composition roots: a type change and five accessor
renames the compiler checked exhaustively (getSeed -> seed, getProfile ->
preset, getType/dimension -> dimension, getHeightmap -> heightmap, getBiome ->
biome). The two dimension-key methods that returned the same value are one.

Also adds TestWorldStyles, since a PlanningContext needs a WorldStyleField and
a field correctly refuses to be empty; WorldStyleFieldTest's hand-built copy
now comes from there.

IDimensionInfo and NullDimensionInfo survive this change on purpose - deleting
them decides who owns what, and that is the next two PRs, not this one.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>