### PR TITLE
refactor: the preview plans with a context instead of impersonating a dimension (#129, 129e)

### DIFF
--- a/src/main/java/dev/krona/urbex/gui/CitiesTab.java
+++ b/src/main/java/dev/krona/urbex/gui/CitiesTab.java
@@ -498,7 +498,7 @@ public class CitiesTab extends GridLayoutTab {
      * The registries the preview should sample biomes from: the ones loaded for the world being
      * created, so datapack biomes and world-type choices are reflected. Degrades to {@code null}
      * (the pre-preview "registry-gated rules skipped" behaviour) rather than letting
-     * {@code NullDimensionInfo}'s {@code lookupOrThrow(BIOME)} take the screen down if a
+     * {@code PreviewTerrain}'s {@code lookupOrThrow(BIOME)} take the screen down if a
      * half-loaded context ever lacks the biome registry.
      */
     @Nullable

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -6,7 +6,6 @@ import com.mojang.serialization.JsonOps;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.setup.WorldStyleMix;
-import dev.krona.urbex.gui.NullDimensionInfo;
 import dev.krona.urbex.plan.RoadType;
 import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.varia.ChunkCoord;
@@ -16,7 +15,6 @@ import dev.krona.urbex.worldgen.lost.Highway;
 import dev.krona.urbex.worldgen.lost.RailChunkType;
 import dev.krona.urbex.worldgen.lost.Railway;
 import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
-import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -29,8 +27,8 @@ import javax.annotation.Nullable;
 import java.util.Random;
 
 /**
- * The world-creation city/building preview: a small (62x58) chunk-grid image sampled from a
- * {@link NullDimensionInfo}, cached against the (profile, worldstyle, seed, mode) that produced it so
+ * The world-creation city/building preview: a small (62x58) chunk-grid image sampled through a
+ * {@link PreviewContext}, cached against the (profile, worldstyle, seed, mode) that produced it so
  * repeated {@link #update} calls while the player is merely dragging a slider don't recompute
  * anything.
  * <p>
@@ -50,11 +48,11 @@ import java.util.Random;
  *       chunk generates.</li>
  * </ul>
  * "Honest" relative to the old editor's preview map renderer: that preview always ran
- * with {@code PlanningContext.getWorld() == null}, which silently skipped the worldstyle
- * city-chance multiplier and the CITY_MINHEIGHT/MAXHEIGHT gate in {@code City.getCityFactor} (both
- * guarded on {@code getWorld() != null}). This preview is built with real registry access, so those
- * guards - now keyed on {@code registryAccess() != null} - evaluate the same rules a real dimension
- * would (see {@code City.java} and {@code NullDimensionInfo} for the registry-access plumbing).
+ * against a dimension with no level at all, which silently skipped the worldstyle city-chance
+ * multiplier and the CITY_MINHEIGHT/MAXHEIGHT gate in {@code City.getCityFactor} (both guarded on
+ * {@code getWorld() != null}). This preview is built with real registry access, so those guards -
+ * now keyed on {@code registryAccess() != null} - evaluate the same rules a real dimension would
+ * (see {@code City.java} and {@link PreviewContext} for the registry-access plumbing).
  */
 public class CityPreview implements AutoCloseable {
 
@@ -229,9 +227,9 @@ public class CityPreview implements AutoCloseable {
         // out from under whatever else was reading them. They are part of the snapshot the preview
         // compiles for itself now, so a new preview simply has its own (issue #129).
         //
-        // Only the map/transport/roads samplers walk a NullDimensionInfo; CITY renders straight from
-        // the preset, so it does not pay to build one there - nor to resolve the world styles, which
-        // is why that sits inside this branch and inside the guard rather than above it.
+        // Only the map/transport/roads samplers plan anything; CITY renders straight from the
+        // preset, so it does not pay to build a context there - nor to resolve the world styles,
+        // which is why that sits inside this branch and inside the guard rather than above it.
         //
         // Two things under the guard can throw, and both must leave the screen standing:
         //   - GridSettings.fromPreset validates the road settings, and a preset can be momentarily
@@ -242,7 +240,7 @@ public class CityPreview implements AutoCloseable {
         //     and taking the screen down mid-drag is no way to say so. Keep showing the last good
         //     preview until the preset makes sense again; a preset still inconsistent at world
         //     creation fails there, with the field named. (IllegalArgumentException.)
-        //   - NullDimensionInfo's world styles: building the fallback placeholder raises the
+        //   - The world styles: building the fallback placeholder raises the
         //     post-resolution requiredness error if a field required of a resolved chain is ever
         //     added and not added to the placeholder (IllegalStateException, out of Resolved.require
         //     - which is the whole reason the placeholder is covered by a test of its own). The
@@ -250,12 +248,12 @@ public class CityPreview implements AutoCloseable {
         //     registry access at all, so it is on the ordinary path and not a corner.
         // The guard stays wrapped around just this construction so a bug in a renderer's own math is
         // never silently swallowed as "the preset is invalid".
-        NullDimensionInfo diminfo = null;
+        PreviewContext context = null;
         if (mode != Mode.CITY) {
             try {
                 // The ids in a WorldStyleMix are validated on construction, so they are already
                 // qualified by the time they reach here.
-                diminfo = new NullDimensionInfo(preset, worldStyles, seed, registryAccess);
+                context = PreviewContext.create(preset, worldStyles, seed, registryAccess);
             } catch (IllegalArgumentException | IllegalStateException e) {
                 // Nothing has been drawn at this point, so `colors` and `texture` still hold the last
                 // good render. Leaving `mode` alone too keeps the legend describing the image actually
@@ -266,9 +264,9 @@ public class CityPreview implements AutoCloseable {
             }
         }
         switch (mode) {
-            case MAP -> renderMap(diminfo);
-            case TRANSPORT -> renderTransport(diminfo, preset);
-            case ROADS -> renderRoads(diminfo, preset);
+            case MAP -> renderMap(context);
+            case TRANSPORT -> renderTransport(context, preset);
+            case ROADS -> renderRoads(context, preset);
             case CITY -> renderCity(preset, seed);
         }
         this.mode = mode;
@@ -277,16 +275,16 @@ public class CityPreview implements AutoCloseable {
 
     // ---- MAP -----------------------------------------------------------------
 
-    private void renderMap(NullDimensionInfo diminfo) {
+    private void renderMap(PreviewContext context) {
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {
-                colors[z * WIDTH + x] = sampleColor(diminfo, x, z);
+                colors[z * WIDTH + x] = sampleColor(context, x, z);
             }
         }
     }
 
-    private static int sampleColor(NullDimensionInfo diminfo, int x, int z) {
-        char b = diminfo.getBiomeChar(x, z);
+    private static int sampleColor(PreviewContext context, int x, int z) {
+        char b = context.terrain().biomeChar(x, z);
         int terrainColor = switch (b) {
             // '-' and '=' are the ocean/river water chars - same blue the old renderPreviewMap used.
             case '-', '=' -> WATER_COLOR;
@@ -295,7 +293,7 @@ public class CityPreview implements AutoCloseable {
             case '*', 'd' -> 0xffcccc55;
             default -> 0xff005500;
         };
-        PlanningContext planning = diminfo.planning();
+        PlanningContext planning = context.planning();
         ChunkCoord coord = planning.coord(x, z);
         ChunkCandidate candidate = ChunkPlan.getChunkCandidateGui(coord, planning);
         if (candidate.isCity()) {
@@ -311,11 +309,11 @@ public class CityPreview implements AutoCloseable {
      * old {@code renderPreviewTransports} did with its {@code soft} base), with rail and highway
      * chunks blended over. Highway-over-rail is a distinct grey so an interchange is visible.
      */
-    private void renderTransport(NullDimensionInfo diminfo, Preset profile) {
-        PlanningContext planning = diminfo.planning();
+    private void renderTransport(PreviewContext context, Preset profile) {
+        PlanningContext planning = context.planning();
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {
-                int base = soften(sampleColor(diminfo, x, z));
+                int base = soften(sampleColor(context, x, z));
                 ChunkCoord c = planning.coord(x, z);
                 boolean hasRail = Railway.getRailChunkType(c, planning, profile).getType() != RailChunkType.NONE;
                 int overlay = hasRail ? RAIL_OVERLAY : 0;
@@ -353,19 +351,19 @@ public class CityPreview implements AutoCloseable {
      * {@code ChunkPlan.getEffectiveRoadType()} - the field never learns about the content
      * decision, on purpose, to keep that decision graph acyclic). Real generation resolves multi-
      * building placement through {@link dev.krona.urbex.worldgen.lost.MultiChunk}, which reaches a
-     * live {@code WorldGenLevel} to look up building assets; this preview runs off
-     * {@link NullDimensionInfo} with no server, so that placement is not something it can reproduce
+     * live {@code WorldGenLevel} to look up building assets; this preview runs off a
+     * {@link PreviewContext} with no server, so that placement is not something it can reproduce
      * without touching generation-path code to add a registry-only asset lookup - out of this mode's
      * scope. So: a chunk an accepted multi-building will claim in the real world may still show a
      * road colour here. Unlike the predicate this replaced, that is an honest, narrow gap (multi-
      * building footprints only, not a random fraction of the whole grid), not a defect masquerading
      * as a guarantee.
      */
-    private void renderRoads(NullDimensionInfo diminfo, Preset profile) {
-        PlanningContext planning = diminfo.planning();
+    private void renderRoads(PreviewContext context, Preset profile) {
+        PlanningContext planning = context.planning();
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {
-                int base = soften(sampleColor(diminfo, x, z));
+                int base = soften(sampleColor(context, x, z));
                 ChunkCoord c = planning.coord(x, z);
                 RoadType type = ChunkPlan.effectiveRoadType(c, planning, profile);
                 colors[z * WIDTH + x] = blend(base, roadColour(type));

--- a/src/main/java/dev/krona/urbex/gui/preview/PreviewContext.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/PreviewContext.java
@@ -1,17 +1,14 @@
-package dev.krona.urbex.gui;
+package dev.krona.urbex.gui.preview;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
-import dev.krona.urbex.gui.preview.PreviewTerrain;
 import dev.krona.urbex.plan.grid.GridRoadField;
 import dev.krona.urbex.plan.grid.GridSettings;
-import dev.krona.urbex.worldgen.DimensionCaches;
 import dev.krona.urbex.setup.WorldStyleMix;
-import dev.krona.urbex.worldgen.IDimensionInfo;
+import dev.krona.urbex.worldgen.DimensionCaches;
 import dev.krona.urbex.worldgen.LevelShape;
 import dev.krona.urbex.worldgen.PlanningContext;
 import dev.krona.urbex.worldgen.WorldStyleField;
-import dev.krona.urbex.worldgen.CityGenerator;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetCompiler;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetDiagnostics;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
@@ -30,9 +27,24 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 
-public class NullDimensionInfo implements IDimensionInfo {
+/**
+ * What the world-creation preview plans against: a {@link PlanningContext} and the bitmap terrain it
+ * reads.
+ *
+ * <p>This replaces {@code NullDimensionInfo}, which reached the production planner by impersonating a
+ * server dimension - answering {@code null} to "what level are you?" and, to be constructible at all,
+ * building a {@link dev.krona.urbex.worldgen.CityGenerator} nothing drove. Nothing here impersonates
+ * anything: the preview holds the same value a loaded level's runtime holds, built from what the
+ * world-creation screen actually knows (issue #129).</p>
+ *
+ * <p>The generator is gone entirely. The preview samples city placement, road classes and rail and
+ * highway chunk <em>types</em>; it renders none of them as blocks, so it never had a use for one.</p>
+ *
+ * @param terrain also reachable as {@code planning().terrain()}; named here because the renderer
+ *                colours its map straight from the bitmap, which is not a planning question.
+ */
+public record PreviewContext(PlanningContext planning, PreviewTerrain terrain) {
 
     /** What the placeholder world style calls itself, so a load error can name it. */
     private static final Identifier PLACEHOLDER_ID =
@@ -40,21 +52,21 @@ public class NullDimensionInfo implements IDimensionInfo {
     /** A style the bundled pack actually ships, and qualified; see {@link #placeholderStyle()}. */
     private static final String PLACEHOLDER_OUTSIDE_STYLE = Urbex.MODID + ":standard";
 
-    private final Random random;
-    private final PreviewTerrain terrain;
-    private final PlanningContext planning;
-    private final CityGenerator feature;
-
     /**
-     * The preview's dimension info. Takes the whole {@link WorldStyleMix} the player chose, so a
+     * Builds the preview's context. Takes the whole {@link WorldStyleMix} the player chose, so a
      * mixed selection previews as a mix rather than as its primary alone - judging a balance before
      * committing to the world is the point of the control.
      * <p>
      * Every id resolves independently: one style the datapacks no longer ship falls back to the
      * placeholder for that entry alone, rather than taking the whole preview with it.
+     *
+     * @throws IllegalArgumentException if the preset's road settings are self-contradictory
+     *                                  ({@link GridSettings#fromPreset})
+     * @throws IllegalStateException    if the placeholder world style stops declaring a field that
+     *                                  becomes required after resolution
      */
-    public NullDimensionInfo(Preset profile, WorldStyleMix worldStyles, long seed, @Nullable RegistryAccess registryAccess) {
-        DimensionCaches caches = new DimensionCaches(seed);
+    public static PreviewContext create(Preset preset, WorldStyleMix worldStyles, long seed,
+                                        @Nullable RegistryAccess registryAccess) {
         // The preview compiles its own snapshot and owns it, rather than reaching for the server's.
         // It has no session - it runs on the client, on the world-creation screen, before any server
         // exists - and must not acquire one. Diagnostics are discarded on purpose: a broken pack is
@@ -79,27 +91,24 @@ public class NullDimensionInfo implements IDimensionInfo {
             resolvedEntries.add(new WorldStyleField.Weighted(entry.weight(),
                     resolved != null ? resolved : new WorldStyle(PLACEHOLDER_ID, List.of(placeholderStyle()))));
         }
-        random = new Random(seed);
-        terrain = new PreviewTerrain(profile, registryAccess);
-        planning = new PlanningContext(
+        PreviewTerrain terrain = new PreviewTerrain(preset, registryAccess);
+        return new PreviewContext(new PlanningContext(
                 seed,
                 // The overworld, which is what the preview draws.
                 Level.OVERWORLD,
-                profile,
+                preset,
                 assets,
                 new WorldStyleField(seed, resolvedEntries),
-                // The preview's own seed and dimension, so the roads it draws are the roads the
-                // world will have. Same construction as DefaultDimensionInfo; there is no server to
-                // ask.
+                // The preview's own seed and dimension, so the roads it draws are the roads the world
+                // will have. Same construction as a loaded level's; there is no server to ask.
                 new GridRoadField(seed, Level.OVERWORLD.identifier().toString(),
-                        GridSettings.fromPreset(profile)),
-                caches,
+                        GridSettings.fromPreset(preset)),
+                new DimensionCaches(seed),
                 // The vanilla overworld's shape: a preview runs before any level exists, so there is
-                // nothing to ask, and every planning rule that reads a height bound or the water
-                // line gets a real answer rather than an NPE off a null level (issue #129).
+                // nothing to ask, and every planning rule that reads a height bound or the water line
+                // gets a real answer rather than an NPE off a null level.
                 LevelShape.VANILLA_OVERWORLD,
-                terrain);
-        feature = new CityGenerator(planning, profile);
+                terrain), terrain);
     }
 
     /**
@@ -110,8 +119,9 @@ public class NullDimensionInfo implements IDimensionInfo {
      * {@code outsidestyle}, {@code citystyles} and the whole of {@code parts}, down to each of the
      * twenty-two wiring components {@code PartSelector.requireComplete} checks. Anything left absent
      * is an {@link IllegalStateException} out of the constructor rather than a decode failure, and
-     * this is the one place in {@code src/main} that builds a {@code WorldStyleDefinition} by hand instead
-     * of decoding one, so no datapack test covers it; {@code NullDimensionInfoPlaceholderTest} does.
+     * this is the one place in {@code src/main} that builds a {@code WorldStyleDefinition} by hand
+     * instead of decoding one, so no datapack test covers it; {@code PreviewPlaceholderStyleTest}
+     * does.
      * <p>
      * The lists are declared and empty rather than absent because the preview draws no parts: it
      * samples biomes, city placement, road classes and rail/highway chunk <em>types</em>, none of
@@ -153,25 +163,4 @@ public class NullDimensionInfo implements IDimensionInfo {
     private static Optional<Mergeable<String>> noParts() {
         return Optional.of(new Mergeable<>(true, Collections.emptyList()));
     }
-
-    /** The config preview renderer's own source. Nothing here places generated blocks. */
-    public Random getRandom() {
-        return random;
-    }
-
-    @Override
-    public PlanningContext planning() {
-        return planning;
-    }
-
-    @Override
-    public CityGenerator getFeature() {
-        return feature;
-    }
-
-    /** The bitmap character at a chunk, for the renderer that colours the preview map from it. */
-    public char getBiomeChar(int chunkX, int chunkZ) {
-        return terrain.biomeChar(chunkX, chunkZ);
-    }
-
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/City.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/City.java
@@ -246,9 +246,9 @@ public class City {
         }
 
         if (factor > 0.0001 && provider.registryAccess() != null) {
-            // The compiled styles are already on the dimension info (DefaultDimensionInfo /
-            // NullDimensionInfo resolve them once at construction) - Preset itself carries no
-            // worldStyle any more, so there is nothing left to re-resolve here.
+            // The compiled styles are already on the planning context, resolved once when it was
+            // built - Preset itself carries no worldStyle any more, so there is nothing left to
+            // re-resolve here.
             //
             // primary(), not the chunk's style: this decides whether a city exists at all, so
             // attributing it to a nearby city would be circular.

--- a/src/test/java/dev/krona/urbex/gui/preview/PreviewPlaceholderStyleTest.java
+++ b/src/test/java/dev/krona/urbex/gui/preview/PreviewPlaceholderStyleTest.java
@@ -1,4 +1,4 @@
-package dev.krona.urbex.gui;
+package dev.krona.urbex.gui.preview;
 
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.setup.WorldStyleMix;
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The world-creation preview's placeholder world style must satisfy the same post-resolution rules
  * every datapack world style does.
  * <p>
- * {@link NullDimensionInfo} builds it whenever it cannot resolve the chosen one - either because it
+ * {@link PreviewContext} builds it whenever it cannot resolve the chosen one - either because it
  * was handed no {@code RegistryAccess} at all (the Cities tab and the Customize screen both pass
  * null deliberately when the biome registry or the parent screen is absent) or because the lookup
  * failed, which is what a stale GUI world style no longer shipped by any datapack looks like. The
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * is driven from the render pass. This test is the guard: every field {@code WorldStyle} requires
  * after resolution has to be declared here, and every asset name has to name its namespace.
  */
-class NullDimensionInfoPlaceholderTest {
+class PreviewPlaceholderStyleTest {
 
     @BeforeAll
     static void bootstrap() {
@@ -45,17 +45,17 @@ class NullDimensionInfoPlaceholderTest {
         Bootstrap.bootStrap();
     }
 
-    private static NullDimensionInfo placeholderPreview() {
+    private static PreviewContext placeholderPreview() {
         Preset preset = new Preset(Identifier.fromNamespaceAndPath("urbex", "test-placeholder"));
         // Null registry access is the GUI's own fallback, and it is also the only way to reach the
         // placeholder without a loaded registry to fail a lookup against.
-        return new NullDimensionInfo(preset, WorldStyleMix.of(Identifier.fromNamespaceAndPath("urbex", "standard")),
+        return PreviewContext.create(preset, WorldStyleMix.of(Identifier.fromNamespaceAndPath("urbex", "standard")),
                 1234L, null);
     }
 
     @Test
     void thePreviewBuildsWithoutRegistryAccess() {
-        NullDimensionInfo diminfo = assertDoesNotThrow(NullDimensionInfoPlaceholderTest::placeholderPreview,
+        PreviewContext diminfo = assertDoesNotThrow(PreviewPlaceholderStyleTest::placeholderPreview,
                 "the preview must fall back to the placeholder world style, not throw");
         assertNotNull(diminfo.planning().worldStyles().primary(), "the placeholder world style must be built");
     }

--- a/src/test/java/dev/krona/urbex/worldgen/lost/ChunkContentResolverTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/ChunkContentResolverTest.java
@@ -460,7 +460,7 @@ class ChunkContentResolverTest {
      * </ol>
      * {@code MultiChunk}'s own random building <em>selection</em> stays out of reach either way -
      * it needs a datapack-loaded level ({@code AssetRegistries} resolves through
-     * {@code CommonLevelAccessor}, and {@code NullDimensionInfo.getWorld()} is {@code null}) that
+     * {@code CommonLevelAccessor}, which a world-creation preview has no way to produce) that
      * this suite deliberately keeps out (see the class javadoc). Both tests below reuse the real
      * conflict <em>rule</em>, {@code MULTI_BUILDING_STREET_CONFLICT.roadBlocks}, rather than
      * reimplementing it, and the second reads {@code MultiChunk}'s own file rather than asserting


### PR DESCRIPTION
NullDimensionInfo is gone. The world-creation preview builds a PreviewContext -
the same PlanningContext a loaded level's runtime holds, plus the bitmap terrain
its renderer colours from - and hands that to the production planner.

What it stops doing is claiming to be a dimension. To be constructible as one it
had to answer getWorld() with null, and it had to build a CityGenerator so that
getFeature() had something to return. That generator was never driven: the
preview samples city placement, road classes and rail and highway chunk types,
and renders none of them as blocks. It existed because the interface said a
dimension has a generator.

The null level was the expensive half. Nothing in planning could ask a question
a preview cannot answer without either an NPE or a branch on "am I the preview?",
so the rules the preview skipped were skipped by accident of what it lacked
rather than by any decision. 129a through 129d removed the last of those
branches one at a time; this removes what they were branching on.

The preview keeps its own compiled AssetSnapshot, its own caches, its own seed
and its own placeholder world style, all of which moved across unchanged - the
placeholder with the test that guards it, renamed to PreviewPlaceholderStyleTest
and moved beside the class that builds it now.

Digest goldens all unchanged; no server generation path is touched by this.
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>