### PR TITLE
refactor: the planning module depends on nothing but java (#129, 129h)

### DIFF
--- a/src/main/java/dev/krona/urbex/config/PresetRoadGrid.java
+++ b/src/main/java/dev/krona/urbex/config/PresetRoadGrid.java
@@ -1,0 +1,46 @@
+package dev.krona.urbex.config;
+
+import dev.krona.urbex.plan.grid.GridSettings;
+
+/**
+ * Reads a preset's road-grid fields into the {@link GridSettings} the planner takes.
+ *
+ * <p>It sits here, on the configuration side, rather than as a {@code fromPreset} factory on
+ * {@code GridSettings} - which is where it used to be, written with a fully-qualified parameter type
+ * so that an import scan would not notice. {@code dev.krona.urbex.plan} is the dependency-free
+ * planning module: a pure function of seed, dimension id, coordinates and settings, exercisable with
+ * no game running and no configuration loaded. A conversion knows both sides, so it belongs to the
+ * side that already knows the other (issue #129).</p>
+ *
+ * <p>A straight read: {@link GridSettings}'s constructor is the only validation, and it stays strict.
+ * A preset whose {@code secondaryRoadMinCountX} exceeds its {@code secondaryRoadMaxCountX} is a
+ * preset nobody can generate the world they wrote down from, and quietly widening the pair here would
+ * hand them a different world with no diagnostic. Callers that cannot afford the exception - the
+ * settings preview, which rebuilds one of these on every keystroke and can therefore see a
+ * half-finished edit - are the ones that handle it.</p>
+ */
+public final class PresetRoadGrid {
+
+    private PresetRoadGrid() {
+    }
+
+    /**
+     * @throws IllegalArgumentException if the preset's road settings contradict each other
+     */
+    public static GridSettings of(Preset preset) {
+        return new GridSettings(
+                preset.PRIMARY_ROAD_SPACING_X,
+                preset.PRIMARY_ROAD_SPACING_Z,
+                preset.PRIMARY_ROAD_OPTIONAL_CHANCE,
+                preset.PRIMARY_ROAD_FORCE_EVERY,
+                preset.SECONDARY_ROAD_MIN_COUNT_X,
+                preset.SECONDARY_ROAD_MAX_COUNT_X,
+                preset.SECONDARY_ROAD_MIN_COUNT_Z,
+                preset.SECONDARY_ROAD_MAX_COUNT_Z,
+                preset.MINIMUM_ROAD_SEPARATION,
+                preset.MINIMUM_ROAD_EDGE_DISTANCE,
+                preset.TERTIARY_ROAD_CHANCE,
+                preset.TERTIARY_ROAD_MIN_LENGTH,
+                preset.TERTIARY_ROAD_MAX_LENGTH);
+    }
+}

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -232,7 +232,7 @@ public class CityPreview implements AutoCloseable {
         // which is why that sits inside this branch and inside the guard rather than above it.
         //
         // Two things under the guard can throw, and both must leave the screen standing:
-        //   - GridSettings.fromPreset validates the road settings, and a preset can be momentarily
+        //   - PresetRoadGrid.of validates the road settings, and a preset can be momentarily
         //     self-contradictory. The road settings come in min/max pairs held by two independent
         //     sliders, so dragging a minimum up necessarily passes through states where it exceeds
         //     its maximum. GridSettings refuses those, correctly - a world must never be generated

--- a/src/main/java/dev/krona/urbex/gui/preview/PreviewContext.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/PreviewContext.java
@@ -2,8 +2,8 @@ package dev.krona.urbex.gui.preview;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.config.PresetRoadGrid;
 import dev.krona.urbex.plan.grid.GridRoadField;
-import dev.krona.urbex.plan.grid.GridSettings;
 import dev.krona.urbex.setup.WorldStyleMix;
 import dev.krona.urbex.worldgen.DimensionCaches;
 import dev.krona.urbex.worldgen.LevelShape;
@@ -61,7 +61,7 @@ public record PreviewContext(PlanningContext planning, PreviewTerrain terrain) {
      * placeholder for that entry alone, rather than taking the whole preview with it.
      *
      * @throws IllegalArgumentException if the preset's road settings are self-contradictory
-     *                                  ({@link GridSettings#fromPreset})
+     *                                  ({@link PresetRoadGrid#of})
      * @throws IllegalStateException    if the placeholder world style stops declaring a field that
      *                                  becomes required after resolution
      */
@@ -102,7 +102,7 @@ public record PreviewContext(PlanningContext planning, PreviewTerrain terrain) {
                 // The preview's own seed and dimension, so the roads it draws are the roads the world
                 // will have. Same construction as a loaded level's; there is no server to ask.
                 new GridRoadField(seed, Level.OVERWORLD.identifier().toString(),
-                        GridSettings.fromPreset(preset)),
+                        PresetRoadGrid.of(preset)),
                 new DimensionCaches(seed),
                 // The vanilla overworld's shape: a preview runs before any level exists, so there is
                 // nothing to ask, and every planning rule that reads a height bound or the water line

--- a/src/main/java/dev/krona/urbex/plan/grid/GridSettings.java
+++ b/src/main/java/dev/krona/urbex/plan/grid/GridSettings.java
@@ -60,32 +60,4 @@ public record GridSettings(
         return new GridSettings(8, 8, 0.45f, 4, 0, 2, 0, 2, 4, 3, 0.40f, 2, 5);
     }
 
-    /**
-     * The settings a profile asks for. This one method is the whole of the {@code plan} package's
-     * contact with the rest of the mod: it imports a configuration class, not a Minecraft class, so
-     * the package stays game-free and its tests keep running headless. Keep it that way.
-     *
-     * <p>A straight read: the constructor above is the only validation, and it stays strict. A preset
-     * whose {@code secondaryRoadMinCountX} exceeds its {@code secondaryRoadMaxCountX} is a preset
-     * nobody can generate the world they wrote down from, and quietly widening the pair here would
-     * hand them a different world with no diagnostic. Callers that cannot afford the exception -
-     * the settings preview, which rebuilds one of these on every keystroke and can therefore see a
-     * half-finished edit - are the ones that handle it.
-     */
-    public static GridSettings fromPreset(dev.krona.urbex.config.Preset profile) {
-        return new GridSettings(
-                profile.PRIMARY_ROAD_SPACING_X,
-                profile.PRIMARY_ROAD_SPACING_Z,
-                profile.PRIMARY_ROAD_OPTIONAL_CHANCE,
-                profile.PRIMARY_ROAD_FORCE_EVERY,
-                profile.SECONDARY_ROAD_MIN_COUNT_X,
-                profile.SECONDARY_ROAD_MAX_COUNT_X,
-                profile.SECONDARY_ROAD_MIN_COUNT_Z,
-                profile.SECONDARY_ROAD_MAX_COUNT_Z,
-                profile.MINIMUM_ROAD_SEPARATION,
-                profile.MINIMUM_ROAD_EDGE_DISTANCE,
-                profile.TERTIARY_ROAD_CHANCE,
-                profile.TERTIARY_ROAD_MIN_LENGTH,
-                profile.TERTIARY_ROAD_MAX_LENGTH);
-    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
@@ -7,7 +7,7 @@ import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.Presets;
 import dev.krona.urbex.setup.Config;
 import dev.krona.urbex.plan.grid.GridRoadField;
-import dev.krona.urbex.plan.grid.GridSettings;
+import dev.krona.urbex.config.PresetRoadGrid;
 import dev.krona.urbex.setup.PresetChoice;
 import dev.krona.urbex.setup.WorldStyleMix;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
@@ -153,7 +153,7 @@ public record DimensionRuntime(ServerLevel level, @Nullable PlanningContext plan
                 preset,
                 assets,
                 WorldStyleField.resolve(assets, seed, worldStyles),
-                new GridRoadField(seed, dimension.identifier().toString(), GridSettings.fromPreset(preset)),
+                new GridRoadField(seed, dimension.identifier().toString(), PresetRoadGrid.of(preset)),
                 caches,
                 LevelShape.of(level),
                 new LevelTerrain(level, preset, caches));

--- a/src/test/java/dev/krona/urbex/config/PresetRoadGridTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetRoadGridTest.java
@@ -1,6 +1,6 @@
-package dev.krona.urbex.plan.grid;
+package dev.krona.urbex.config;
 
-import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.plan.grid.GridSettings;
 import net.minecraft.resources.Identifier;
 import org.junit.jupiter.api.Test;
 
@@ -9,12 +9,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * {@link GridSettings#fromPreset} is the only adapter between the profile and the strictly validated
- * settings record, and it deliberately does not soften anything on the way through: a profile whose
- * minimum exceeds its maximum describes a world nobody can generate, and widening the pair here would
- * hand its author a different world with no diagnostic at all.
+ * {@link PresetRoadGrid} is the only adapter between the preset and the strictly validated settings
+ * record, and it deliberately does not soften anything on the way through: a preset whose minimum
+ * exceeds its maximum describes a world nobody can generate, and widening the pair here would hand
+ * its author a different world with no diagnostic at all.
+ * <p>
+ * It sits on the configuration side of the boundary. It used to be a {@code GridSettings.fromPreset}
+ * factory inside {@code dev.krona.urbex.plan}, written with a fully-qualified parameter type so the
+ * package's own purity test would not see the reach (issue #129).
  */
-class GridSettingsTest {
+class PresetRoadGridTest {
 
     private static Preset profile() {
         return new Preset(Identifier.fromNamespaceAndPath("urbex", "test"));
@@ -22,7 +26,7 @@ class GridSettingsTest {
 
     @Test
     void aFreshProfileProducesUpstreamsDefaults() {
-        assertEquals(GridSettings.defaults(), GridSettings.fromPreset(profile()));
+        assertEquals(GridSettings.defaults(), PresetRoadGrid.of(profile()));
     }
 
     @Test
@@ -106,7 +110,7 @@ class GridSettingsTest {
      */
     private static void assertNamesTheField(Preset p, String configKey) {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> GridSettings.fromPreset(p));
+                () -> PresetRoadGrid.of(p));
         assertTrue(e.getMessage().contains(configKey),
                 "message must name the offending profile setting '" + configKey + "', was: " + e.getMessage());
     }

--- a/src/test/java/dev/krona/urbex/plan/PlanPurityTest.java
+++ b/src/test/java/dev/krona/urbex/plan/PlanPurityTest.java
@@ -16,30 +16,57 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Enforces the invariant {@link Hash}'s javadoc calls "the purity test": {@code dev.krona.urbex.plan}
- * and its sub-packages must never import Minecraft. The road field, its hashing and its settings
- * validation exist specifically to be pure functions of (seed, dimension id, coordinates, settings)
- * that a plain unit test can exercise with no game running (design spec
- * {@code 2026-08-10-urbex-hierarchical-streets-design.md} sections 1.1 and 3.1-3.2) - that is the
- * whole reason {@link RoadField} is a seam a future terrain-aware planner can implement without
- * touching the renderer. Nothing checked this before this test existed: no ArchUnit dependency, no
- * checkstyle rule, no import-scanning test of any kind, so a {@code net.minecraft.*} import could
- * land in a {@code plan} file and every other test would keep passing while the property this
- * package exists to guarantee quietly stopped holding.
+ * and its sub-packages may depend on {@code java.*} and on themselves, and on nothing else.
  *
- * <p>A straight import-line scan needs no special case for the module's one documented reach
- * towards Minecraft-adjacent code: {@link dev.krona.urbex.plan.grid.GridSettings#fromPreset} takes
- * a {@code dev.krona.urbex.config.Preset} parameter, but writes that type fully-qualified in
- * the method signature rather than importing it, specifically so a scan like this one has nothing to
- * exclude. There is deliberately no allowlist below - if that ever stops being true, this test is
- * supposed to fail, not learn to ignore the new import.
+ * <p>The road field, its hashing and its settings validation exist specifically to be pure functions
+ * of (seed, dimension id, coordinates, settings) that a plain unit test can exercise with no game
+ * running (design spec {@code 2026-08-10-urbex-hierarchical-streets-design.md} sections 1.1 and
+ * 3.1-3.2) - that is the whole reason {@link RoadField} is a seam a future terrain-aware planner can
+ * implement without touching the renderer. Nothing checked this before this test existed: no ArchUnit
+ * dependency, no checkstyle rule, no import-scanning test of any kind, so a {@code net.minecraft.*}
+ * import could land in a {@code plan} file and every other test would keep passing while the property
+ * this package exists to guarantee quietly stopped holding.
+ *
+ * <h2>Why it also reads the source text</h2>
+ *
+ * <p>An import scan alone was not enough, and the package's own code proved it: {@code GridSettings}
+ * carried a {@code fromPreset(dev.krona.urbex.config.Preset)} factory whose parameter type was
+ * written out fully-qualified <em>specifically so that a scan like this one had nothing to
+ * exclude</em>, with a comment saying as much. The reach was real - the planning module knew about
+ * the configuration module - and the check saw nothing. The conversion lives on the configuration
+ * side now, as {@code PresetRoadGrid} (issue #129), and the second test below closes the loophole
+ * rather than trusting the next author to remember the first one.
+ *
+ * <p>There is deliberately no allowlist. {@code javax.annotation.Nullable} is the one non-{@code java}
+ * name the package uses, and it is permitted below by an explicit, narrow exception with its reason
+ * written down - if anything else ever needs one, this test is supposed to fail and the exception is
+ * supposed to be argued, not widened.
  */
 class PlanPurityTest {
 
     private static final Path PLAN_ROOT = Path.of("src/main/java/dev/krona/urbex/plan");
     private static final Pattern IMPORT = Pattern.compile("(?m)^\\s*import\\s+(?:static\\s+)?([\\w.]+)\\s*;");
+    /**
+     * Any fully-qualified reference to a package of this mod outside {@code plan}, anywhere in the
+     * source text - which is how the one real violation was written. Matched with a leading
+     * non-word boundary so an import line (already covered above) and a javadoc {@code @link} both
+     * count: a {@code @link} to another module is a documentation reference, not a dependency, but
+     * there is currently none, and one appearing is worth a second look either way.
+     */
+    private static final Pattern FOREIGN_MOD_REFERENCE =
+            Pattern.compile("dev\\.krona\\.urbex\\.(?!plan\\b)\\w+");
+    /** Any reference to Minecraft at all, qualified or imported. */
+    private static final Pattern MINECRAFT_REFERENCE = Pattern.compile("net\\.minecraft\\b");
+
+    /**
+     * The one permitted non-{@code java} import: a nullability annotation. It has no runtime
+     * behaviour, resolves to nothing at execution time, and is not a dependency on the game or the
+     * configuration - which is what this package is being kept free of.
+     */
+    private static final String ALLOWED_ANNOTATION_PACKAGE = "javax.annotation.";
 
     @Test
-    void noFileUnderThePlanPackageImportsMinecraft() throws IOException {
+    void everyImportUnderThePlanPackageIsJavaOrPlanItself() throws IOException {
         List<Path> javaFiles = listJavaFiles();
         // A scan that silently finds nothing proves nothing - assert the walk actually reached the
         // package's files, so a moved or renamed root fails loudly here instead of leaving this test
@@ -49,19 +76,44 @@ class PlanPurityTest {
 
         List<String> offenders = new ArrayList<>();
         for (Path file : javaFiles) {
-            String source = Files.readString(file);
-            Matcher matcher = IMPORT.matcher(source);
+            Matcher matcher = IMPORT.matcher(Files.readString(file));
             while (matcher.find()) {
                 String imported = matcher.group(1);
-                if (imported.startsWith("net.minecraft.") || imported.equals("net.minecraft")) {
-                    offenders.add(file + " imports " + imported);
+                if (imported.startsWith("java.") || imported.startsWith("dev.krona.urbex.plan.")
+                        || imported.startsWith(ALLOWED_ANNOTATION_PACKAGE)) {
+                    continue;
                 }
+                offenders.add(file + " imports " + imported);
             }
         }
         assertTrue(offenders.isEmpty(),
                 "dev.krona.urbex.plan is the dependency-free planning module every other worldgen "
-                        + "piece depends on, never the reverse - it must import nothing from "
-                        + "net.minecraft. Offending imports:\n" + String.join("\n", offenders));
+                        + "piece depends on, never the reverse - it may import java.* and itself, and "
+                        + "nothing else. Offending imports:\n" + String.join("\n", offenders));
+    }
+
+    @Test
+    void noFileUnderThePlanPackageNamesMinecraftOrAnotherModulePackageInItsText() throws IOException {
+        List<Path> javaFiles = listJavaFiles();
+        assertFalse(javaFiles.isEmpty(), "expected to find at least one .java file under " + PLAN_ROOT);
+
+        List<String> offenders = new ArrayList<>();
+        for (Path file : javaFiles) {
+            String source = Files.readString(file);
+            collect(offenders, file, source, MINECRAFT_REFERENCE);
+            collect(offenders, file, source, FOREIGN_MOD_REFERENCE);
+        }
+        assertTrue(offenders.isEmpty(),
+                "a fully-qualified name reaches just as far as an import does, and writing one is how "
+                        + "the previous version of this rule was worked around. Offending references:\n"
+                        + String.join("\n", offenders));
+    }
+
+    private static void collect(List<String> offenders, Path file, String source, Pattern pattern) {
+        Matcher matcher = pattern.matcher(source);
+        while (matcher.find()) {
+            offenders.add(file + " names " + matcher.group() + " at offset " + matcher.start());
+        }
     }
 
     private static List<Path> listJavaFiles() throws IOException {


### PR DESCRIPTION
GridSettings carried a fromPreset(dev.krona.urbex.config.Preset) factory whose
parameter type was written out fully-qualified - with a comment saying it was
written that way specifically so the package's own purity test would have
nothing to exclude. The reach was real: the dependency-free planning module
knew about the configuration module, and the check that existed to catch that
saw nothing.

The conversion moves to the side that already knows both, as
config.PresetRoadGrid.of(preset). Nothing about it changes; it still refuses a
preset whose minimum exceeds its maximum rather than widening the pair, and the
settings preview is still the caller that handles the exception.

PlanPurityTest gets two teeth. It now asserts what dev.krona.urbex.plan may
import - java.* and itself, plus javax.annotation.Nullable by an explicit
narrow exception with its reason written down - rather than only what it may
not. And it reads the source text for any fully-qualified net.minecraft or
dev.krona.urbex.<not plan> name, because that is how the rule was worked around
the first time.

GridSettingsTest moves with the code it tests, as config/PresetRoadGridTest.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Closes the last of #129's acceptance criteria.

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>