### PR TITLE
refactor: the carver hook reaches generation through the session (#129, 129g)

### DIFF
--- a/src/main/java/dev/krona/urbex/mixin/CarverHookMixin.java
+++ b/src/main/java/dev/krona/urbex/mixin/CarverHookMixin.java
@@ -1,6 +1,5 @@
 package dev.krona.urbex.mixin;
 
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.worldgen.CityFeature;
 import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.world.level.StructureManager;
@@ -36,9 +35,6 @@ public class CarverHookMixin {
     private void urbex$generateCity(WorldGenRegion region, long seed, RandomState randomState,
                                     BiomeManager biomeManager, StructureManager structureManager,
                                     ChunkAccess chunk, CallbackInfo ci) {
-        CityFeature feature = Registration.cityFeature();
-        if (feature != null) {
-            feature.generateFromPipeline(region, chunk);
-        }
+        CityFeature.generateFromPipeline(region, chunk);
     }
 }

--- a/src/main/java/dev/krona/urbex/setup/Registration.java
+++ b/src/main/java/dev/krona/urbex/setup/Registration.java
@@ -8,16 +8,19 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 
 
+/**
+ * Registers the configured-feature entry point.
+ * <p>
+ * It used to keep the registered instance in a static field so the carver-stage mixin could find
+ * something to call. Nothing reads that field now: {@link CityFeature#generateFromPipeline} is
+ * static, because it holds no state and reads everything from the level's published runtime (issue
+ * #129). What is left is the registration itself, which the feature needs to be nameable from a
+ * datapack.
+ */
 public class Registration {
 
-    private static CityFeature cityFeature;
-
-    public static CityFeature cityFeature() {
-        return cityFeature;
-    }
-
     public static void init() {
-        cityFeature = Registry.register(BuiltInRegistries.FEATURE,
+        Registry.register(BuiltInRegistries.FEATURE,
                 Identifier.fromNamespaceAndPath(Urbex.MODID, "city"), new CityFeature());
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
@@ -8,6 +8,7 @@ import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
@@ -52,12 +53,20 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
     /**
      * Generates the city content for {@code chunk}. Called from the carver-stage hook.
      * <p>
+     * Static, because it needs nothing from the registered feature instance - it holds no state, and
+     * everything this reads comes from the level's published {@link DimensionRuntime}. The carver
+     * hook used to reach it through {@code Registration.cityFeature()}, a process-global slot holding
+     * whichever {@code CityFeature} the last {@code Registration.init()} made; that is the last of
+     * the "ask a static for the thing that generates" lookups #129 is about, and a lookup that can
+     * answer {@code null} (before registration, or in a test) for something the mixin then skips
+     * silently.
+     * <p>
      * The runtime is read once, at the top, and everything below uses that one reference. A
      * {@code /reload} or an unload landing mid-chunk republishes the level's runtime for the
      * <em>next</em> chunk and leaves this one generating against the epoch it captured - which is
      * the whole point of the ownership move, and the opposite of what the dirty counter did.
      */
-    public boolean generateFromPipeline(WorldGenRegion region, net.minecraft.world.level.chunk.ChunkAccess chunk) {
+    public static boolean generateFromPipeline(WorldGenRegion region, ChunkAccess chunk) {
         DimensionRuntime runtime = GenerationSession.runtimeFor(region);
         if (runtime == null) {
             reportMissingRuntime(region.getLevel(), chunk.getPos());

--- a/src/main/java/dev/krona/urbex/worldgen/StructureSuppressor.java
+++ b/src/main/java/dev/krona/urbex/worldgen/StructureSuppressor.java
@@ -1,7 +1,6 @@
 package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.setup.Config;
-import dev.krona.urbex.setup.Registration;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import net.minecraft.world.level.ChunkPos;

--- a/src/test/java/dev/krona/urbex/worldgen/GenerationEntryPointTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/GenerationEntryPointTest.java
@@ -1,0 +1,50 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.setup.Registration;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Nothing reaches generation through a process-global instance any more.
+ * <p>
+ * The carver-stage mixin used to call {@code Registration.cityFeature()} - a static slot holding
+ * whichever {@code CityFeature} the last {@code Registration.init()} produced - and skip generation
+ * silently when it answered null. That is the shape #129 is about: a static asked for the thing that
+ * generates, when the level's own published {@link DimensionRuntime} already has everything the
+ * answer would have been used for.
+ * <p>
+ * Asserted by reflection rather than by reading the mixin's source, because what matters is that
+ * there is nothing to look up: a static entry point cannot be reached through an instance, and a
+ * class with no {@code CityFeature} field has no instance to hand out.
+ */
+class GenerationEntryPointTest {
+
+    @Test
+    void theCarverStageEntryPointNeedsNoRegisteredInstance() throws Exception {
+        Method entry = CityFeature.class.getDeclaredMethod("generateFromPipeline",
+                net.minecraft.server.level.WorldGenRegion.class,
+                net.minecraft.world.level.chunk.ChunkAccess.class);
+
+        assertTrue(Modifier.isStatic(entry.getModifiers()),
+                "generateFromPipeline holds no state and reads everything from the level's published "
+                        + "runtime, so the carver hook must not need an instance to call it");
+    }
+
+    @Test
+    void registrationKeepsNoFeatureInstanceToBeLookedUp() {
+        for (Field field : Registration.class.getDeclaredFields()) {
+            assertTrue(!CityFeature.class.isAssignableFrom(field.getType()),
+                    "Registration." + field.getName() + " is a process-global CityFeature slot; "
+                            + "generation is reached through GenerationSession, not through this");
+        }
+        assertEquals(0, Registration.class.getDeclaredFields().length,
+                "Registration registers and holds nothing - a field here is state with the lifetime "
+                        + "of the process rather than of a server");
+    }
+}


### PR DESCRIPTION
The mixin called Registration.cityFeature() - a static slot holding whichever
CityFeature the last Registration.init() produced - and skipped generation
silently when it answered null. generateFromPipeline is static now, because it
holds no state and reads everything it needs from the level's own published
DimensionRuntime, so there is nothing to look up and nothing that can be
absent.

The registration itself stays: the feature has to be nameable from a datapack.
What goes is the field, the accessor, and the null branch.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>