### PR TITLE
refactor: configuration storage splits from configuration publication (#130, 130a)

### DIFF
--- a/src/main/java/dev/krona/urbex/config/ConfigRepository.java
+++ b/src/main/java/dev/krona/urbex/config/ConfigRepository.java
@@ -1,0 +1,141 @@
+package dev.krona.urbex.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import dev.krona.urbex.Urbex;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Where the configuration is kept, and how it gets there from an older format.
+ *
+ * <p>Storage only. Nothing here decides anything, publishes anything or is read by generation - it
+ * turns files into an {@link UrbexConfig} and back. {@code Config} used to do this alongside global
+ * publication, dimension-rule parsing, precedence, saved-data writes, validation and preset caching,
+ * all in one class of static fields (issue #130).</p>
+ *
+ * <p>Both files are read fail-soft, and deliberately so. A config that will not parse leaves the
+ * defaults (or, for a world file, the global config) in place and says so in the log, rather than
+ * refusing to start: an unreadable settings file is not a reason a player cannot open their world.
+ * Contrast the asset compiler, which does refuse - a datapack that does not compile has no defaults
+ * to fall back to.</p>
+ */
+public final class ConfigRepository {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+    private ConfigRepository() {
+    }
+
+    /**
+     * Reads {@code <config>/urbex/urbex.json}, migrating the legacy {@code common.toml} on first run,
+     * and writes the file back in full.
+     *
+     * <p>The write-back is not incidental: it is how every available option becomes visible to
+     * whoever is editing the file, so it goes through {@link UrbexConfig#toFullJson} and names every
+     * key whatever its value. The ordinary encoding omits any key that still holds its default,
+     * which for a fresh install is all of them - so this used to write {@code {}} while claiming to
+     * be "the full, normalized file".</p>
+     *
+     * @return the parsed config, or {@link UrbexConfig#DEFAULT} if there is no file or it does not
+     *         parse
+     */
+    public static UrbexConfig loadGlobal(Path configDir) {
+        Path dir = configDir.resolve("urbex");
+        Path file = dir.resolve("urbex.json");
+        UrbexConfig config = UrbexConfig.DEFAULT;
+        JsonObject json = null;
+        if (Files.exists(file)) {
+            json = readJson(file);
+        } else {
+            Path legacy = dir.resolve("common.toml");
+            if (Files.exists(legacy)) {
+                json = readLegacyToml(legacy);
+                Urbex.getLogger().info("Migrating legacy config {} to {}", legacy, file);
+            }
+        }
+        if (json != null) {
+            Optional<UrbexConfig> parsed = UrbexConfig.fromJson(json);
+            if (parsed.isPresent()) {
+                config = parsed.get();
+            } else {
+                Urbex.getLogger().error("Invalid config in {} - using defaults. Fix or delete the file.", file);
+            }
+        }
+        write(file, dir, UrbexConfig.toFullJson(config));
+        return config;
+    }
+
+    /**
+     * Applies {@code <world>/serverconfig/urbex.json} (or the legacy {@code urbex-server.toml}) over
+     * {@code global}.
+     *
+     * <p>The merge is per-key and happens at the JSON level, so a world file carries only what it
+     * changes. Unlike the global file this one is not written back when it already exists: it is the
+     * player's own list of differences, and normalizing it would fill it with every key they did not
+     * ask to change. A migrated legacy file <em>is</em> written, because otherwise the migration
+     * would run again on every start.</p>
+     */
+    public static UrbexConfig applyWorldOverrides(UrbexConfig global, Path worldRoot) {
+        Path dir = worldRoot.resolve("serverconfig");
+        Path file = dir.resolve("urbex.json");
+        JsonObject overrides = null;
+        if (Files.exists(file)) {
+            overrides = readJson(file);
+        } else {
+            Path legacy = dir.resolve("urbex-server.toml");
+            if (Files.exists(legacy)) {
+                overrides = readLegacyToml(legacy);
+                Urbex.getLogger().info("Migrating legacy world config {} to {}", legacy, file);
+                write(file, dir, overrides);
+            }
+        }
+        if (overrides == null || overrides.isEmpty()) {
+            return global;
+        }
+        JsonObject merged = UrbexConfig.merge(UrbexConfig.toJson(global), overrides);
+        Optional<UrbexConfig> parsed = UrbexConfig.fromJson(merged);
+        if (parsed.isEmpty()) {
+            Urbex.getLogger().error("Invalid world config in {} - ignoring it.", file);
+            return global;
+        }
+        Urbex.getLogger().info("Applied {} world config override(s) from {}", overrides.size(), file);
+        return parsed.get();
+    }
+
+    private static void write(Path file, Path dir, JsonObject json) {
+        if (json == null) {
+            return;
+        }
+        try {
+            Files.createDirectories(dir);
+            Files.writeString(file, GSON.toJson(json));
+        } catch (IOException e) {
+            Urbex.getLogger().error("Could not write {}", file, e);
+        }
+    }
+
+    private static JsonObject readJson(Path file) {
+        try (Reader reader = Files.newBufferedReader(file)) {
+            return JsonParser.parseReader(reader).getAsJsonObject();
+        } catch (Exception e) {
+            Urbex.getLogger().error("Could not read {}", file, e);
+            return null;
+        }
+    }
+
+    private static JsonObject readLegacyToml(Path file) {
+        try {
+            return LegacyToml.toJson(Files.readAllLines(file));
+        } catch (IOException e) {
+            Urbex.getLogger().error("Could not read {}", file, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/config/UrbexConfig.java
+++ b/src/main/java/dev/krona/urbex/config/UrbexConfig.java
@@ -71,13 +71,56 @@ public record UrbexConfig(
             Codec.BOOL.optionalFieldOf("experimentalMultiWorldStyles", DEFAULT.experimentalMultiWorldStyles()).forGetter(UrbexConfig::experimentalMultiWorldStyles)
     ).apply(instance, UrbexConfig::new));
 
+    /**
+     * The same fields, all required, used only for writing the global file - see {@link #toFullJson}.
+     * Never used to read: a config file is allowed to name only what it changes.
+     */
+    private static final Codec<UrbexConfig> FULL_CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Codec.STRING.listOf().fieldOf("dimensionsWithPresets").forGetter(UrbexConfig::dimensionsWithPresets),
+            Codec.intRange(1, 100).fieldOf("heightSampleSize").forGetter(UrbexConfig::heightSampleSize),
+            Codec.STRING.fieldOf("selectedPreset").forGetter(UrbexConfig::selectedPreset),
+            Codec.STRING.fieldOf("selectedWorldStyle").forGetter(UrbexConfig::selectedWorldStyle),
+            Codec.intRange(1, 100000).fieldOf("todoQueueSize").forGetter(UrbexConfig::todoQueueSize),
+            Codec.BOOL.fieldOf("forceSaplingGrowth").forGetter(UrbexConfig::forceSaplingGrowth),
+            Codec.intRange(1, 86400).fieldOf("cacheCleanupSeconds").forGetter(UrbexConfig::cacheCleanupSeconds),
+            Codec.STRING.listOf().fieldOf("avoidStructures").forGetter(UrbexConfig::avoidStructures),
+            Codec.BOOL.fieldOf("avoidSurfaceStructures").forGetter(UrbexConfig::avoidSurfaceStructures),
+            Codec.BOOL.fieldOf("structuresYieldToCities").forGetter(UrbexConfig::structuresYieldToCities),
+            Codec.BOOL.fieldOf("avoidVillages").forGetter(UrbexConfig::avoidVillages),
+            Codec.BOOL.fieldOf("avoidFlattening").forGetter(UrbexConfig::avoidFlattening),
+            Codec.BOOL.fieldOf("experimentalMultiWorldStyles").forGetter(UrbexConfig::experimentalMultiWorldStyles)
+    ).apply(instance, UrbexConfig::new));
+
     /** Parses a config from JSON; empty if any present key fails validation. */
     public static Optional<UrbexConfig> fromJson(JsonObject json) {
         return CODEC.parse(JsonOps.INSTANCE, json).result();
     }
 
+    /**
+     * Encodes the differences from the defaults. Every key whose value <em>is</em> the default is
+     * omitted, because {@link Codec#optionalFieldOf(String, Object)} omits it - which is what makes
+     * a world's override file carry only what it changes.
+     */
     public static JsonObject toJson(UrbexConfig config) {
         return CODEC.encodeStart(JsonOps.INSTANCE, config).getOrThrow().getAsJsonObject();
+    }
+
+    /**
+     * Encodes every key, whatever its value.
+     *
+     * <p>For the global file, which is written back on every start so that it documents itself: a
+     * player reading {@code config/urbex/urbex.json} should see the options they could set. With
+     * {@link #toJson} they saw a fresh install write {@code {}} and had to go and find the key names
+     * somewhere else - the write-back had claimed to be "the full, normalized file" since the
+     * ModConfigSpec was replaced by a codec (issue #75), and quietly had not been one.</p>
+     *
+     * <p>The second codec exists because there is no way to ask a {@link Codec} built from
+     * {@code optionalFieldOf} to encode a default anyway. {@link UrbexConfigTest} guards the two
+     * against drifting apart, so a field added to the record and not to this one fails a test rather
+     * than silently stopping being written.</p>
+     */
+    public static JsonObject toFullJson(UrbexConfig config) {
+        return FULL_CODEC.encodeStart(JsonOps.INSTANCE, config).getOrThrow().getAsJsonObject();
     }
 
     /** Shallow key-level merge: every key the overlay carries replaces the base's. */

--- a/src/main/java/dev/krona/urbex/setup/Config.java
+++ b/src/main/java/dev/krona/urbex/setup/Config.java
@@ -1,13 +1,11 @@
 package dev.krona.urbex.setup;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.Presets;
+import dev.krona.urbex.config.ConfigRepository;
 import dev.krona.urbex.config.UrbexConfig;
 import dev.krona.urbex.data.UrbexData;
 import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
@@ -22,9 +20,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.LevelResource;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -84,99 +79,25 @@ public class Config {
         return reduced;
     }
 
-    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
-
     /**
-     * Loads the global config from {@code config/urbex/urbex.json}, migrating the legacy
-     * {@code common.toml} on first run. Called once from mod init.
+     * Loads the global config. Called once from mod init.
+     * <p>
+     * Reading the file, migrating a legacy one and writing it back are {@link ConfigRepository}'s
+     * business; what happens here is publication - the two slots every other path reads (issue #130).
      */
     public static void loadGlobal(Path configDir) {
-        Path dir = configDir.resolve("urbex");
-        Path file = dir.resolve("urbex.json");
-        JsonObject json = null;
-        if (Files.exists(file)) {
-            json = readJson(file);
-        } else {
-            Path legacy = dir.resolve("common.toml");
-            if (Files.exists(legacy)) {
-                json = readLegacyToml(legacy);
-                Urbex.getLogger().info("Migrating legacy config {} to {}", legacy, file);
-            }
-        }
-        if (json != null) {
-            Optional<UrbexConfig> parsed = UrbexConfig.fromJson(json);
-            if (parsed.isPresent()) {
-                global = parsed.get();
-            } else {
-                Urbex.getLogger().error("Invalid config in {} - using defaults. Fix or delete the file.", file);
-            }
-        }
+        global = ConfigRepository.loadGlobal(configDir);
         active = global;
-        // Write back the full, normalized file so every available option is visible
-        try {
-            Files.createDirectories(dir);
-            Files.writeString(file, GSON.toJson(UrbexConfig.toJson(global)));
-        } catch (IOException e) {
-            Urbex.getLogger().error("Could not write {}", file, e);
-        }
     }
 
     /**
-     * Applies {@code <world>/serverconfig/urbex.json} (or the legacy
-     * {@code urbex-server.toml}) over the global config. Called at SERVER_STARTING, before any
-     * worldgen; the merge is per-key, so a world file only carries what it changes.
+     * Applies this world's own overrides over the global config. Called at SERVER_STARTING, before
+     * any worldgen.
      */
     public static void applyWorldOverrides(MinecraftServer server) {
-        UrbexConfig result = global;
-        Path dir = server.getWorldPath(LevelResource.ROOT).resolve("serverconfig");
-        Path file = dir.resolve("urbex.json");
-        JsonObject overrides = null;
-        if (Files.exists(file)) {
-            overrides = readJson(file);
-        } else {
-            Path legacy = dir.resolve("urbex-server.toml");
-            if (Files.exists(legacy)) {
-                overrides = readLegacyToml(legacy);
-                Urbex.getLogger().info("Migrating legacy world config {} to {}", legacy, file);
-                try {
-                    Files.createDirectories(dir);
-                    Files.writeString(file, GSON.toJson(overrides));
-                } catch (IOException e) {
-                    Urbex.getLogger().error("Could not write {}", file, e);
-                }
-            }
-        }
-        if (overrides != null && !overrides.isEmpty()) {
-            JsonObject merged = UrbexConfig.merge(UrbexConfig.toJson(global), overrides);
-            Optional<UrbexConfig> parsed = UrbexConfig.fromJson(merged);
-            if (parsed.isPresent()) {
-                result = parsed.get();
-                Urbex.getLogger().info("Applied {} world config override(s) from {}", overrides.size(), file);
-            } else {
-                Urbex.getLogger().error("Invalid world config in {} - ignoring it.", file);
-            }
-        }
-        active = result;
+        active = ConfigRepository.applyWorldOverrides(global, server.getWorldPath(LevelResource.ROOT));
         AVOID_STRUCTURES_SET = null;
         resetPresetCache();
-    }
-
-    private static JsonObject readJson(Path file) {
-        try (Reader reader = Files.newBufferedReader(file)) {
-            return JsonParser.parseReader(reader).getAsJsonObject();
-        } catch (Exception e) {
-            Urbex.getLogger().error("Could not read {}", file, e);
-            return null;
-        }
-    }
-
-    private static JsonObject readLegacyToml(Path file) {
-        try {
-            return dev.krona.urbex.config.LegacyToml.toJson(Files.readAllLines(file));
-        } catch (IOException e) {
-            Urbex.getLogger().error("Could not read {}", file, e);
-            return null;
-        }
     }
 
     /**

--- a/src/test/java/dev/krona/urbex/config/ConfigRepositoryTest.java
+++ b/src/test/java/dev/krona/urbex/config/ConfigRepositoryTest.java
@@ -1,0 +1,143 @@
+package dev.krona.urbex.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Storage and migration, tested without publishing anything.
+ * <p>
+ * This is what the split is for. Reading a file, migrating an older format and merging a world's
+ * overrides used to be methods on {@code Config} that wrote to its static slots on the way through,
+ * so a test of the file handling was a test of the whole process-wide configuration state - which is
+ * why {@code ExperimentalMixGateTest} has to reset that state in a {@code @BeforeEach} and say so
+ * (issue #130). Nothing here touches anything outside its temporary directory.
+ */
+class ConfigRepositoryTest {
+
+    @Test
+    void anAbsentConfigYieldsTheDefaultsAndWritesThemOut(@TempDir Path configDir) throws IOException {
+        UrbexConfig loaded = ConfigRepository.loadGlobal(configDir);
+
+        assertEquals(UrbexConfig.DEFAULT, loaded);
+        Path written = configDir.resolve("urbex").resolve("urbex.json");
+        assertTrue(Files.exists(written), "the file is written back so its options are discoverable");
+        assertTrue(Files.readString(written).contains("experimentalMultiWorldStyles"),
+                "including keys still at their default - that is what makes the file document "
+                        + "itself, and what it did not do while writing only the differences");
+    }
+
+    @Test
+    void aValidConfigIsReadBack(@TempDir Path configDir) throws IOException {
+        writeGlobal(configDir, "{\"heightSampleSize\": 7, \"avoidVillages\": false}");
+
+        UrbexConfig loaded = ConfigRepository.loadGlobal(configDir);
+
+        assertEquals(7, loaded.heightSampleSize());
+        assertFalse(loaded.avoidVillages());
+        assertEquals(UrbexConfig.DEFAULT.todoQueueSize(), loaded.todoQueueSize(),
+                "a key the file does not mention keeps its default");
+    }
+
+    @Test
+    void anUnparseableConfigLeavesTheDefaultsRatherThanRefusingToStart(@TempDir Path configDir) throws IOException {
+        // Out of range for the codec's intRange(1, 100). A settings file nobody can parse is not a
+        // reason a player cannot open their world - unlike a datapack, there is something sensible
+        // to fall back to.
+        writeGlobal(configDir, "{\"heightSampleSize\": 9999}");
+
+        assertEquals(UrbexConfig.DEFAULT, ConfigRepository.loadGlobal(configDir));
+    }
+
+    @Test
+    void aLegacyTomlIsMigratedOnFirstRun(@TempDir Path configDir) throws IOException {
+        Path dir = Files.createDirectories(configDir.resolve("urbex"));
+        Files.writeString(dir.resolve("common.toml"), String.join("\n", List.of(
+                "heightSampleSize = 9",
+                "avoidFlattening = false")));
+
+        UrbexConfig loaded = ConfigRepository.loadGlobal(configDir);
+
+        assertEquals(9, loaded.heightSampleSize());
+        assertFalse(loaded.avoidFlattening());
+        assertTrue(Files.exists(dir.resolve("urbex.json")),
+                "the migrated values are written as JSON, so the TOML is read once and never again");
+    }
+
+    // ------------------------------------------------------------------ world overrides
+
+    @Test
+    void aWorldWithNoOverridesKeepsTheGlobalConfigItself(@TempDir Path worldRoot) {
+        UrbexConfig global = UrbexConfig.DEFAULT;
+
+        assertSame(global, ConfigRepository.applyWorldOverrides(global, worldRoot),
+                "no file means no decision to make, not a rebuild of the same values");
+    }
+
+    @Test
+    void aWorldOverridesOnlyTheKeysItNames(@TempDir Path worldRoot) throws IOException {
+        UrbexConfig global = ConfigRepository.applyWorldOverrides(UrbexConfig.DEFAULT, worldRoot);
+        writeWorld(worldRoot, "{\"selectedPreset\": \"urbex:largecities\"}");
+
+        UrbexConfig merged = ConfigRepository.applyWorldOverrides(global, worldRoot);
+
+        assertEquals("urbex:largecities", merged.selectedPreset());
+        assertEquals(global.heightSampleSize(), merged.heightSampleSize(),
+                "everything the world file does not mention comes from the global config");
+    }
+
+    @Test
+    void anUnparseableWorldFileIsIgnoredRatherThanTakingTheWorldDown(@TempDir Path worldRoot) throws IOException {
+        writeWorld(worldRoot, "{\"cacheCleanupSeconds\": -5}");
+
+        assertSame(UrbexConfig.DEFAULT,
+                ConfigRepository.applyWorldOverrides(UrbexConfig.DEFAULT, worldRoot));
+    }
+
+    @Test
+    void aLegacyWorldTomlIsMigratedAndNotReadTwice(@TempDir Path worldRoot) throws IOException {
+        Path dir = Files.createDirectories(worldRoot.resolve("serverconfig"));
+        Files.writeString(dir.resolve("urbex-server.toml"), "todoQueueSize = 42");
+
+        UrbexConfig merged = ConfigRepository.applyWorldOverrides(UrbexConfig.DEFAULT, worldRoot);
+
+        assertEquals(42, merged.todoQueueSize());
+        assertTrue(Files.exists(dir.resolve("urbex.json")),
+                "written on migration, or the migration would run again on every start");
+    }
+
+    /**
+     * The world file is the player's own list of differences. Normalizing it the way the global file
+     * is normalized would fill it with every key they did not ask to change, and the next global
+     * default change would then silently not reach that world.
+     */
+    @Test
+    void anExistingWorldFileIsNotRewritten(@TempDir Path worldRoot) throws IOException {
+        writeWorld(worldRoot, "{\"todoQueueSize\": 42}");
+        Path file = worldRoot.resolve("serverconfig").resolve("urbex.json");
+        String before = Files.readString(file);
+
+        ConfigRepository.applyWorldOverrides(UrbexConfig.DEFAULT, worldRoot);
+
+        assertEquals(before, Files.readString(file));
+    }
+
+    private static void writeGlobal(Path configDir, String json) throws IOException {
+        Path dir = Files.createDirectories(configDir.resolve("urbex"));
+        Files.writeString(dir.resolve("urbex.json"), json);
+    }
+
+    private static void writeWorld(Path worldRoot, String json) throws IOException {
+        Path dir = Files.createDirectories(worldRoot.resolve("serverconfig"));
+        Files.writeString(dir.resolve("urbex.json"), json);
+    }
+}

--- a/src/test/java/dev/krona/urbex/config/UrbexConfigTest.java
+++ b/src/test/java/dev/krona/urbex/config/UrbexConfigTest.java
@@ -33,6 +33,37 @@ public class UrbexConfigTest {
         assertEquals(20, cfg.todoQueueSize());   // untouched fields keep defaults
     }
 
+    /**
+     * The written global file names every option, so the file a player opens documents what they can
+     * set. The ordinary encoding omits any key still holding its default, which for a fresh install
+     * is all of them - it wrote {@code {}} while its own comment called it "the full, normalized
+     * file" (issue #130).
+     */
+    @Test
+    public void theFullEncodingNamesEveryFieldEvenAtItsDefault() {
+        JsonObject full = UrbexConfig.toFullJson(UrbexConfig.DEFAULT);
+
+        assertEquals(UrbexConfig.class.getRecordComponents().length, full.size(),
+                "every record component must be written; a field added to the record and not to "
+                        + "FULL_CODEC would silently stop appearing in the file");
+        assertTrue(full.has("experimentalMultiWorldStyles"));
+        assertTrue(full.has("avoidStructures"));
+        assertEquals(new JsonObject(), UrbexConfig.toJson(UrbexConfig.DEFAULT),
+                "while the difference encoding stays empty - that is what lets a world file carry "
+                        + "only what it changes");
+    }
+
+    @Test
+    public void theFullEncodingRoundTrips() {
+        UrbexConfig config = UrbexConfig.fromJson(JsonParser.parseString(
+                        "{\"selectedPreset\": \"urbex:largecities\", \"heightSampleSize\": 9, "
+                                + "\"experimentalMultiWorldStyles\": true}")
+                .getAsJsonObject()).orElseThrow();
+
+        assertEquals(config, UrbexConfig.fromJson(UrbexConfig.toFullJson(config)).orElseThrow(),
+                "the two codecs must agree about what each key means, not only about its name");
+    }
+
     @Test
     public void outOfRangeValueIsRejected() {
         JsonObject json = JsonParser.parseString("{\"heightSampleSize\": 0}").getAsJsonObject();


### PR DESCRIPTION
Config combined file IO, legacy migration, global publication, dimension-rule
parsing, precedence, saved-data writes, validation and preset caching in one
class of static fields. This takes the first of those out: ConfigRepository
turns files into an UrbexConfig and back, decides nothing, and publishes
nothing. Config keeps the two slots everything else reads.

Both files stay fail-soft, and the reason is now written down: a settings file
nobody can parse is not a reason a player cannot open their world, unlike a
datapack, which has no defaults to fall back to.

**One defect the split surfaced.** The global file is written back on every
start "so every available option is visible" - that is what its comment has
said since the ModConfigSpec was replaced by a codec (#75). It was not true.
optionalFieldOf omits any key whose value is still the default, so a fresh
install wrote {} and a player had to go and find the key names somewhere else.
Testing the storage layer on its own is what showed it, which is the point of
separating it.

UrbexConfig.toFullJson names every key whatever its value, and the global
write-back uses it. The world file keeps the difference encoding: it is the
player's own list of what they changed, and filling it with every other key
would mean the next default change silently did not reach that world.
UrbexConfigTest guards the two codecs against drifting - a field added to the
record and not to FULL_CODEC fails a test rather than quietly stopping being
written.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>