### PR TITLE
feat: exactly one Urbex generation per chunk (#131, 131a)

### DIFF
--- a/docs/datapacks.md
+++ b/docs/datapacks.md
@@ -104,6 +104,23 @@ The practical consequence: a pack that is not the heaviest in a mix will not see
 railway parts used. Nothing about that is worth designing around — author the world style as if it
 were the only one, and it will be, for every city it owns.
 
+### Do not place the `urbex:city` feature
+
+Urbex generates each chunk once, at the end of the carver stage, without any feature placement. You
+do not need to place anything, and you should not: **placing `urbex:city` in a biome's `features` is
+refused**, with one warning per dimension in the log. It used to generate the chunk a second time,
+planning against terrain the first pass had already rewritten.
+
+The feature exists for one case: a **custom chunk generator** that is neither
+`minecraft:noise` nor `minecraft:flat` (nor a mod generator extending one of those classes). Urbex
+has no hook into such a generator, so a world using one gets no cities at all unless the pack places
+`urbex:city` itself. That is what the feature is for, and it is the supported way in.
+
+Placing it costs one guarantee. Features run at the decoration stage, where a neighbouring chunk's
+own feature pass may or may not have run yet, so what Urbex reads from the terrain depends on how the
+server scheduled its worker threads — the same world can generate differently twice. The carver-stage
+path has no such problem. If your world runs on a vanilla generator, leave the feature alone.
+
 ## `extends`
 
 `extends` takes **one fully-qualified id, in the same registry as the file declaring it**:

--- a/docs/superpowers/specs/2026-08-13-generation-dispatch-design.md
+++ b/docs/superpowers/specs/2026-08-13-generation-dispatch-design.md
@@ -1,0 +1,118 @@
+# One generation dispatch, and one failure contract (#131)
+
+Phase 3, item 12 of epic #134. Two separate questions that the issue keeps together because they
+share a call site: *how many times can Urbex generate one chunk*, and *what happens when doing so
+fails*.
+
+## Part 1 — dispatch
+
+### What exists
+
+Two entry points reach `CityFeature.generateFromPipeline`, and nothing coordinates them:
+
+- **The carver tail.** `CarverHookMixin` injects at `TAIL` of `applyCarvers` on
+  `NoiseBasedChunkGenerator` and `FlatLevelSource`. This is the real path, and the reason it exists
+  is #18: at the decoration stage a neighbouring chunk's feature pass may or may not have bled into
+  this one, so anything Urbex read from the terrain depended on worker scheduling. At the carver tail
+  the terrain is a pure function of the seed.
+- **`CityFeature.place`.** The `urbex:city` feature is registered so a datapack *can* name it. The mod
+  does not inject it anywhere and the bundled pack does not use it.
+
+So today:
+
+- a datapack that puts `urbex:city` in a biome's `features` generates the chunk **twice** — once at
+  the carver tail and once at decoration, the second pass planning against terrain the first pass
+  already rewrote;
+- a chunk generator that is neither `NoiseBasedChunkGenerator` nor `FlatLevelSource` gets **no**
+  Urbex generation at all, however its dimension is configured, and says nothing about it.
+
+### Decision
+
+Take the issue's second option — **an explicit per-chunk marker** — rather than deprecating the
+feature path, and keep the feature path as the deliberate custom-generator integration point.
+
+A `ChunkAccess` mixin carries one `@Unique boolean`, reached through a `GeneratedChunkMark`
+interface. `generateFromPipeline` marks the chunk before it generates and refuses a chunk already
+marked. The mark dies with the chunk object, so there is no map to grow and nothing to clean up.
+
+This is chosen over the two alternatives on offer:
+
+- *Deprecate the feature path.* It is the only way a custom generator can ever be supported, and
+  removing it converts "double generation" into "no generation, silently" for those worlds.
+- *Ask whether the carver hook applies* (`generator instanceof NoiseBasedChunkGenerator ||
+  instanceof FlatLevelSource`). Stateless and tempting, but wrong for a generator that extends
+  `NoiseBasedChunkGenerator` and overrides `applyCarvers` without calling `super`: the predicate says
+  the hook ran, the hook did not, and the chunk gets nothing. A marker records what actually
+  happened rather than what should have.
+
+Custom-generator support becomes explicit in both directions:
+
+- a generator the carver mixin applies to needs nothing — it is generated at the carver tail, and an
+  explicitly placed `urbex:city` feature is refused with one log line per level;
+- any other generator gets no carver hook, so placing `urbex:city` in its biomes is how a pack opts
+  in, and the marker guarantees that this is once per chunk.
+
+The cost is stated rather than hidden: a chunk generated through the feature path is generated at the
+decoration stage, which is exactly the ordering #18 moved away from. That is a documented property of
+opting in, not a regression of the supported path.
+
+## Part 2 — failure contract
+
+### What exists
+
+```java
+try {
+    feature.generate(runtime, region, chunk);
+} catch (Exception e) {
+    Urbex.getLogger().error(...);
+    ErrorLogger.logChunkInfo(...);
+    ErrorLogger.report(...);
+}
+return true;                       // <- success, whatever happened
+```
+
+Every failure is one category: log it and report success. The chunk continues through the pipeline
+and is saved.
+
+Whether that is even survivable depends on *where* the failure landed, and the driver has a real
+commit point that makes the three cases distinguishable:
+
+| When | State of the chunk | What is currently saved |
+| --- | --- | --- |
+| Before `ChunkDriver.actuallyGenerate` | Nothing written — the driver buffers into its own section cache | Pure vanilla terrain, in the middle of a city |
+| During `actuallyGenerate` (`flushToChunk`) | Partially written | Half a city |
+| After it (`ChunkFixer.fix`, post-todos, block-entity cleanup) | City written, post-processing incomplete | A city missing its deferred writes |
+
+### Direction
+
+Three categories, as the issue sets out:
+
+- **Configuration/asset validation failure** — already handled: `AssetCompiler` diagnostics refuse
+  the world at load, and `DimensionRuntime.create` refuses a level whose city style cannot resolve.
+  Nothing to do beyond stating that this is where such failures belong.
+- **Retryable generation failure** — the exception propagates out of `generateFromPipeline`. On the
+  carver path that fails the chunk task rather than saving a chunk that is quietly wrong; on the
+  feature path `place` returns `false`.
+- **Non-fatal diagnostic** — reported without changing the result. This is what `ErrorLogger.report`
+  is for, and it stays.
+
+Error reporting must be runtime-scoped and safe during shutdown. `ErrorLogger.report` already guards
+the shutdown window (a worker finishing after `SERVER_STOPPED` used to NPE inside the error handler
+and lose the message it was reporting); what it is not yet is scoped — it reads a static server
+reference. That is the same `ServerAccess` coupling the milestone's completion criteria name.
+
+### Verification
+
+Fault injection at the three points above, asserting that the original failure survives and that no
+partially-written chunk is reported as a success. This is a unit-testable property of
+`generateFromPipeline` once the marker exists, since the marker is what tells a second attempt that
+the first one happened.
+
+## Order of work
+
+1. **The marker.** `GeneratedChunkMark` + `ChunkAccess` mixin; `generateFromPipeline` refuses a
+   second invocation; `place` documented as the custom-generator integration point. *(p3i.)*
+2. **The failure contract.** Exceptions stop becoming success; the three categories are named in
+   code; fault-injection coverage. *(p3j.)*
+
+Both must leave the digest goldens alone: no supported path changes what a chunk contains.

--- a/src/main/java/dev/krona/urbex/mixin/GeneratedChunkMarkMixin.java
+++ b/src/main/java/dev/krona/urbex/mixin/GeneratedChunkMarkMixin.java
@@ -1,0 +1,35 @@
+package dev.krona.urbex.mixin;
+
+import dev.krona.urbex.worldgen.GeneratedChunkMark;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+/**
+ * Gives every chunk one boolean: has Urbex generated here yet.
+ *
+ * <p>See {@link GeneratedChunkMark} for why the mark belongs on the chunk rather than in a map. The
+ * field is deliberately not serialised - it answers a question about one generation pass, and a chunk
+ * read back from disk has finished generating.</p>
+ *
+ * <p>{@code synchronized} so that claiming is one operation rather than a check and an act. It costs
+ * nothing worth measuring: the body is a read and a write of one field, it calls nothing, and it
+ * cannot be contended in practice, because the two callers are ordered by the chunk pipeline
+ * ({@code CARVERS} strictly before {@code FEATURES} for a given chunk). It also cannot deadlock,
+ * whoever else uses the chunk's monitor, because it acquires nothing else while holding it.</p>
+ */
+@Mixin(ChunkAccess.class)
+public class GeneratedChunkMarkMixin implements GeneratedChunkMark {
+
+    @Unique
+    private boolean urbex$generated;
+
+    @Override
+    public synchronized boolean urbex$claimGeneration() {
+        if (urbex$generated) {
+            return false;
+        }
+        urbex$generated = true;
+        return true;
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
@@ -23,6 +23,17 @@ import java.util.concurrent.ConcurrentHashMap;
  * It used to own the process-global dimension map and the dirty-counter protocol that maintained
  * it; both belong to {@link GenerationSession} now, which publishes a {@link DimensionRuntime} per
  * loaded level and retires it on unload (issue #125). What is left here is the dispatch.
+ *
+ * <h2>Exactly one invocation per chunk</h2>
+ *
+ * <p>Two routes reach {@link #generateFromPipeline}, and until issue #131 nothing coordinated them:
+ * the carver-tail hook, which is how every supported world generates, and {@link #place}, which a
+ * datapack can name in a biome's {@code features}. A pack that did both generated the chunk twice,
+ * the second pass planning against terrain the first pass had already rewritten.</p>
+ *
+ * <p>The chunk itself now records that Urbex has been here - see {@link GeneratedChunkMark} - and the
+ * second caller is refused. Which of the two arrives first is not this class's business: whichever
+ * does, generates.</p>
  */
 public class CityFeature extends Feature<NoneFeatureConfiguration> {
 
@@ -31,14 +42,24 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
     }
 
     /**
-     * The feature entry point is retained so an explicitly-configured datapack feature still
-     * works, but the mod no longer injects it: city generation runs from the end of the carver
-     * stage instead (see {@code CarverHookMixin}). At the decoration stage, a neighbouring
-     * chunk's complete feature pass - ore blobs, border-crossing trees - may or may not have
-     * bled into this chunk yet, so everything Urbex read from the terrain depended on worker
-     * scheduling (issue #18). The pipeline guarantees that no neighbour's features can run
-     * until this chunk finishes CARVERS, so at the carver tail Urbex always sees pure
-     * noise+surface+carver terrain, and every vanilla feature lands strictly after the city.
+     * The custom-generator integration point: place {@code urbex:city} in a biome's features to
+     * generate cities under a chunk generator the carver hook does not reach.
+     *
+     * <p>The mod injects this nowhere and the bundled pack does not use it. A world on
+     * {@code NoiseBasedChunkGenerator} or {@code FlatLevelSource} - which is every vanilla world -
+     * is generated at the carver tail instead (see {@code CarverHookMixin}), and placing the feature
+     * there as well is refused rather than generating twice. Any other generator gets no carver hook
+     * at all, so this is how such a world opts in, and it works because the marker makes the two
+     * routes mutually exclusive rather than because a pack author avoided one of them.</p>
+     *
+     * <p><strong>Opting in this way costs the ordering guarantee #18 established.</strong> A feature
+     * runs at the decoration stage, where a neighbouring chunk's complete feature pass - ore blobs,
+     * border-crossing trees - may or may not have bled into this chunk yet, so what Urbex reads from
+     * the terrain depends on worker scheduling. The carver tail has no such problem: the pipeline
+     * guarantees no neighbour's features can run until this chunk finishes {@code CARVERS}, so Urbex
+     * always sees pure noise+surface+carver terrain and every vanilla feature lands strictly after
+     * the city. That is a property of the supported path, and a pack taking this one is choosing to
+     * do without it.</p>
      */
     @Override
     public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> context) {
@@ -61,12 +82,21 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
      * answer {@code null} (before registration, or in a test) for something the mixin then skips
      * silently.
      * <p>
+     * Claims the chunk first, so a second route to the same chunk is refused rather than generating
+     * over what the first one wrote. Claimed before any other check, including "does Urbex generate
+     * in this dimension at all": the marker records that this chunk has been dispatched, and the
+     * answer to a question asked twice about one chunk must not depend on which caller asked.
+     * <p>
      * The runtime is read once, at the top, and everything below uses that one reference. A
      * {@code /reload} or an unload landing mid-chunk republishes the level's runtime for the
      * <em>next</em> chunk and leaves this one generating against the epoch it captured - which is
      * the whole point of the ownership move, and the opposite of what the dirty counter did.
      */
     public static boolean generateFromPipeline(WorldGenRegion region, ChunkAccess chunk) {
+        if (!GeneratedChunkMark.claim(chunk)) {
+            reportDoubleDispatch(region.getLevel(), chunk.getPos());
+            return false;
+        }
         DimensionRuntime runtime = GenerationSession.runtimeFor(region);
         if (runtime == null) {
             reportMissingRuntime(region.getLevel(), chunk.getPos());
@@ -131,5 +161,29 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
                 pos.x(), pos.z(), level.dimension().identifier());
     }
 
+    /**
+     * Reported once per dimension per JVM, like the missing-runtime case above, and for the same
+     * reason: a pack that reaches here is generating differently from every other install of itself,
+     * and nothing else in the mod would say so.
+     * <p>
+     * The refusal itself is not a failure - it is the contract working - so this is a warning rather
+     * than an error, and the pack keeps its cities. What it costs the pack is the ordering guarantee
+     * described on {@link #place}, for the chunks the feature would have been the first to claim.
+     */
+    private static void reportDoubleDispatch(ServerLevel level, ChunkPos pos) {
+        if (!REPORTED_DOUBLE_DISPATCH.add(level.dimension())) {
+            return;
+        }
+        Urbex.getLogger().warn(
+                "Urbex was asked to generate chunk {},{} in '{}' twice. The chunk was generated once, "
+                        + "by whichever route arrived first, and the second request was refused - "
+                        + "generating again would plan against terrain the first pass had already "
+                        + "rewritten. A datapack has placed the 'urbex:city' feature in a world whose "
+                        + "generator Urbex already hooks; remove it, since it is only needed for a "
+                        + "custom chunk generator. Reported once per dimension.",
+                pos.x(), pos.z(), level.dimension().identifier());
+    }
+
     private static final Set<ResourceKey<Level>> REPORTED_MISSING_RUNTIME = ConcurrentHashMap.newKeySet();
+    private static final Set<ResourceKey<Level>> REPORTED_DOUBLE_DISPATCH = ConcurrentHashMap.newKeySet();
 }

--- a/src/main/java/dev/krona/urbex/worldgen/GeneratedChunkMark.java
+++ b/src/main/java/dev/krona/urbex/worldgen/GeneratedChunkMark.java
@@ -1,0 +1,63 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.world.level.chunk.ChunkAccess;
+
+/**
+ * Whether Urbex has already generated a chunk, carried by the chunk itself.
+ *
+ * <p>Two entry points can reach city generation: the carver-tail hook, which is how every supported
+ * world generates, and the registered {@code urbex:city} feature, which a datapack can place
+ * explicitly. Nothing coordinated them, so a pack that named the feature in a biome's {@code features}
+ * generated the chunk twice - the second pass planning against terrain the first pass had already
+ * rewritten (issue #131).</p>
+ *
+ * <p>The mark lives on the {@link ChunkAccess} through a mixin-added field rather than in a set
+ * somewhere, because that gives it exactly the right lifetime for free: it is created with the chunk
+ * and collected with it. A {@code Set<ChunkPos>} would need a policy for when to forget a chunk, and
+ * getting that wrong in either direction is either a leak or a chunk generated twice after all.</p>
+ *
+ * <p>One method rather than a getter and a setter, so that claiming is not a check followed by an
+ * act. The two callers cannot in fact race - the chunk pipeline orders {@code CARVERS} strictly
+ * before {@code FEATURES} for a given chunk - but "this is safe if you know how the pipeline
+ * schedules" is a worse thing to write down than an operation that is safe either way.</p>
+ */
+public interface GeneratedChunkMark {
+
+    /**
+     * Claims this chunk for generation, if nobody has.
+     *
+     * <p>Claiming happens <em>before</em> generating rather than after: a generation that fails
+     * partway has still written whatever it wrote, and a second attempt through the other entry point
+     * would write over it rather than repair it.</p>
+     *
+     * @return {@code true} for the first caller only
+     */
+    boolean urbex$claimGeneration();
+
+    /**
+     * Claims {@code chunk}, or answers {@code true} if it cannot carry a mark.
+     *
+     * @return {@code true} if this caller is the one that may generate the chunk
+     */
+    static boolean claim(ChunkAccess chunk) {
+        return claimMark(chunk);
+    }
+
+    /**
+     * @see #claim(ChunkAccess)
+     *
+     * <p>Takes an {@link Object} only so the rule can be exercised without one: {@code ChunkAccess}
+     * is an abstract class that can be neither constructed nor proxied in a unit test, and a rule
+     * deciding which of two callers may write a chunk is worth testing directly rather than only
+     * through a dedicated-server run.</p>
+     */
+    static boolean claimMark(Object chunk) {
+        if (!(chunk instanceof GeneratedChunkMark mark)) {
+            // Every ChunkAccess is mixed into, so this is unreachable in a running game. Refusing to
+            // generate for something that cannot carry the mark would be the worse failure of the
+            // two: it looks exactly like "this dimension has no preset".
+            return true;
+        }
+        return mark.urbex$claimGeneration();
+    }
+}

--- a/src/main/resources/urbex.mixins.json
+++ b/src/main/resources/urbex.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_25",
   "mixins": [
     "CarverHookMixin",
+    "GeneratedChunkMarkMixin",
     "MinecraftServerMixin",
     "StructureStartMixin",
     "UnsafeReadGateMixin"

--- a/src/test/java/dev/krona/urbex/worldgen/GeneratedChunkMarkTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/GeneratedChunkMarkTest.java
@@ -1,0 +1,110 @@
+package dev.krona.urbex.worldgen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One chunk, one generation, whichever route asks.
+ * <p>
+ * Two entry points reach city generation - the carver-tail hook and the registered
+ * {@code urbex:city} feature - and until issue #131 nothing coordinated them: a datapack that named
+ * the feature in a biome's {@code features} generated the chunk twice, the second pass planning
+ * against terrain the first pass had already rewritten. The claim below is what makes them mutually
+ * exclusive.
+ * <p>
+ * Driven through {@link GeneratedChunkMark#claimMark} rather than the {@code ChunkAccess} overload:
+ * {@code ChunkAccess} is an abstract class, so it can be neither constructed nor proxied here, and
+ * the rule under test is about the mark rather than about chunks.
+ */
+class GeneratedChunkMarkTest {
+
+    @Test
+    void theFirstCallerClaimsTheChunkAndTheSecondIsRefused() {
+        Object chunk = new Marked();
+
+        assertTrue(GeneratedChunkMark.claimMark(chunk), "the first route to arrive generates");
+        assertFalse(GeneratedChunkMark.claimMark(chunk), "the second does not");
+        assertFalse(GeneratedChunkMark.claimMark(chunk), "and neither does a third");
+    }
+
+    @Test
+    void chunksAreClaimedIndependently() {
+        Object one = new Marked();
+        Object other = new Marked();
+
+        assertTrue(GeneratedChunkMark.claimMark(one));
+        assertTrue(GeneratedChunkMark.claimMark(other),
+                "a claim on one chunk says nothing about another");
+    }
+
+    /**
+     * Something that cannot carry the mark - which is nothing in a running game, since the mixin
+     * applies to {@code ChunkAccess} itself. Refusing to generate for it would look exactly like
+     * "this dimension has no preset", which is the harder of the two failures to diagnose.
+     */
+    @Test
+    void anUnmarkableChunkIsAlwaysAllowedToGenerate() {
+        assertTrue(GeneratedChunkMark.claimMark(new Object()));
+        assertTrue(GeneratedChunkMark.claimMark(null));
+    }
+
+    /**
+     * The two callers cannot in fact race - the chunk pipeline orders {@code CARVERS} strictly
+     * before {@code FEATURES} for a given chunk - but the claim is written so that it would not
+     * matter if they did, and a property nobody exercises is a property nobody knows they have
+     * broken. Hence one operation rather than a check followed by an act.
+     */
+    @Test
+    void concurrentClaimsElectExactlyOneWinner() throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            for (int attempt = 0; attempt < 500; attempt++) {
+                Object chunk = new Marked();
+                AtomicInteger winners = new AtomicInteger();
+                CyclicBarrier start = new CyclicBarrier(2);
+                Future<?> a = pool.submit(() -> race(chunk, start, winners));
+                Future<?> b = pool.submit(() -> race(chunk, start, winners));
+                a.get();
+                b.get();
+                assertEquals(1, winners.get(),
+                        "exactly one of two racing callers may generate a chunk (attempt " + attempt + ")");
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private static void race(Object chunk, CyclicBarrier start, AtomicInteger winners) {
+        try {
+            start.await();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+        if (GeneratedChunkMark.claimMark(chunk)) {
+            winners.incrementAndGet();
+        }
+    }
+
+    /** Stands in for what the mixin adds to every {@code ChunkAccess}, with the same locking. */
+    private static final class Marked implements GeneratedChunkMark {
+        private boolean generated;
+
+        @Override
+        public synchronized boolean urbex$claimGeneration() {
+            if (generated) {
+                return false;
+            }
+            generated = true;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Two routes reach city generation and nothing coordinated them. The carver-tail
hook is how every supported world generates; CityFeature.place is registered so
a datapack can name urbex:city in a biome's features. A pack that did both
generated the chunk twice - the second pass planning against terrain the first
pass had already rewritten.

The chunk now carries the answer. A ChunkAccess mixin adds one boolean reached
through GeneratedChunkMark, and generateFromPipeline claims the chunk before it
does anything else; the second caller is refused with one warning per dimension.
The mark lives on the chunk rather than in a Set<ChunkPos> because that gives it
the right lifetime for free - a set would need a policy for when to forget a
chunk, and getting that wrong is either a leak or a chunk generated twice after
all.

Claiming is one operation rather than a check and an act. The two callers cannot
in fact race, since the pipeline orders CARVERS strictly before FEATURES for a
given chunk, but "safe if you know how the pipeline schedules" is a worse thing
to write down than an operation that is safe either way.

The feature path is kept, and is now explicitly the custom-generator integration
point: a generator that is neither NoiseBasedChunkGenerator nor FlatLevelSource
gets no carver hook, so placing urbex:city is how such a world opts in - and it
works because the marker makes the routes exclusive, not because a pack author
avoided one. Deprecating it instead would have converted "generates twice" into
"generates never, silently" for those worlds.

What opting in costs is stated rather than hidden, in the javadoc and in
docs/datapacks.md: a feature runs at the decoration stage, which is exactly the
ordering #18 moved away from, so the same world can generate differently twice.

Design: docs/superpowers/specs/2026-08-13-generation-dispatch-design.md.

Digest goldens all unchanged, and so are the driven-chunk counts (114, 497, 580,
579, 579) - the claim suppresses no real generation:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>