### PR TITLE
refactor: which selection a world generates with becomes a pure function (#130, 130c)

### DIFF
--- a/src/main/java/dev/krona/urbex/setup/Config.java
+++ b/src/main/java/dev/krona/urbex/setup/Config.java
@@ -17,6 +17,8 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.LevelResource;
 
+import javax.annotation.Nullable;
+
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -206,49 +208,20 @@ public class Config {
         }
 
         UrbexData data = UrbexData.getData(level);
+        WorldSelectionResolver.Resolution resolution = WorldSelectionResolver.resolve(
+                publishedSelection(), savedSelection(data), !data.getSelectedPreset().isEmpty(),
+                configuredSelection(), level.dimension() == Level.OVERWORLD).orElse(null);
         Identifier selectedPreset = null;
         WorldStyleMix selectedWorldStyles = null;
         String selectedOverrides = null;
-
-        // A world that already recorded a choice keeps it, even with a client selection published.
-        // The client fields are how the create-world screen hands its choice to the integrated
-        // server, so they are only ever meant for a world being created - which by definition has
-        // no saved choice yet. Applying them to a world that has one is only reachable when they
-        // outlived the screen that set them (issue #113: abandon world creation, then load an
-        // existing world), and the cost of that was not a wrong preset for one session but a
-        // permanent one: the branch below writes what it resolved into UrbexData, overwriting the
-        // selection that world was created with. PresetSelection.discardPublication clears them at
-        // the source; this makes the overwrite unreachable even if some future path forgets to.
-        boolean worldHasOwnChoice = !data.getSelectedPreset().isEmpty();
-        if (presetFromClient != null && !worldHasOwnChoice) {
-            selectedPreset = presetFromClient;
-            selectedWorldStyles = gateMix(
-                    worldStyleMixFromClient != null ? worldStyleMixFromClient : DEFAULT_WORLD_STYLE_MIX,
-                    "The world being created");
-            selectedOverrides = overridesFromClient;
-            // Remember the client's selection in SavedData.
-            data.setChoice(selectedPreset.toString(), selectedWorldStyles,
-                    selectedOverrides == null ? "" : selectedOverrides);
-        } else {
-            String savedPreset = data.getSelectedPreset();
-            if (!savedPreset.isEmpty()) {
-                selectedPreset = Identifier.tryParse(savedPreset);
-                if (selectedPreset == null) {
-                    Urbex.getLogger().error("Malformed saved preset id '{}' in world data; treating the overworld's selection as unset.", savedPreset);
-                } else {
-                    // getSelectedWorldStyles is itself fail-soft: a corrupted or hand-edited save
-                    // degrades to the default rather than taking a worldgen worker down.
-                    selectedWorldStyles = gateMix(data.getSelectedWorldStyles(), "This world's saved selection");
-                    String savedOverrides = data.getSelectedOverrides();
-                    selectedOverrides = savedOverrides.isEmpty() ? null : savedOverrides;
-                }
-            } else if (level.dimension() == Level.OVERWORLD) {
-                // Parsed when the config was published. The global config's own selection stays a
-                // single id: it is the overworld-only default for installs that never open the
-                // Cities tab, and a mix there would add a third place to look for one setting
-                // without adding any reach.
-                selectedPreset = active.selectedPreset();
-                selectedWorldStyles = active.selectedWorldStyles();
+        if (resolution != null) {
+            WorldSelection selection = resolution.selection();
+            selectedPreset = selection.preset();
+            selectedWorldStyles = selection.worldStyles();
+            selectedOverrides = selection.patch().orElse(null);
+            if (resolution.persist()) {
+                data.setChoice(selectedPreset.toString(), selectedWorldStyles,
+                        selectedOverrides == null ? "" : selectedOverrides);
             }
         }
 
@@ -308,6 +281,54 @@ public class Config {
             }
         }
         return cache;
+    }
+
+    /**
+     * What the create-world screen published, or null.
+     * <p>
+     * The three static fields it arrives in are #73's business; this only reads them.
+     */
+    @Nullable
+    private static WorldSelection publishedSelection() {
+        if (presetFromClient == null) {
+            return null;
+        }
+        return new WorldSelection(presetFromClient,
+                gateMix(worldStyleMixFromClient != null ? worldStyleMixFromClient : DEFAULT_WORLD_STYLE_MIX,
+                        "The world being created"),
+                Optional.ofNullable(overridesFromClient));
+    }
+
+    /**
+     * What this world already recorded, or null.
+     * <p>
+     * Fail-soft throughout: saved data can be hand-edited between sessions, and a malformed id must
+     * degrade to "no selection" rather than taking a worldgen worker down.
+     */
+    @Nullable
+    private static WorldSelection savedSelection(UrbexData data) {
+        String savedPreset = data.getSelectedPreset();
+        if (savedPreset.isEmpty()) {
+            return null;
+        }
+        Identifier preset = Identifier.tryParse(savedPreset);
+        if (preset == null) {
+            Urbex.getLogger().error("Malformed saved preset id '{}' in world data; treating the "
+                    + "overworld's selection as unset.", savedPreset);
+            return null;
+        }
+        // getSelectedWorldStyles is itself fail-soft, for the same reason.
+        String savedOverrides = data.getSelectedOverrides();
+        return new WorldSelection(preset,
+                gateMix(data.getSelectedWorldStyles(), "This world's saved selection"),
+                savedOverrides.isEmpty() ? Optional.empty() : Optional.of(savedOverrides));
+    }
+
+    /** The global config's own selection, or null. Already parsed - see {@link GlobalConfig}. */
+    @Nullable
+    private static WorldSelection configuredSelection() {
+        Identifier preset = active.selectedPreset();
+        return preset == null ? null : new WorldSelection(preset, active.selectedWorldStyles());
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/setup/WorldSelection.java
+++ b/src/main/java/dev/krona/urbex/setup/WorldSelection.java
@@ -1,0 +1,33 @@
+package dev.krona.urbex.setup;
+
+import net.minecraft.resources.Identifier;
+
+import java.util.Optional;
+
+/**
+ * What one world generates with: a preset, the world styles it draws from, and an optional
+ * customization patch on top.
+ *
+ * <p>Three things that always travel together and never did. They arrive from the create-world
+ * screen as three static fields on {@code Config}, are stored in {@code UrbexData} as three strings,
+ * and were carried through the resolution below as three locals - so "is there a selection" was
+ * spelled differently at each step, and the patch could be dropped without the preset noticing
+ * (issue #130).</p>
+ *
+ * <p>The patch stays a {@code String} of {@code PresetDefinition} JSON rather than a decoded overlay.
+ * Decoding it is fail-soft and happens where the preset is resolved, because the two sources it can
+ * come from differ in how much they can be trusted: a client publication was encoded by
+ * {@code PresetSelection.publish} moments ago, while saved data may have been hand-edited between
+ * sessions, and a corrupt one must not refuse the level.</p>
+ */
+public record WorldSelection(Identifier preset, WorldStyleMix worldStyles, Optional<String> patch) {
+
+    public WorldSelection(Identifier preset, WorldStyleMix worldStyles) {
+        this(preset, worldStyles, Optional.empty());
+    }
+
+    /** The choice this selection makes for one dimension. */
+    public PresetChoice asChoice() {
+        return new PresetChoice(preset, worldStyles, patch);
+    }
+}

--- a/src/main/java/dev/krona/urbex/setup/WorldSelectionResolver.java
+++ b/src/main/java/dev/krona/urbex/setup/WorldSelectionResolver.java
@@ -1,0 +1,71 @@
+package dev.krona.urbex.setup;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/**
+ * Which of the three places a world's selection can come from wins.
+ *
+ * <p>A pure function of its three arguments: no level, no saved data, no registries, no static
+ * state. The precedence itself is unchanged - what changes is that it can be read in one place and
+ * exercised without a server (issue #130). It used to be interleaved with reading saved data,
+ * writing saved data, parsing identifiers, gating world-style mixes and resolving against the live
+ * registries, in one method reached from a worldgen worker.</p>
+ */
+public final class WorldSelectionResolver {
+
+    private WorldSelectionResolver() {
+    }
+
+    /**
+     * A resolved selection, and whether the world should record it.
+     *
+     * <p>Only a client publication is recorded. The other two sources are already durable - saved
+     * data is where the record would go, and the global config is a default a player can change
+     * between sessions and expect to take effect.</p>
+     */
+    public record Resolution(WorldSelection selection, boolean persist) {}
+
+    /**
+     * @param published    what the create-world screen handed the integrated server, or null
+     * @param saved        what this world already recorded, or null if it recorded nothing
+     *                     <em>or</em> if what it recorded will not parse
+     * @param hasRecord    whether this world recorded anything at all. Separate from
+     *                     {@code saved != null} on purpose: a world whose recorded selection is
+     *                     corrupt is still a world that was created once, and must not have a stale
+     *                     publication written over it - see below.
+     * @param configured   the global config's own selection, or null. Overworld-only: it is the
+     *                     default for installs that never open the Cities tab.
+     * @param overworld    whether the level being resolved is the overworld
+     */
+    public static Optional<Resolution> resolve(@Nullable WorldSelection published,
+                                               @Nullable WorldSelection saved,
+                                               boolean hasRecord,
+                                               @Nullable WorldSelection configured,
+                                               boolean overworld) {
+        // A world that already recorded a choice keeps it, even with a client selection published.
+        // The published selection is how the create-world screen hands its choice to the integrated
+        // server, so it is only ever meant for a world being created - which by definition has no
+        // saved choice yet. Applying it to a world that has one is only reachable when it outlived
+        // the screen that set it (issue #113: abandon world creation, then load an existing world),
+        // and the cost of that was not a wrong preset for one session but a permanent one, because
+        // a published selection is written into the world's saved data. PresetSelection
+        // .discardPublication clears it at the source; this makes the overwrite unreachable even if
+        // some future path forgets to.
+        if (published != null && !hasRecord) {
+            return Optional.of(new Resolution(published, true));
+        }
+        if (saved != null) {
+            return Optional.of(new Resolution(saved, false));
+        }
+        // Gated on hasRecord as well, not only on saved: a world that recorded a selection which
+        // will not parse gets no selection at all rather than the global default. Substituting a
+        // different preset into a world that was created with one is the expensive kind of wrong -
+        // the terrain is written once - and the log line naming the malformed id is the thing the
+        // player can act on. An unrecorded world has nothing to contradict.
+        if (overworld && !hasRecord && configured != null) {
+            return Optional.of(new Resolution(configured, false));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/test/java/dev/krona/urbex/setup/WorldSelectionResolverTest.java
+++ b/src/test/java/dev/krona/urbex/setup/WorldSelectionResolverTest.java
@@ -1,0 +1,108 @@
+package dev.krona.urbex.setup;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which of the three sources of a world's selection wins.
+ * <p>
+ * The precedence is unchanged; what is new is that it can be exercised at all. It used to be
+ * interleaved with reading saved data, writing saved data, parsing identifiers, gating world-style
+ * mixes and resolving ids against the live registries, inside one method reached from a worldgen
+ * worker - so the only way to see it was to run a server (issue #130).
+ */
+class WorldSelectionResolverTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static final WorldSelection PUBLISHED = selection("urbex:published");
+    private static final WorldSelection SAVED = selection("urbex:saved");
+    private static final WorldSelection CONFIGURED = selection("urbex:configured");
+
+    @Test
+    void aNewWorldTakesWhatTheCreateWorldScreenPublished() {
+        WorldSelectionResolver.Resolution resolution =
+                resolve(PUBLISHED, null, false, CONFIGURED, true).orElseThrow();
+
+        assertEquals(PUBLISHED, resolution.selection());
+        assertTrue(resolution.persist(), "and records it, so the next load does not depend on the "
+                + "screen's leftovers");
+    }
+
+    @Test
+    void aWorldThatRecordedAChoiceKeepsIt() {
+        WorldSelectionResolver.Resolution resolution =
+                resolve(PUBLISHED, SAVED, true, CONFIGURED, true).orElseThrow();
+
+        assertEquals(SAVED, resolution.selection());
+        assertFalse(resolution.persist(), "it is already where it would be written");
+    }
+
+    /**
+     * The #113 corner, and the reason {@code hasRecord} is a separate argument. A world whose
+     * recorded selection will not parse is still a world that was created once; treating it as
+     * unrecorded would let a publication that outlived the create-world screen be written over it -
+     * permanently, because a publication is persisted - or let the global default silently replace
+     * the preset that world's terrain was written from.
+     */
+    @Test
+    void aWorldWithACorruptRecordGetsNoSelectionRatherThanSomebodyElses() {
+        assertTrue(resolve(PUBLISHED, null, true, CONFIGURED, true).isEmpty(),
+                "not the stale publication, which would be written into the save");
+        assertTrue(resolve(null, null, true, CONFIGURED, true).isEmpty(),
+                "and not the global default either - the log line naming the malformed id is what "
+                        + "the player can act on");
+    }
+
+    @Test
+    void theConfigsOwnSelectionIsTheOverworldsDefault() {
+        WorldSelectionResolver.Resolution resolution =
+                resolve(null, null, false, CONFIGURED, true).orElseThrow();
+
+        assertEquals(CONFIGURED, resolution.selection());
+        assertFalse(resolution.persist(),
+                "a default a player can change between sessions must not be frozen into the world");
+    }
+
+    @Test
+    void theConfigsOwnSelectionDoesNotReachOtherDimensions() {
+        assertTrue(resolve(null, null, false, CONFIGURED, false).isEmpty(),
+                "selectedPreset is the overworld's; other dimensions are named by "
+                        + "dimensionsWithPresets");
+    }
+
+    @Test
+    void aWorldWithNoSelectionAnywhereHasNone() {
+        assertTrue(resolve(null, null, false, null, true).isEmpty());
+    }
+
+    @Test
+    void aSavedSelectionReachesEveryDimensionNotJustTheOverworld() {
+        // Unlike the config's own selection: a saved choice is this world's, and the nether entry
+        // derived from GENERATE_NETHER depends on resolving it outside the overworld too.
+        assertEquals(SAVED, resolve(null, SAVED, true, null, false).orElseThrow().selection());
+    }
+
+    private static Optional<WorldSelectionResolver.Resolution> resolve(
+            WorldSelection published, WorldSelection saved, boolean hasRecord,
+            WorldSelection configured, boolean overworld) {
+        return WorldSelectionResolver.resolve(published, saved, hasRecord, configured, overworld);
+    }
+
+    private static WorldSelection selection(String preset) {
+        return new WorldSelection(Identifier.parse(preset), Config.DEFAULT_WORLD_STYLE_MIX);
+    }
+}


### PR DESCRIPTION
A world's selection can come from three places - what the create-world screen
published, what the world recorded, and the global config's own default - and
the rule for which wins was interleaved with reading saved data, writing saved
data, parsing identifiers, gating world-style mixes and resolving ids against
the live registries, inside one method reached from a worldgen worker. The only
way to see the rule was to run a server.

WorldSelectionResolver.resolve is that rule and nothing else: five arguments in,
a resolution out, no level, no saved data, no registries, no static state. The
precedence is unchanged, including both corners that are easy to get wrong and
now have tests:

  - a world that recorded a choice keeps it even with a publication present -
    a publication that outlived its screen would otherwise be written into the
    save, permanently (#113);
  - a world whose record will not parse is still a world that was created once,
    so it gets no selection rather than the publication or the global default.
    That is why hasRecord is an argument of its own and not "saved != null".

WorldSelection is the three values that always travelled together and never had
a name: preset, world styles, and the optional customization patch. It is not
versioned yet - the version earns its keep at the transport boundary, which is
#73, and adding one here would change the saved format for no reader.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>