### PR TITLE
fix: a chunk that fails to generate stops being reported as success (#131, 131b)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -218,11 +218,37 @@ public class ChunkDriver {
      * recorder keeps accumulating across it, so nothing lands on the late-write path any more
      * (issue #48).
      */
+    /**
+     * Where this driver is relative to writing its buffered blocks into the world.
+     *
+     * <p>Everything before {@link #flushToChunk} is buffered in this driver's own section cache, so
+     * a generation that fails before it has touched nothing. What a failure costs depends on which
+     * side of that line it lands on, and a report that cannot say which side is a report nobody can
+     * act on (issue #131).</p>
+     */
+    public enum CommitState {
+        /** Nothing has been written to the world. The chunk is still pure vanilla terrain. */
+        BUFFERED,
+        /** Partway through writing. Some of this chunk's city is in the world and some is not. */
+        COMMITTING,
+        /** Every buffered block is in the world. Anything after this is post-processing. */
+        COMMITTED
+    }
+
+    private CommitState commitState = CommitState.BUFFERED;
+
+    /** @see CommitState */
+    public CommitState commitState() {
+        return commitState;
+    }
+
     public void flushToChunk(ChunkAccess chunk) {
+        commitState = CommitState.COMMITTING;
         BulkSectionAccess bulk = new BulkSectionAccess(region);
         cache.generate(bulk);
         bulk.close();
         cache.clear();
+        commitState = CommitState.COMMITTED;
     }
 
     public void actuallyGenerate(ChunkAccess chunk) {

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkGenerationFailure.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkGenerationFailure.java
@@ -1,0 +1,68 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.varia.ChunkCoord;
+
+/**
+ * One chunk failed to generate, and did not generate a different way instead.
+ *
+ * <p>This is the middle of the three failure categories issue #131 sets out, and the only one that
+ * needs a type:</p>
+ *
+ * <ul>
+ *   <li><b>Configuration or asset validation.</b> Refused where the runtime is built - a pack that
+ *       does not compile refuses the world at load, naming every problem at once, and a level whose
+ *       city style cannot resolve refuses the level. Nothing gets as far as a chunk.</li>
+ *   <li><b>Generation failure</b> - this. The chunk is not generated, so it must not be saved as
+ *       though it were; the exception leaves {@code CityFeature.generateFromPipeline} and fails the
+ *       chunk task.</li>
+ *   <li><b>Non-fatal diagnostic.</b> Reported through {@link ErrorLogger} without changing the
+ *       result.</li>
+ * </ul>
+ *
+ * <p>What this replaces is a {@code catch (Exception)} around the whole of generation that logged and
+ * then <em>returned success</em>. A chunk that threw halfway through writing a building continued
+ * through the pipeline and was saved - vanilla terrain with half a city in it, next to neighbours
+ * that got theirs, and nothing in the world to say which chunks were affected. The log line was
+ * there; the chunk was ruined anyway, permanently, and only a log nobody reads distinguished it from
+ * a chunk that generated correctly.</p>
+ *
+ * <p>The commit state is carried because it is the difference between "nothing was written" and
+ * "half a city was written", and a report that cannot say which is a report nobody can act on. It
+ * does not change what happens - a failed chunk fails either way - it changes what the person
+ * reading the log has to go and check.</p>
+ */
+public class ChunkGenerationFailure extends RuntimeException {
+
+    private final ChunkCoord coord;
+    private final ChunkDriver.CommitState commitState;
+
+    public ChunkGenerationFailure(ChunkCoord coord, ChunkDriver.CommitState commitState, Throwable cause) {
+        super(describe(coord, commitState), cause);
+        this.coord = coord;
+        this.commitState = commitState;
+    }
+
+    /** Which chunk failed. */
+    public ChunkCoord coord() {
+        return coord;
+    }
+
+    /** How much of that chunk had reached the world when it failed. */
+    public ChunkDriver.CommitState commitState() {
+        return commitState;
+    }
+
+    private static String describe(ChunkCoord coord, ChunkDriver.CommitState commitState) {
+        String state = switch (commitState) {
+            case BUFFERED -> "nothing was written to the world - the chunk is untouched vanilla "
+                    + "terrain, and will be regenerated from scratch if it is requested again";
+            case COMMITTING -> "the chunk was partway through being written, so part of its city is "
+                    + "in the world and part is not";
+            case COMMITTED -> "the chunk's blocks were written and it failed during post-processing, "
+                    + "so its city is present but its deferred writes may not be";
+        };
+        return "Urbex failed to generate chunk " + coord.chunkX() + "," + coord.chunkZ() + " in '"
+                + coord.dimension().identifier() + "': " + state + ". The chunk task fails rather "
+                + "than saving a chunk that is quietly wrong.";
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityFeature.java
@@ -106,29 +106,26 @@ public class CityFeature extends Feature<NoneFeatureConfiguration> {
             // Urbex does not generate in this dimension. A published decision, not a missing one.
             return false;
         }
-        PlanningContext diminfo = runtime.planning();
         ChunkPos center = chunk.getPos();
         Holder<Biome> biome = region.getBiome(center.getMiddleBlockPosition(60));
         if (biome.is(UrbexTags.IS_VOID)) {
             return false;
         }
 
-        int chunkX = center.x();
-        int chunkZ = center.z();
         // No lock. The terrain feature holds no per-chunk state any more (that is on the
         // ChunkGenContext built inside generate()), the caches it reaches are concurrent,
         // and the region arrives as an argument instead of being written onto the shared
         // PlanningContext. So Urbex generation runs on the worker pool in parallel with the
         // rest of worldgen again, as it did before the driver became shared.
-        CityGenerator feature = runtime.generator();
-        try {
-            feature.generate(runtime, region, chunk);
-        } catch (Exception e) {
-            Urbex.getLogger().error("Error generating chunk {},{} (preset={}, dimension={})",
-                    chunkX, chunkZ, diminfo.preset().getId(), diminfo.dimension().identifier(), e);
-            ErrorLogger.logChunkInfo(chunkX, chunkZ, diminfo);
-            ErrorLogger.report("There was an error generating a chunk. See log for details!");
-        }
+        //
+        // No catch either, which is the point. This used to wrap generate() in catch (Exception),
+        // log, and return true - so a chunk that threw halfway through writing a building continued
+        // through the pipeline and was saved: vanilla terrain with half a city in it, next to
+        // neighbours that got theirs, distinguished from a correct chunk only by a log line nobody
+        // reads. A ChunkGenerationFailure leaves here and fails the chunk task instead, having
+        // already reported itself (issue #131). Returning true is therefore a statement about what
+        // happened rather than about what was attempted.
+        runtime.generator().generate(runtime, region, chunk);
         return true;
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -217,12 +217,43 @@ public class CityGenerator {
      *                redirect this generation's work to a different epoch (issue #125).
      */
     public void generate(DimensionRuntime runtime, WorldGenRegion region, ChunkAccess chunk) {
+        ChunkCoord coord = new ChunkCoord(provider.dimension(), chunk.getPos().x(), chunk.getPos().z());
+        try {
+            generateOrThrow(runtime, region, chunk, coord);
+        } catch (Throwable t) {
+            // One category, one outcome: the chunk is not generated, so it must not continue through
+            // the pipeline and be saved as though it were (issue #131). What used to happen here was
+            // a log line and a return of success.
+            //
+            // generateOrThrow attaches the commit state, because only it can see the driver. Anything
+            // that arrives here unattached failed before the driver existed, which is the same thing
+            // as having written nothing.
+            ChunkGenerationFailure failure = t instanceof ChunkGenerationFailure attached
+                    ? attached
+                    : new ChunkGenerationFailure(coord, ChunkDriver.CommitState.BUFFERED, t);
+            Urbex.getLogger().error(failure.getMessage(), failure.getCause());
+            ErrorLogger.logChunkInfo(coord.chunkX(), coord.chunkZ(), provider);
+            // A non-fatal diagnostic in its own right: the chunk fails whether or not anyone is
+            // listening, and this only tells whoever is playing to go and read the log.
+            ErrorLogger.report(runtime.level().getServer(),
+                    "There was an error generating a chunk. See log for details!");
+            throw failure;
+        }
+    }
+
+    /**
+     * The generation itself, with the commit state attached to whatever it throws.
+     * <p>
+     * Only this method can see the driver, and the driver is the only thing that knows whether a
+     * failure landed before, during or after the buffered blocks were written to the world - see
+     * {@link ChunkDriver.CommitState}.
+     */
+    private void generateOrThrow(DimensionRuntime runtime, WorldGenRegion region,
+                                 ChunkAccess chunk, ChunkCoord coord) {
         long start = System.currentTimeMillis();
 
-        int chunkX = chunk.getPos().x();
-        int chunkZ = chunk.getPos().z();
-
-        ChunkCoord coord = new ChunkCoord(provider.dimension(), chunkX, chunkZ);
+        int chunkX = coord.chunkX();
+        int chunkZ = coord.chunkZ();
 
         // A copy, because correctTerrainShape() below writes the corrected surface back into it.
         // The instance in caches().heightmap is shared with every other thread generating a chunk
@@ -237,6 +268,7 @@ public class CityGenerator {
         // so a /reload landing mid-chunk cannot be observed halfway through a building (issue #128).
         ChunkGenContext ctx = new ChunkGenContext(region, chunk, coord, provider, profile, info,
                 runtime.tasks(), runtime.tags());
+        try {
 
         boolean doCity = info.isCity;
 
@@ -302,6 +334,9 @@ public class CityGenerator {
 
         long time = System.currentTimeMillis() - start;
         statistics.addTime(time);
+        } catch (Throwable t) {
+            throw new ChunkGenerationFailure(coord, ctx.driver.commitState(), t);
+        }
     }
 
     public Statistics getStatistics() {

--- a/src/main/java/dev/krona/urbex/worldgen/ErrorLogger.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ErrorLogger.java
@@ -8,13 +8,9 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Player;
-import dev.krona.urbex.varia.ServerAccess;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import javax.annotation.Nullable;
 
 public class ErrorLogger {
 
@@ -23,22 +19,26 @@ public class ErrorLogger {
     /**
      * Tells whoever is playing that a chunk went wrong, at most once every ten seconds.
      * <p>
+     * The server arrives as an argument, from the level whose runtime this generation belongs to,
+     * rather than being read from a process-global slot. That slot was the last thing on any
+     * worldgen or error-reporting path reaching {@code ServerAccess}, and reading it here meant a
+     * chunk failing during a different server's lifetime reported to that server (issue #131).
+     * <p>
      * The null guard is not defensive tidiness. This is called from the handler around chunk
      * generation, and the window it most wants to survive is shutdown - a worker finishing a chunk
-     * after {@code SERVER_STOPPED} has cleared the static server reference. Without it the error
-     * <em>handler</em> threw a {@link NullPointerException} of its own, turning a reported chunk
-     * failure into a dead worldgen worker and losing the message that was being reported (issue
-     * #56). The log line below is not a fallback for the chat message; it is where the report has
-     * always actually belonged, and now happens whether or not anyone is listening.
+     * after the server has stopped. Without it the error <em>handler</em> threw a
+     * {@link NullPointerException} of its own, turning a reported chunk failure into a dead worldgen
+     * worker and losing the message that was being reported (issue #56). The log line below is not a
+     * fallback for the chat message; it is where the report has always actually belonged, and now
+     * happens whether or not anyone is listening.
      */
-    public static void report(String message) {
+    public static void report(@Nullable MinecraftServer server, String message) {
         long time = System.currentTimeMillis();
         if (lastReportTime != -1 && lastReportTime >= (time - 10000)) {
             return;
         }
         lastReportTime = time;
         Urbex.getLogger().error(message);
-        MinecraftServer server = ServerAccess.getServer();
         if (server == null) {
             return;
         }

--- a/src/test/java/dev/krona/urbex/worldgen/ChunkDriverCommitStateTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/ChunkDriverCommitStateTest.java
@@ -1,0 +1,163 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.IdMapper;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelHeightAccessor;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.chunk.PalettedContainerFactory;
+import net.minecraft.world.level.chunk.ProtoChunk;
+import net.minecraft.world.level.chunk.Strategy;
+import net.minecraft.world.level.chunk.UpgradeData;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Fault injection at the commit point.
+ * <p>
+ * The driver buffers every write into its own section cache and puts them into the world in one
+ * pass, so "did this chunk reach the world" has three answers and only the driver knows which. Issue
+ * #131 makes a failed chunk say which, and this is the case that cannot be reasoned about from the
+ * code alone: a failure <em>during</em> the write leaves some sections placed and some not, and the
+ * state must reflect that rather than the intent.
+ */
+class ChunkDriverCommitStateTest {
+
+    private static final LevelHeightAccessor HEIGHT = LevelHeightAccessor.create(-64, 384);
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void aDriverThatHasNotFlushedHasWrittenNothing() {
+        ProtoChunk chunk = protoChunk();
+        ChunkDriver driver = new ChunkDriver();
+        driver.setPrimer(levelFor(chunk, false), chunk);
+        driver.current(0, 64, 0).block(Blocks.STONE.defaultBlockState());
+
+        assertEquals(ChunkDriver.CommitState.BUFFERED, driver.commitState(),
+                "blocks written into the driver are not blocks written into the world");
+    }
+
+    @Test
+    void aCompletedFlushIsCommitted() {
+        ProtoChunk chunk = protoChunk();
+        ChunkDriver driver = new ChunkDriver();
+        driver.setPrimer(levelFor(chunk, false), chunk);
+        driver.current(0, 64, 0).block(Blocks.STONE.defaultBlockState());
+
+        driver.flushToChunk(chunk);
+
+        assertEquals(ChunkDriver.CommitState.COMMITTED, driver.commitState());
+    }
+
+    @Test
+    void aFlushThatFailsPartwayStaysCommitting() {
+        ProtoChunk chunk = protoChunk();
+        ChunkDriver driver = new ChunkDriver();
+        // A level that throws when the flush reaches for a section: the driver is midway through
+        // putting its buffer into the world, which is exactly the state that must not be reported as
+        // either "nothing happened" or "everything happened".
+        driver.setPrimer(levelFor(chunk, true), chunk);
+        driver.current(0, 64, 0).block(Blocks.STONE.defaultBlockState());
+
+        assertThrows(RuntimeException.class, () -> driver.flushToChunk(chunk));
+
+        assertEquals(ChunkDriver.CommitState.COMMITTING, driver.commitState(),
+                "a flush that threw partway must not claim to have committed, nor to have written "
+                        + "nothing - part of this chunk's city may be in the world");
+    }
+
+    private static ProtoChunk protoChunk() {
+        return new ProtoChunk(new ChunkPos(0, 0), UpgradeData.EMPTY, HEIGHT,
+                palettedContainerFactory(), null);
+    }
+
+    private static PalettedContainerFactory palettedContainerFactory() {
+        Holder<Biome> biome = dummyBiome();
+        IdMapper<Holder<Biome>> biomeIds = new IdMapper<>();
+        biomeIds.add(biome);
+        return new PalettedContainerFactory(
+                Strategy.createForBlockStates(Block.BLOCK_STATE_REGISTRY),
+                Blocks.AIR.defaultBlockState(),
+                null,
+                Strategy.createForBiomes(biomeIds),
+                biome,
+                null);
+    }
+
+    private static Holder<Biome> dummyBiome() {
+        BiomeSpecialEffects effects = new BiomeSpecialEffects(
+                0, Optional.empty(), Optional.empty(), Optional.empty(),
+                BiomeSpecialEffects.GrassColorModifier.NONE);
+        return Holder.direct(new Biome.BiomeBuilder()
+                .temperature(0.5f)
+                .downfall(0.5f)
+                .specialEffects(effects)
+                .mobSpawnSettings(MobSpawnSettings.EMPTY)
+                .generationSettings(BiomeGenerationSettings.EMPTY)
+                .build());
+    }
+
+    private static LevelAccessor levelFor(ProtoChunk chunk, boolean failOnChunkLookup) {
+        return (LevelAccessor) Proxy.newProxyInstance(
+                LevelAccessor.class.getClassLoader(),
+                new Class<?>[]{LevelAccessor.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getMinY" -> HEIGHT.getMinY();
+                    case "getMaxY" -> HEIGHT.getMaxY();
+                    case "getHeight" -> HEIGHT.getHeight();
+                    case "getSectionsCount" -> HEIGHT.getSectionsCount();
+                    case "getSectionIndex" -> HEIGHT.getSectionIndex((int) args[0]);
+                    case "getChunk" -> {
+                        if (failOnChunkLookup) {
+                            throw new IllegalStateException("injected fault during commit");
+                        }
+                        yield chunk;
+                    }
+                    case "getBlockState" -> chunk.getBlockState((BlockPos) args[0]);
+                    case "hasChunk" -> true;
+                    case "toString" -> "chunk-level";
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0f;
+        }
+        if (type == double.class) {
+            return 0d;
+        }
+        return null;
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/ChunkGenerationFailureTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/ChunkGenerationFailureTest.java
@@ -1,0 +1,79 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.varia.ChunkCoord;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A failed chunk says what it cost.
+ * <p>
+ * The three commit states are the three things a person reading the log has to go and check, and
+ * they are not the same job: nothing written means the chunk regenerates clean if it is requested
+ * again, partway written means part of a city is in the world, and written-then-failed means the
+ * blocks are there but the deferred writes may not be. Until issue #131 all three were one log line
+ * followed by a return of success.
+ */
+class ChunkGenerationFailureTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static final ChunkCoord COORD = new ChunkCoord(Level.OVERWORLD, 12, -7);
+
+    @Test
+    void theOriginalFailureIsAlwaysTheCause() {
+        IllegalStateException original = new IllegalStateException("the actual problem");
+
+        ChunkGenerationFailure failure =
+                new ChunkGenerationFailure(COORD, ChunkDriver.CommitState.BUFFERED, original);
+
+        assertSame(original, failure.getCause(),
+                "the wrapper adds the chunk and the phase; it must never replace the failure");
+    }
+
+    @Test
+    void everyFailureNamesTheChunkAndTheDimension() {
+        for (ChunkDriver.CommitState state : ChunkDriver.CommitState.values()) {
+            String message = new ChunkGenerationFailure(COORD, state, new RuntimeException()).getMessage();
+            assertTrue(message.contains("12,-7"), "must name the chunk, was: " + message);
+            assertTrue(message.contains("minecraft:overworld"),
+                    "must name the dimension, was: " + message);
+        }
+    }
+
+    @Test
+    void eachCommitStateDescribesADifferentConsequence() {
+        String buffered = messageFor(ChunkDriver.CommitState.BUFFERED);
+        String committing = messageFor(ChunkDriver.CommitState.COMMITTING);
+        String committed = messageFor(ChunkDriver.CommitState.COMMITTED);
+
+        assertEquals(3, java.util.Set.of(buffered, committing, committed).size(),
+                "a report that says the same thing whatever happened is a report nobody can act on");
+        assertTrue(buffered.contains("nothing was written"), buffered);
+        assertTrue(committing.contains("partway"), committing);
+        assertTrue(committed.contains("post-processing"), committed);
+    }
+
+    @Test
+    void theCoordinateAndPhaseAreReadableWithoutParsingTheMessage() {
+        ChunkGenerationFailure failure =
+                new ChunkGenerationFailure(COORD, ChunkDriver.CommitState.COMMITTING, new RuntimeException());
+
+        assertEquals(COORD, failure.coord());
+        assertEquals(ChunkDriver.CommitState.COMMITTING, failure.commitState());
+    }
+
+    private static String messageFor(ChunkDriver.CommitState state) {
+        return new ChunkGenerationFailure(COORD, state, new RuntimeException()).getMessage();
+    }
+}


### PR DESCRIPTION
generateFromPipeline wrapped the whole of generation in catch (Exception),
logged, and returned true. A chunk that threw halfway through writing a
building continued through the pipeline and was saved: vanilla terrain with
half a city in it, next to neighbours that got theirs, distinguished from a
correct chunk only by a log line nobody reads. Permanently, because nothing
ever revisits a saved chunk.

There is no catch there any more. The three categories the issue asks for are
now distinct:

  - configuration and asset validation failures are refused where the runtime
    is built, as they already were, and never reach a chunk;
  - a generation failure becomes a ChunkGenerationFailure and leaves
    generateFromPipeline, so the chunk task fails instead of saving a chunk
    that is quietly wrong;
  - a non-fatal diagnostic goes through ErrorLogger and changes nothing.

The failure carries where it landed, because that is the difference between
"nothing was written" and "half a city was written" and a report that cannot
say which is a report nobody can act on. ChunkDriver buffers every write and
puts them into the world in one pass, so it is the only thing that knows:
BUFFERED, COMMITTING, COMMITTED. The message says what each costs the person
reading the log.

Fault injection covers the case that cannot be read off the code:
ChunkDriverCommitStateTest throws from inside the flush and asserts the state
is neither "nothing happened" nor "everything happened".

ErrorLogger.report takes the server rather than reading ServerAccess. That was
the last worldgen or error-reporting path reaching the process-global slot, and
reading it there meant a chunk failing during one server's lifetime could report
to a different one. It keeps its null guard, which exists for shutdown: a worker
finishing after the server stopped used to NPE inside the error handler and lose
the message it was reporting.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>