### PR TITLE
refactor: the configuration is parsed once, into typed values (#130, 130b)

### DIFF
--- a/src/main/java/dev/krona/urbex/gui/CitiesTab.java
+++ b/src/main/java/dev/krona/urbex/gui/CitiesTab.java
@@ -331,7 +331,7 @@ public class CitiesTab extends GridLayoutTab {
         List<String> choices = PresetSelection.CLIENT.styleChoices();
         Minecraft.getInstance().gui.setScreen(new WorldStyleDialog(screen, choices, worldStyleNames,
                 PresetSelection.CLIENT.effectiveWorldStyles(),
-                Config.EXPERIMENTAL_MULTI_WORLD_STYLES.get(),
+                Config.experimentalMultiWorldStyles(),
                 this::onWorldStylesChanged));
     }
 

--- a/src/main/java/dev/krona/urbex/setup/Config.java
+++ b/src/main/java/dev/krona/urbex/setup/Config.java
@@ -6,13 +6,10 @@ import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.Presets;
 import dev.krona.urbex.config.ConfigRepository;
-import dev.krona.urbex.config.UrbexConfig;
 import dev.krona.urbex.data.UrbexData;
 import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
-import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
@@ -26,13 +23,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
- * Configuration access. Values come from the codec-backed {@link UrbexConfig}: the global
- * {@code config/urbex/urbex.json}, optionally overridden per world by
- * {@code <world>/serverconfig/urbex.json}. Legacy Forge Config API Port TOML files are read
- * once and migrated (issue #75).
+ * Which configuration is in effect, and the decisions taken from it.
  * <p>
- * The public surface is kept supplier-shaped ({@code Config.X.get()}) so the many call sites
- * did not have to change when the ModConfigSpec backing was removed.
+ * Reading and writing the files is {@link ConfigRepository}'s job; turning what they say into
+ * identifiers and dimension rules is {@link GlobalConfig}'s. What is left here is publication - one
+ * slot for the global config and one for the running world's - plus the per-dimension preset choice
+ * derived from it (issue #130).
+ * <p>
+ * The accessors are plain methods. They were {@code Supplier} constants so that call sites written
+ * against the NeoForge {@code ModConfigSpec} did not have to change when it was removed (#75); the
+ * spec has been gone for two releases and the shape was only ever a migration aid.
  */
 public class Config {
 
@@ -45,21 +45,50 @@ public class Config {
     public static final WorldStyleMix DEFAULT_WORLD_STYLE_MIX = WorldStyleMix.of(DEFAULT_WORLD_STYLE);
 
     /** The currently active config: global, with the running world's overrides applied. */
-    private static volatile UrbexConfig active = UrbexConfig.DEFAULT;
+    private static volatile GlobalConfig active = GlobalConfig.DEFAULT;
     /** The global config alone, restored when a world's overrides are dropped. */
-    private static volatile UrbexConfig global = UrbexConfig.DEFAULT;
+    private static volatile GlobalConfig global = GlobalConfig.DEFAULT;
 
-    public static final Supplier<String> SELECTED_PRESET = () -> active.selectedPreset();
-    public static final Supplier<String> SELECTED_WORLD_STYLE = () -> active.selectedWorldStyle();
-    public static final Supplier<Integer> TODO_QUEUE_SIZE = () -> active.todoQueueSize();
-    public static final Supplier<Boolean> FORCE_SAPLING_GROWTH = () -> active.forceSaplingGrowth();
-    public static final Supplier<Integer> CACHE_CLEANUP_SECONDS = () -> active.cacheCleanupSeconds();
-    public static final Supplier<Integer> HEIGHT_SAMPLE_SIZE = () -> active.heightSampleSize();
-    public static final Supplier<Boolean> AVOID_SURFACE_STRUCTURES = () -> active.avoidSurfaceStructures();
-    public static final Supplier<Boolean> STRUCTURES_YIELD_TO_CITIES = () -> active.structuresYieldToCities();
-    public static final Supplier<Boolean> AVOID_VILLAGES = () -> active.avoidVillages();
-    public static final Supplier<Boolean> AVOID_FLATTENING = () -> active.avoidFlattening();
-    public static final Supplier<Boolean> EXPERIMENTAL_MULTI_WORLD_STYLES = () -> active.experimentalMultiWorldStyles();
+    /** Everything in effect right now, typed. */
+    public static GlobalConfig active() {
+        return active;
+    }
+
+    public static int todoQueueSize() {
+        return active.file().todoQueueSize();
+    }
+
+    public static boolean forceSaplingGrowth() {
+        return active.file().forceSaplingGrowth();
+    }
+
+    public static int cacheCleanupSeconds() {
+        return active.file().cacheCleanupSeconds();
+    }
+
+    public static int heightSampleSize() {
+        return active.file().heightSampleSize();
+    }
+
+    public static boolean avoidSurfaceStructures() {
+        return active.file().avoidSurfaceStructures();
+    }
+
+    public static boolean structuresYieldToCities() {
+        return active.file().structuresYieldToCities();
+    }
+
+    public static boolean avoidVillages() {
+        return active.file().avoidVillages();
+    }
+
+    public static boolean avoidFlattening() {
+        return active.file().avoidFlattening();
+    }
+
+    public static boolean experimentalMultiWorldStyles() {
+        return active.file().experimentalMultiWorldStyles();
+    }
 
     /**
      * Applies the {@code experimentalMultiWorldStyles} opt-in to a mix that arrived from anywhere -
@@ -70,7 +99,17 @@ public class Config {
      * carry a mix must not quietly get one on an install that never opted in.
      */
     public static WorldStyleMix gateMix(WorldStyleMix mix, String context) {
-        if (mix.isSingle() || EXPERIMENTAL_MULTI_WORLD_STYLES.get()) {
+        return gateMix(mix, experimentalMultiWorldStyles(), context);
+    }
+
+    /**
+     * @see #gateMix(WorldStyleMix, String)
+     *
+     * <p>Takes the flag rather than reading it, for the one caller that has to gate a mix while the
+     * config carrying the flag is still being built - see {@link GlobalConfig#of}.</p>
+     */
+    static WorldStyleMix gateMix(WorldStyleMix mix, boolean allowMixes, String context) {
+        if (mix.isSingle() || allowMixes) {
             return mix;
         }
         WorldStyleMix reduced = mix.reducedToPrimary();
@@ -86,7 +125,7 @@ public class Config {
      * business; what happens here is publication - the two slots every other path reads (issue #130).
      */
     public static void loadGlobal(Path configDir) {
-        global = ConfigRepository.loadGlobal(configDir);
+        global = GlobalConfig.of(ConfigRepository.loadGlobal(configDir));
         active = global;
     }
 
@@ -95,8 +134,8 @@ public class Config {
      * any worldgen.
      */
     public static void applyWorldOverrides(MinecraftServer server) {
-        active = ConfigRepository.applyWorldOverrides(global, server.getWorldPath(LevelResource.ROOT));
-        AVOID_STRUCTURES_SET = null;
+        active = GlobalConfig.of(ConfigRepository.applyWorldOverrides(
+                global.file(), server.getWorldPath(LevelResource.ROOT)));
         resetPresetCache();
     }
 
@@ -116,16 +155,11 @@ public class Config {
     public static WorldStyleMix worldStyleMixFromClient = null;
     public static String overridesFromClient = null;
 
-    // Lazily filled from avoidStructures by cacheAvoidedStructures(). Must start out null:
-    // that method only fills the set when it is still null.
-    private static Set<Identifier> AVOID_STRUCTURES_SET = null;
-
     public static void reset() {
         presetFromClient = null;
         worldStyleMixFromClient = null;
         overridesFromClient = null;
         dimensionPresetCache = null;
-        AVOID_STRUCTURES_SET = null;
         active = global;
     }
 
@@ -141,63 +175,6 @@ public class Config {
             dimensionPresetCache = cache;
         }
         return cache.get(type);
-    }
-
-    /**
-     * Parses one {@code dimensionsWithPresets} entry: {@code dimension=preset[@worldstyle]}. The
-     * preset and worldstyle names must name their namespace: {@link DataTools#fromName} rejects a
-     * bare one rather than defaulting it, so {@code minecraft:overworld=default} is refused and
-     * {@code minecraft:overworld=urbex:default} is not. (The dimension id on the left is parsed by
-     * {@link Identifier#parse} and does still default, to {@code minecraft} - it is a vanilla id,
-     * not a datapack cross-reference.) Malformed entries - wrong arity on either side of {@code =},
-     * or an id that fails to parse - are logged and rejected rather than thrown, so one bad line in
-     * the config doesn't take the whole list down.
-     * <p>
-     * The rejection messages below carry {@code e.getMessage()} through, because for the two
-     * {@code fromName} calls that is the only place the "add a namespace, e.g. urbex:default" hint
-     * exists - and a config written before namespaces were mandatory is exactly the case that hits
-     * it, so it is the one message that user will see.
-     */
-    public static Optional<Map.Entry<ResourceKey<Level>, PresetChoice>> parseDimensionPresetEntry(String entry) {
-        String[] split = entry.split("=");
-        if (split.length != 2) {
-            Urbex.getLogger().error("Bad format for config value: '{}'! Expected 'dimension=preset[@worldstyle]'.", entry);
-            return Optional.empty();
-        }
-        ResourceKey<Level> dimensionType;
-        try {
-            dimensionType = ResourceKey.create(Registries.DIMENSION, Identifier.parse(split[0]));
-        } catch (Exception e) {
-            Urbex.getLogger().error("Bad dimension id in config value: '{}'!", entry);
-            return Optional.empty();
-        }
-
-        String presetPart = split[1];
-        String presetName = presetPart;
-        WorldStyleMix worldStyles = DEFAULT_WORLD_STYLE_MIX;
-        int at = presetPart.indexOf('@');
-        if (at >= 0) {
-            presetName = presetPart.substring(0, at);
-            String stylePart = presetPart.substring(at + 1);
-            try {
-                // The whole tail, not one id: a single qualified id is just a one-entry mix, so the
-                // pre-mixing form parses unchanged.
-                worldStyles = gateMix(WorldStyleMix.parse(stylePart), "dimensionsWithPresets entry '" + entry + "'");
-            } catch (Exception e) {
-                Urbex.getLogger().error("Bad worldstyle spec in config value: '{}'! {}", entry, e.getMessage());
-                return Optional.empty();
-            }
-        }
-
-        Identifier presetId;
-        try {
-            presetId = DataTools.fromName(presetName);
-        } catch (Exception e) {
-            Urbex.getLogger().error("Bad preset id in config value: '{}'! {}", entry, e.getMessage());
-            return Optional.empty();
-        }
-
-        return Optional.of(Map.entry(dimensionType, new PresetChoice(presetId, worldStyles, Optional.empty())));
     }
 
     /**
@@ -221,8 +198,11 @@ public class Config {
      */
     private static Map<ResourceKey<Level>, PresetChoice> buildPresetCache(ServerLevel level) {
         Map<ResourceKey<Level>, PresetChoice> cache = new ConcurrentHashMap<>();
-        for (String dp : active.dimensionsWithPresets()) {
-            parseDimensionPresetEntry(dp).ifPresent(e -> cache.put(e.getKey(), e.getValue()));
+        // Parsed once, when the config was published, rather than per cache build. The messages a
+        // malformed entry produces therefore reach the log at load time, where a player can act on
+        // them, instead of from whichever worldgen worker first needed the cache.
+        for (GlobalConfig.DimensionRule rule : active.dimensionRules()) {
+            cache.put(rule.dimension(), rule.choice());
         }
 
         UrbexData data = UrbexData.getData(level);
@@ -263,16 +243,12 @@ public class Config {
                     selectedOverrides = savedOverrides.isEmpty() ? null : savedOverrides;
                 }
             } else if (level.dimension() == Level.OVERWORLD) {
-                String globalPreset = Config.SELECTED_PRESET.get();
-                if (globalPreset != null && !globalPreset.isEmpty()) {
-                    selectedPreset = DataTools.fromName(globalPreset);
-                    // The global config's own selection stays a single id: it is the overworld-only
-                    // default for installs that never open the Cities tab, and a mix there would add
-                    // a third place to look for one setting without adding any reach.
-                    String globalStyle = Config.SELECTED_WORLD_STYLE.get();
-                    selectedWorldStyles = globalStyle == null || globalStyle.isEmpty()
-                            ? DEFAULT_WORLD_STYLE_MIX : WorldStyleMix.of(DataTools.fromName(globalStyle));
-                }
+                // Parsed when the config was published. The global config's own selection stays a
+                // single id: it is the overworld-only default for installs that never open the
+                // Cities tab, and a mix there would add a third place to look for one setting
+                // without adding any reach.
+                selectedPreset = active.selectedPreset();
+                selectedWorldStyles = active.selectedWorldStyles();
             }
         }
 
@@ -348,24 +324,22 @@ public class Config {
         Registry<dev.krona.urbex.worldgen.lost.regassets.WorldStyleDefinition> worldStyles =
                 server.registryAccess().lookupOrThrow(CustomRegistries.WORLDSTYLES_REGISTRY_KEY);
 
-        String selected = SELECTED_PRESET.get();
-        if (selected != null && !selected.isEmpty()) {
-            requirePreset(presets, DataTools.fromName(selected), "config selectedPreset '" + selected + "'");
+        Identifier selected = active.selectedPreset();
+        if (selected != null) {
+            requirePreset(presets, selected, "config selectedPreset '" + selected + "'");
         }
-        String selectedStyle = SELECTED_WORLD_STYLE.get();
-        if (selectedStyle != null && !selectedStyle.isEmpty()) {
-            requireWorldStyle(worldStyles, DataTools.fromName(selectedStyle), "config selectedWorldStyle '" + selectedStyle + "'");
+        for (Identifier style : active.selectedWorldStyles().styles()) {
+            requireWorldStyle(worldStyles, style, "config selectedWorldStyle '" + style + "'");
         }
 
-        for (String dp : active.dimensionsWithPresets()) {
-            Optional<Map.Entry<ResourceKey<Level>, PresetChoice>> parsed = parseDimensionPresetEntry(dp);
-            // Malformed entries are reported by parseDimensionPresetEntry itself; not this method's concern.
-            parsed.ifPresent(e -> {
-                requirePreset(presets, e.getValue().preset(), "dimensionsWithPresets entry '" + dp + "'");
-                for (Identifier style : e.getValue().worldStyles().styles()) {
-                    requireWorldStyle(worldStyles, style, "dimensionsWithPresets entry '" + dp + "'");
-                }
-            });
+        // Over the parsed rules: a malformed entry was reported when the config was published and is
+        // not in this list, which is what stops it being reported a second time here.
+        for (GlobalConfig.DimensionRule rule : active.dimensionRules()) {
+            String where = "dimensionsWithPresets entry for '" + rule.dimension().identifier() + "'";
+            requirePreset(presets, rule.choice().preset(), where);
+            for (Identifier style : rule.choice().worldStyles().styles()) {
+                requireWorldStyle(worldStyles, style, where);
+            }
         }
     }
 
@@ -392,22 +366,10 @@ public class Config {
     }
 
     public static boolean isAvoidedStructure(Identifier id) {
-        cacheAvoidedStructures();
-        return AVOID_STRUCTURES_SET.contains(id);
+        return active.avoidStructures().contains(id);
     }
 
     public static boolean hasAvoidedStructures() {
-        cacheAvoidedStructures();
-        return !AVOID_STRUCTURES_SET.isEmpty();
-    }
-
-    private static void cacheAvoidedStructures() {
-        if (AVOID_STRUCTURES_SET == null) {
-            Set<Identifier> set = new HashSet<>();
-            for (String s : active.avoidStructures()) {
-                set.add(Identifier.parse(s));
-            }
-            AVOID_STRUCTURES_SET = set;
-        }
+        return !active.avoidStructures().isEmpty();
     }
 }

--- a/src/main/java/dev/krona/urbex/setup/GlobalConfig.java
+++ b/src/main/java/dev/krona/urbex/setup/GlobalConfig.java
@@ -1,0 +1,187 @@
+package dev.krona.urbex.setup;
+
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.config.UrbexConfig;
+import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The configuration as the rest of the mod means it: identifiers rather than strings, dimension
+ * rules rather than a list of {@code dimension=preset[@worldstyle]} lines.
+ *
+ * <p>{@link UrbexConfig} is the file. This is what it says. The two are separate because the
+ * strings in a file are not the values a decision is made from, and the translation used to happen
+ * wherever a decision needed one: {@code dimensionsWithPresets} was re-parsed on every preset-cache
+ * build <em>and</em> again during start-up validation, and {@code avoidStructures} was parsed into a
+ * lazily-filled nullable static that three unrelated code paths had to remember to invalidate
+ * (issue #130).</p>
+ *
+ * <p>Parsing once, here, also moves every "bad format for config value" message to load time, where
+ * a player can act on it - the same messages used to be logged from a worldgen worker on whichever
+ * chunk first built the cache.</p>
+ *
+ * @param dimensionRules  each {@code dimensionsWithPresets} entry that parsed, in declaration order.
+ *                        A malformed entry is reported and dropped rather than throwing: one bad
+ *                        line should not take the whole list down.
+ * @param selectedPreset  the overworld's own selection, or null if the file names none
+ * @param selectedWorldStyles the overworld's own world styles; a single-entry mix, because this is
+ *                        the overworld-only default for installs that never open the Cities tab, and
+ *                        a mix here would add a third place to look for one setting
+ * @param avoidStructures the structure ids cities keep away from, parsed once
+ */
+public record GlobalConfig(
+        UrbexConfig file,
+        List<DimensionRule> dimensionRules,
+        @Nullable Identifier selectedPreset,
+        WorldStyleMix selectedWorldStyles,
+        Set<Identifier> avoidStructures) {
+
+    /** One {@code dimensionsWithPresets} entry, parsed. */
+    public record DimensionRule(ResourceKey<Level> dimension, PresetChoice choice) {}
+
+    public static final GlobalConfig DEFAULT = of(UrbexConfig.DEFAULT);
+
+    /**
+     * Translates a parsed file.
+     *
+     * <p>The {@code experimentalMultiWorldStyles} gate is applied here, reading the flag off the
+     * same file the entries came from. It used to read the published active config while that config
+     * was being built.</p>
+     */
+    public static GlobalConfig of(UrbexConfig file) {
+        List<DimensionRule> rules = new ArrayList<>();
+        Map<ResourceKey<Level>, String> seen = new LinkedHashMap<>();
+        for (String entry : file.dimensionsWithPresets()) {
+            parseDimensionEntry(entry, file.experimentalMultiWorldStyles()).ifPresent(rule -> {
+                String previous = seen.put(rule.dimension(), entry);
+                if (previous != null) {
+                    Urbex.getLogger().warn("Two dimensionsWithPresets entries name '{}': '{}' is "
+                                    + "replaced by '{}'.", rule.dimension().identifier(), previous, entry);
+                    rules.removeIf(existing -> existing.dimension().equals(rule.dimension()));
+                }
+                rules.add(rule);
+            });
+        }
+
+        Identifier selectedPreset = null;
+        String preset = file.selectedPreset();
+        if (preset != null && !preset.isEmpty()) {
+            try {
+                selectedPreset = DataTools.fromName(preset);
+            } catch (Exception e) {
+                Urbex.getLogger().error("Bad selectedPreset '{}' in config; ignoring it. {}",
+                        preset, e.getMessage());
+            }
+        }
+        WorldStyleMix selectedStyles = Config.DEFAULT_WORLD_STYLE_MIX;
+        String style = file.selectedWorldStyle();
+        if (style != null && !style.isEmpty()) {
+            try {
+                selectedStyles = WorldStyleMix.of(DataTools.fromName(style));
+            } catch (Exception e) {
+                Urbex.getLogger().error("Bad selectedWorldStyle '{}' in config; using '{}'. {}",
+                        style, Config.DEFAULT_WORLD_STYLE, e.getMessage());
+            }
+        }
+
+        Set<Identifier> avoided = file.avoidStructures().stream()
+                .map(GlobalConfig::parseStructureId)
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toUnmodifiableSet());
+
+        return new GlobalConfig(file, List.copyOf(rules), selectedPreset, selectedStyles, avoided);
+    }
+
+    @Nullable
+    private static Identifier parseStructureId(String raw) {
+        try {
+            return Identifier.parse(raw);
+        } catch (Exception e) {
+            Urbex.getLogger().error("Bad structure id '{}' in avoidStructures; ignoring it.", raw);
+            return null;
+        }
+    }
+
+    /**
+     * Parses one {@code dimensionsWithPresets} entry: {@code dimension=preset[@worldstyle]}.
+     * <p>
+     * The preset and worldstyle names must name their namespace: {@link DataTools#fromName} rejects
+     * a bare one rather than defaulting it, so {@code minecraft:overworld=default} is refused and
+     * {@code minecraft:overworld=urbex:default} is not. (The dimension id on the left is parsed by
+     * {@link Identifier#parse} and does still default, to {@code minecraft} - it is a vanilla id,
+     * not a datapack cross-reference.) Malformed entries - wrong arity on either side of {@code =},
+     * or an id that fails to parse - are logged and rejected rather than thrown, so one bad line in
+     * the config doesn't take the whole list down.
+     * <p>
+     * The rejection messages carry {@code e.getMessage()} through, because for the two
+     * {@code fromName} calls that is the only place the "add a namespace, e.g. urbex:default" hint
+     * exists - and a config written before namespaces were mandatory is exactly the case that hits
+     * it, so it is the one message that user will see.
+     */
+    public static Optional<DimensionRule> parseDimensionEntry(String entry, boolean allowMixes) {
+        String[] split = entry.split("=");
+        if (split.length != 2) {
+            Urbex.getLogger().error("Bad format for config value: '{}'! Expected 'dimension=preset[@worldstyle]'.", entry);
+            return Optional.empty();
+        }
+        ResourceKey<Level> dimensionType;
+        try {
+            dimensionType = ResourceKey.create(Registries.DIMENSION, Identifier.parse(split[0]));
+        } catch (Exception e) {
+            Urbex.getLogger().error("Bad dimension id in config value: '{}'!", entry);
+            return Optional.empty();
+        }
+
+        String presetPart = split[1];
+        String presetName = presetPart;
+        WorldStyleMix worldStyles = Config.DEFAULT_WORLD_STYLE_MIX;
+        int at = presetPart.indexOf('@');
+        if (at >= 0) {
+            presetName = presetPart.substring(0, at);
+            String stylePart = presetPart.substring(at + 1);
+            try {
+                // The whole tail, not one id: a single qualified id is just a one-entry mix, so the
+                // pre-mixing form parses unchanged.
+                worldStyles = Config.gateMix(WorldStyleMix.parse(stylePart), allowMixes,
+                        "dimensionsWithPresets entry '" + entry + "'");
+            } catch (Exception e) {
+                Urbex.getLogger().error("Bad worldstyle spec in config value: '{}'! {}", entry, e.getMessage());
+                return Optional.empty();
+            }
+        }
+
+        Identifier presetId;
+        try {
+            presetId = DataTools.fromName(presetName);
+        } catch (Exception e) {
+            Urbex.getLogger().error("Bad preset id in config value: '{}'! {}", entry, e.getMessage());
+            return Optional.empty();
+        }
+
+        return Optional.of(new DimensionRule(dimensionType,
+                new PresetChoice(presetId, worldStyles, Optional.empty())));
+    }
+
+    /** The rule for {@code dimension}, or null. Last declaration wins; see {@link #of}. */
+    @Nullable
+    public PresetChoice ruleFor(ResourceKey<Level> dimension) {
+        for (DimensionRule rule : dimensionRules) {
+            if (rule.dimension().equals(dimension)) {
+                return rule.choice();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -379,7 +379,7 @@ public class CityGenerator {
      * on the generation path (issue #126).
      */
     static AvoidChunk hasBlacklistedStructure(WorldGenLevel level, int chunkX, int chunkZ) {
-        if (!Config.AVOID_VILLAGES.get() && !Config.AVOID_SURFACE_STRUCTURES.get()
+        if (!Config.avoidVillages() && !Config.avoidSurfaceStructures()
                 && !Config.hasAvoidedStructures()) {
             return AvoidChunk.NO;
         }
@@ -403,12 +403,12 @@ public class CityGenerator {
                 if (!entry.getValue().isEmpty()) {
                     Structure structure = entry.getKey();
                     Optional<ResourceKey<Structure>> key = structures.getResourceKey(structure);
-                    if (Config.AVOID_VILLAGES.get()
+                    if (Config.avoidVillages()
                             && key.map(k -> structures.getOrThrow(k).is(StructureTags.VILLAGE)).orElse(false)) {
                         return true;
                     }
                     // Catch-all for structure mods: everything that builds at the surface step
-                    if (Config.AVOID_SURFACE_STRUCTURES.get()
+                    if (Config.avoidSurfaceStructures()
                             && structure.step() == GenerationStep.Decoration.SURFACE_STRUCTURES) {
                         return true;
                     }
@@ -458,7 +458,7 @@ public class CityGenerator {
 
     private void doNormalChunk(ChunkGenContext ctx, ChunkPlan info, ChunkHeightmap heightmap, AvoidChunk avoidChunk) {
 //        debugClearChunk(chunkX, chunkZ, primer);
-        if ((avoidChunk != AvoidChunk.YES || !Config.AVOID_FLATTENING.get()) && profile.isDefault()) {
+        if ((avoidChunk != AvoidChunk.YES || !Config.avoidFlattening()) && profile.isDefault()) {
             correctTerrainShape(ctx, info.coord, heightmap);
 //            flattenChunkToCityBorder(chunkX, chunkZ);
         }
@@ -2000,7 +2000,7 @@ public class CityGenerator {
                 BlockPos pos = info.getRelativePos(rx, oy + y, rz);
                 if (block instanceof SaplingBlock saplingBlock) {
                     BlockState finalB = b;
-                    if (Config.FORCE_SAPLING_GROWTH.get()) {
+                    if (Config.forceSaplingGrowth()) {
                         // The todo runs later, on the server thread, long after this context is gone.
                         // Key the tree it grows on the sapling's position so it is the same tree no
                         // matter when the todo is drained.

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
@@ -31,24 +31,24 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class DimensionCaches {
 
-    public final TimedCache<ChunkCoord, ChunkPlan> chunkPlan = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
-    public final TimedCache<ChunkCoord, ChunkCandidate> candidate = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
-    public final TimedCache<ChunkCoord, Integer> cityLevel = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
-    public final TimedCache<ChunkCoord, CityStyle> cityStyle = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
+    public final TimedCache<ChunkCoord, ChunkPlan> chunkPlan = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, ChunkCandidate> candidate = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, Integer> cityLevel = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, CityStyle> cityStyle = new TimedCache<>(Config::cacheCleanupSeconds);
     /**
      * Which world style governs a chunk, when the world was created with several. Only ever
      * populated for a genuine mix: {@link WorldStyleField#atChunk} short-circuits before reaching
      * the cache when there is one style, so a single-style world does not allocate here at all.
      */
-    public final TimedCache<ChunkCoord, WorldStyle> worldStyle = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
-    public final TimedCache<ChunkCoord, MultiChunk> multiChunk = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
-    public final TimedCache<ChunkCoord, BiomeInfo> biomeInfo = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
+    public final TimedCache<ChunkCoord, WorldStyle> worldStyle = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, MultiChunk> multiChunk = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, BiomeInfo> biomeInfo = new TimedCache<>(Config::cacheCleanupSeconds);
     public final ConcurrentHashMap<ChunkCoord, Railway.RailChunkInfo> railInfo = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<ChunkCoord, Integer> xHighwayLevel = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<ChunkCoord, Integer> zHighwayLevel = new ConcurrentHashMap<>();
-    public final TimedCache<ChunkCoord, ChunkHeightmap> heightmap = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
+    public final TimedCache<ChunkCoord, ChunkHeightmap> heightmap = new TimedCache<>(Config::cacheCleanupSeconds);
     /** Keyed on the scatter area's anchor chunk, not a real chunk coordinate. */
-    public final TimedCache<ChunkCoord, Scattered.AreaScan> scatterAreaScan = new TimedCache<>(Config.CACHE_CLEANUP_SECONDS::get);
+    public final TimedCache<ChunkCoord, Scattered.AreaScan> scatterAreaScan = new TimedCache<>(Config::cacheCleanupSeconds);
 
     /**
      * The city-rarity map is per profile rather than per chunk so independently configured profiles

--- a/src/main/java/dev/krona/urbex/worldgen/LevelTaskQueue.java
+++ b/src/main/java/dev/krona/urbex/worldgen/LevelTaskQueue.java
@@ -117,7 +117,7 @@ public final class LevelTaskQueue {
         // At most what was queued when the pass started: a task that retries goes to the back, and
         // without this limit a queue of nothing but retries would be walked over and over until the
         // count budget ran out, retrying each task several times in one tick.
-        int budget = Math.min(Config.TODO_QUEUE_SIZE.get(), queued);
+        int budget = Math.min(Config.todoQueueSize(), queued);
         long deadline = System.nanoTime() + TIME_BUDGET_NANOS;
         for (int done = 0; done < budget; done++) {
             Entry entry = pending.poll();

--- a/src/main/java/dev/krona/urbex/worldgen/LevelTerrain.java
+++ b/src/main/java/dev/krona/urbex/worldgen/LevelTerrain.java
@@ -46,7 +46,7 @@ public final class LevelTerrain implements TerrainSampler {
 
     @Override
     public ChunkHeightmap heightmap(ChunkCoord chunk) {
-        int heightSampleSize = Config.HEIGHT_SAMPLE_SIZE.get();
+        int heightSampleSize = Config.heightSampleSize();
         // The block this chunk shares a sampled height with, and the coordinate that height is taken
         // at. Both come from HeightSampleGrid so that the tiling is a partition and the sampled
         // coordinate is a function of the block rather than of whichever chunk asked first - see the

--- a/src/main/java/dev/krona/urbex/worldgen/StructureSuppressor.java
+++ b/src/main/java/dev/krona/urbex/worldgen/StructureSuppressor.java
@@ -23,7 +23,7 @@ public class StructureSuppressor {
      * edge of a city keeps the pieces that fall outside it.
      */
     public static boolean suppressedByCity(WorldGenLevel level, ChunkPos chunkPos, BoundingBox structureBox) {
-        if (!Config.STRUCTURES_YIELD_TO_CITIES.get()) {
+        if (!Config.structuresYieldToCities()) {
             return false;
         }
         PlanningContext diminfo = GenerationSession.planningFor(level);

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -1006,8 +1006,8 @@ public class ChunkPlan {
     private static int getCityLevelNormal(ChunkCoord coord, PlanningContext provider, Preset profile) {
         ChunkHeightmap heightmap = provider.heightmap(coord);
         int height = heightmap.getHeight();
-        if (profile.USE_AVG_HEIGHTMAP && Config.HEIGHT_SAMPLE_SIZE.get() > 2) {
-            int sampleSize = Config.HEIGHT_SAMPLE_SIZE.get();
+        if (profile.USE_AVG_HEIGHTMAP && Config.heightSampleSize() > 2) {
+            int sampleSize = Config.heightSampleSize();
             int constX = coord.chunkX() < 0 ? -1 : 1;
             int constZ = coord.chunkZ() < 0 ? -1 : 1;
             int chunkBaseX =  (coord.chunkX() / sampleSize) * sampleSize + (sampleSize / 2 * constX);

--- a/src/test/java/dev/krona/urbex/setup/ExperimentalMixGateTest.java
+++ b/src/test/java/dev/krona/urbex/setup/ExperimentalMixGateTest.java
@@ -5,7 +5,6 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.Bootstrap;
-import net.minecraft.world.level.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,18 +53,19 @@ class ExperimentalMixGateTest {
     }
 
     private static PresetChoice parse(String entry) {
-        Optional<Map.Entry<ResourceKey<Level>, PresetChoice>> parsed = Config.parseDimensionPresetEntry(entry);
+        Optional<GlobalConfig.DimensionRule> parsed =
+                GlobalConfig.parseDimensionEntry(entry, Config.experimentalMultiWorldStyles());
         assertTrue(parsed.isPresent(), "entry should parse: " + entry);
         assertEquals(ResourceKey.create(Registries.DIMENSION, Identifier.parse("minecraft:overworld")),
-                parsed.get().getKey());
-        return parsed.get().getValue();
+                parsed.get().dimension());
+        return parsed.get().choice();
     }
 
     @Test
     void withTheFlagOffAMixedEntryKeepsOnlyItsHeaviestStyle(@TempDir Path dir) throws IOException {
         writeConfig(dir, false);
         Config.loadGlobal(dir);
-        assertFalse(Config.EXPERIMENTAL_MULTI_WORLD_STYLES.get());
+        assertFalse(Config.experimentalMultiWorldStyles());
 
         WorldStyleMix styles = parse(MIXED_ENTRY).worldStyles();
         assertTrue(styles.isSingle());
@@ -77,7 +76,7 @@ class ExperimentalMixGateTest {
     void withTheFlagOnTheWholeMixSurvives(@TempDir Path dir) throws IOException {
         writeConfig(dir, true);
         Config.loadGlobal(dir);
-        assertTrue(Config.EXPERIMENTAL_MULTI_WORLD_STYLES.get());
+        assertTrue(Config.experimentalMultiWorldStyles());
 
         WorldStyleMix styles = parse(MIXED_ENTRY).worldStyles();
         assertFalse(styles.isSingle());

--- a/src/test/java/dev/krona/urbex/setup/PresetChoiceTest.java
+++ b/src/test/java/dev/krona/urbex/setup/PresetChoiceTest.java
@@ -9,7 +9,6 @@ import net.minecraft.world.level.Level;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * {@code dimensionsWithPresets} entries are {@code dimension=preset[@worldstylespec]}. The parser
  * is a small static method so it is testable headless, with no server or registry.
+ * <p>
+ * It takes the {@code experimentalMultiWorldStyles} flag as an argument rather than reading the
+ * published config, which is what lets these cases run without publishing anything: the entries are
+ * parsed when a config is translated, and the flag is in the same file they came from (issue #130).
  */
 class PresetChoiceTest {
 
@@ -33,36 +36,37 @@ class PresetChoiceTest {
 
     @Test
     void parsesDimensionPresetEntry() {
-        Optional<Map.Entry<ResourceKey<Level>, PresetChoice>> parsed =
-                Config.parseDimensionPresetEntry("minecraft:overworld=urbex:rarecities");
+        Optional<GlobalConfig.DimensionRule> parsed = parse("minecraft:overworld=urbex:rarecities");
         assertTrue(parsed.isPresent());
-        assertEquals(dimension("minecraft:overworld"), parsed.get().getKey());
-        assertEquals(Identifier.fromNamespaceAndPath("urbex", "rarecities"), parsed.get().getValue().preset());
-        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, parsed.get().getValue().worldStyles());
-        assertTrue(parsed.get().getValue().overridesJson().isEmpty());
+        assertEquals(dimension("minecraft:overworld"), parsed.get().dimension());
+        assertEquals(Identifier.fromNamespaceAndPath("urbex", "rarecities"), parsed.get().choice().preset());
+        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, parsed.get().choice().worldStyles());
+        assertTrue(parsed.get().choice().overridesJson().isEmpty());
 
-        Optional<Map.Entry<ResourceKey<Level>, PresetChoice>> explicitStyle =
-                Config.parseDimensionPresetEntry("minecraft:the_nether=urbex:cavern@urbex:standard");
+        Optional<GlobalConfig.DimensionRule> explicitStyle =
+                parse("minecraft:the_nether=urbex:cavern@urbex:standard");
         assertTrue(explicitStyle.isPresent());
-        assertEquals(dimension("minecraft:the_nether"), explicitStyle.get().getKey());
-        assertEquals(Identifier.fromNamespaceAndPath("urbex", "cavern"), explicitStyle.get().getValue().preset());
+        assertEquals(dimension("minecraft:the_nether"), explicitStyle.get().dimension());
+        assertEquals(Identifier.fromNamespaceAndPath("urbex", "cavern"), explicitStyle.get().choice().preset());
         assertEquals(WorldStyleMix.of(Identifier.fromNamespaceAndPath("urbex", "standard")),
-                explicitStyle.get().getValue().worldStyles());
+                explicitStyle.get().choice().worldStyles());
 
         // A bare (unqualified) name is rejected, not defaulted to the urbex namespace: the entry
         // is logged and dropped, same as any other malformed entry.
-        assertTrue(Config.parseDimensionPresetEntry("minecraft:overworld=default").isEmpty());
+        assertTrue(parse("minecraft:overworld=default").isEmpty());
     }
 
     @Test
     void malformedEntryIsRejectedWithError() {
-        assertTrue(Config.parseDimensionPresetEntry("junk").isEmpty());
-        assertTrue(Config.parseDimensionPresetEntry("a=b=c=d").isEmpty());
+        assertTrue(parse("junk").isEmpty());
+        assertTrue(parse("a=b=c=d").isEmpty());
         // A malformed style spec takes the whole entry down rather than falling back to the default
         // style: generating with the wrong style would hide a typo for the life of the world.
-        assertTrue(Config.parseDimensionPresetEntry(
-                "minecraft:overworld=urbex:default@urbex:standard*0").isEmpty());
-        assertTrue(Config.parseDimensionPresetEntry(
-                "minecraft:overworld=urbex:default@standard*0.5+urbex:cavern").isEmpty());
+        assertTrue(parse("minecraft:overworld=urbex:default@urbex:standard*0").isEmpty());
+        assertTrue(parse("minecraft:overworld=urbex:default@standard*0.5+urbex:cavern").isEmpty());
+    }
+
+    private static Optional<GlobalConfig.DimensionRule> parse(String entry) {
+        return GlobalConfig.parseDimensionEntry(entry, true);
     }
 }


### PR DESCRIPTION
UrbexConfig is the file. GlobalConfig is what it says: identifiers rather than
strings, dimension rules rather than a list of dimension=preset[@worldstyle]
lines, a set of avoided structure ids rather than a list of names.

The translation used to happen wherever a decision needed one, which cost two
things. dimensionsWithPresets was re-parsed on every preset-cache build and
again during start-up validation, so a malformed entry was reported twice - and
the first time from a worldgen worker, on whichever chunk happened to build the
cache, where nobody can act on it. avoidStructures was parsed into a lazily
filled nullable static that three unrelated paths had to remember to null out,
one of which is how a world override could keep the previous world's list.

Both are parsed when the config is published now, and every "bad format for
config value" message lands at load time.

One consequence worth stating: two dimensionsWithPresets entries naming the
same dimension are now reported. They resolved silently last-writer-wins into a
map; the rule is unchanged, it just says so.

The Supplier<X> facade goes with it. Those constants existed so call sites
written against the NeoForge ModConfigSpec did not have to change when it was
removed (#75) - the spec has been gone for two releases and the shape was only
ever a migration aid. Config.heightSampleSize() reads as what it is.

gateMix gains an overload taking the flag, for the one caller that gates a mix
while the config carrying that flag is still being built. That call used to read
the published config from inside the code publishing it.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>