### PR TITLE
refactor: the create-world screen hands over one value, not three fields (#73, #130, 130d)

### DIFF
--- a/src/main/java/dev/krona/urbex/gui/PresetSelection.java
+++ b/src/main/java/dev/krona/urbex/gui/PresetSelection.java
@@ -8,6 +8,8 @@ import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.Presets;
 import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.setup.WorldSelection;
+import dev.krona.urbex.setup.WorldSelectionHandoff;
 import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
 import dev.krona.urbex.worldgen.lost.regassets.data.DataTools;
 import net.minecraft.network.chat.Component;
@@ -18,6 +20,7 @@ import dev.krona.urbex.setup.WorldStyleMix;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Client-side state for "which Urbex preset generates this world", registry-driven since Task 4:
@@ -248,17 +251,16 @@ public final class PresetSelection {
             worldStyles = Config.DEFAULT_WORLD_STYLE_MIX;
         }
         worldStyles = Config.gateMix(worldStyles, "The re-created world's saved selection");
-        // Validated BEFORE publishing, not after: Config.overridesFromClient is read on a worldgen
-        // worker thread the moment a chunk generates (DimensionRuntime.create), so an unparseable
-        // string must never reach it - publishing it and only catching the parse failure later (in
+        // Validated BEFORE publishing, not after: the published patch is read on a worldgen worker
+        // thread the moment a chunk generates (DimensionRuntime.create), so an unparseable string
+        // must never reach it - publishing it and only catching the parse failure later (in
         // reconcilePendingRestore's best-effort visual reconciliation) would leave the bad JSON sitting
-        // in Config while the visual selection quietly fell back to plain.
+        // in the handoff while the visual selection quietly fell back to plain.
         String overrides = validatedOverrides(overridesJson, presetId);
 
         Config.resetPresetCache();
-        Config.presetFromClient = presetId;
-        Config.worldStyleMixFromClient = worldStyles;
-        Config.overridesFromClient = overrides;
+        WorldSelectionHandoff.publish(new WorldSelection(presetId, worldStyles,
+                Optional.ofNullable(overrides)));
         Urbex.getLogger().info("Restored Urbex preset '{}' for world re-creation", presetId);
 
         this.selectedWorldStyles = worldStyles;
@@ -336,22 +338,19 @@ public final class PresetSelection {
      * world would generate with just as much as publishing does.
      */
     public void discardPublication() {
-        if (Config.presetFromClient == null && Config.worldStyleMixFromClient == null
-                && Config.overridesFromClient == null) {
+        if (!WorldSelectionHandoff.isPending()) {
             return;
         }
         Config.resetPresetCache();
-        Config.presetFromClient = null;
-        Config.worldStyleMixFromClient = null;
-        Config.overridesFromClient = null;
+        WorldSelectionHandoff.discard();
         Urbex.getLogger().debug("World creation abandoned; discarded the published Urbex selection");
     }
 
     /**
-     * Publishes the current selection so it reaches world generation: the three {@link Config}
-     * fields the server reads in {@code Config.buildPresetCache}.
+     * Publishes the current selection so it reaches world generation, through
+     * {@link WorldSelectionHandoff}.
      * <ul>
-     *   <li>Disabled: all three {@code null}.</li>
+     *   <li>Disabled: nothing published.</li>
      *   <li>A plain built-in entry: its own id, the effective worldStyle, no overrides.</li>
      *   <li>The transient customized entry: the <em>base</em> preset id it was customized from
      *       (carried, unchanged, in {@code Preset.getId()} through every {@link Preset#copy()}), the
@@ -365,25 +364,22 @@ public final class PresetSelection {
         Config.resetPresetCache();
 
         if (DISABLED_ID.equals(entry.id()) || entry.preset() == null) {
-            Config.presetFromClient = null;
-            Config.worldStyleMixFromClient = null;
-            Config.overridesFromClient = null;
+            WorldSelectionHandoff.discard();
             return;
         }
 
         // Gated here as well as server-side: with experimentalMultiWorldStyles off, what the client
         // publishes must already be what a non-opted-in install would generate.
-        Config.worldStyleMixFromClient = Config.gateMix(effectiveWorldStyles(), "The world being created");
+        WorldStyleMix worldStyles = Config.gateMix(effectiveWorldStyles(), "The world being created");
 
         if (CUSTOMIZED_ID.equals(entry.id())) {
             Preset preset = entry.preset();
-            Config.presetFromClient = preset.getId();
             PresetDefinition re = preset.toDefinition();
             JsonElement json = PresetDefinition.CODEC.encodeStart(JsonOps.INSTANCE, re).getOrThrow();
-            Config.overridesFromClient = GSON.toJson(json);
+            WorldSelectionHandoff.publish(new WorldSelection(preset.getId(), worldStyles,
+                    Optional.of(GSON.toJson(json))));
         } else {
-            Config.presetFromClient = entry.id();
-            Config.overridesFromClient = null;
+            WorldSelectionHandoff.publish(new WorldSelection(entry.id(), worldStyles));
         }
     }
 }

--- a/src/main/java/dev/krona/urbex/setup/Config.java
+++ b/src/main/java/dev/krona/urbex/setup/Config.java
@@ -152,15 +152,8 @@ public class Config {
      */
     private static volatile Map<ResourceKey<Level>, PresetChoice> dimensionPresetCache = null;
 
-    // Selection as published by the client.
-    public static Identifier presetFromClient = null;
-    public static WorldStyleMix worldStyleMixFromClient = null;
-    public static String overridesFromClient = null;
-
     public static void reset() {
-        presetFromClient = null;
-        worldStyleMixFromClient = null;
-        overridesFromClient = null;
+        WorldSelectionHandoff.discard();
         dimensionPresetCache = null;
         active = global;
     }
@@ -284,19 +277,20 @@ public class Config {
     }
 
     /**
-     * What the create-world screen published, or null.
+     * What the create-world screen published, or null. See {@link WorldSelectionHandoff}.
      * <p>
-     * The three static fields it arrives in are #73's business; this only reads them.
+     * Gated again on the way out, not only where it was published: the flag can be off on the
+     * install that reads a publication even if it was on where one was written, and a mix must never
+     * reach generation on an install that never opted in.
      */
     @Nullable
     private static WorldSelection publishedSelection() {
-        if (presetFromClient == null) {
+        WorldSelection published = WorldSelectionHandoff.pending();
+        if (published == null) {
             return null;
         }
-        return new WorldSelection(presetFromClient,
-                gateMix(worldStyleMixFromClient != null ? worldStyleMixFromClient : DEFAULT_WORLD_STYLE_MIX,
-                        "The world being created"),
-                Optional.ofNullable(overridesFromClient));
+        return new WorldSelection(published.preset(),
+                gateMix(published.worldStyles(), "The world being created"), published.patch());
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/setup/WorldSelectionHandoff.java
+++ b/src/main/java/dev/krona/urbex/setup/WorldSelectionHandoff.java
@@ -1,0 +1,97 @@
+package dev.krona.urbex.setup;
+
+import dev.krona.urbex.Urbex;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * How the create-world screen tells the integrated server what the player chose.
+ *
+ * <p>One slot, one writer (the screen), one reader (the first level load of the server it starts).
+ * What it replaces is three {@code public static} fields on {@code Config} - {@code presetFromClient},
+ * {@code worldStyleMixFromClient}, {@code overridesFromClient} - written individually from the GUI,
+ * read individually from a worldgen worker, and cleared individually in three places. Nothing said
+ * they belonged together, so "is a selection pending" was spelled three ways and a clear that missed
+ * one field left a partial selection behind (issues #73, #130).</p>
+ *
+ * <h2>What this is not</h2>
+ *
+ * <p><strong>It is not client/server synchronization.</strong> It works because the create-world
+ * screen and the integrated server it starts are the same process. A dedicated server has no client
+ * to hear from and never reads this: its operator names a preset in
+ * {@code <world>/serverconfig/urbex.json}, and the world records it on first load like any other.
+ * A client connecting to a dedicated server neither publishes nor learns the server's selection.</p>
+ *
+ * <p>That gap is what issue #73 is about, and closing it needs a configuration-phase handshake -
+ * a protocol, with a version on the wire and a compatibility answer for a client that does not have
+ * the mod. The version below is the first half of that: it is checked on read, so a future
+ * handshake can be introduced knowing that a stale in-process publication cannot be mistaken for
+ * one. Until then, this boundary is honest about being singleplayer-only rather than looking like
+ * a sync that quietly does not work.</p>
+ */
+public final class WorldSelectionHandoff {
+
+    /**
+     * The shape of what is handed over. Bump when {@link WorldSelection}'s meaning changes in a way
+     * a reader must not guess about - a new component whose absence is not the same as a default, or
+     * a changed interpretation of the patch.
+     */
+    public static final int VERSION = 1;
+
+    private record Handoff(int version, WorldSelection selection) {}
+
+    /**
+     * Written on the render thread by the create-world screen, read on a worldgen worker by the
+     * level load. Atomic so a reader sees a whole selection or none - which is exactly what three
+     * separate fields could not promise.
+     */
+    private static final AtomicReference<Handoff> SLOT = new AtomicReference<>();
+
+    private WorldSelectionHandoff() {
+    }
+
+    /** Publishes the screen's choice for the server it is about to start. */
+    public static void publish(WorldSelection selection) {
+        SLOT.set(new Handoff(VERSION, selection));
+    }
+
+    /**
+     * Drops whatever was published.
+     * <p>
+     * Called when the screen closes without creating a world. A publication that outlives its screen
+     * is how an abandoned world creation used to reach the <em>next</em> world loaded in the same
+     * session (issue #113); {@link WorldSelectionResolver} refuses to apply one to a world that
+     * already has a record, but this is where it stops existing.
+     */
+    public static void discard() {
+        SLOT.set(null);
+    }
+
+    /**
+     * What the screen published, or null. Reading does not consume it: the preset cache it feeds is
+     * rebuilt when a world's config overrides are applied, and a selection that vanished on first
+     * read would not survive that.
+     */
+    @Nullable
+    public static WorldSelection pending() {
+        Handoff handoff = SLOT.get();
+        if (handoff == null) {
+            return null;
+        }
+        if (handoff.version() != VERSION) {
+            // Unreachable in one process, where both sides are the same build. It is checked anyway
+            // because that stops being true the moment this becomes a wire protocol, and a version
+            // nobody checks is a version that does not exist.
+            Urbex.getLogger().error("Ignoring a world selection published at version {}; this build "
+                    + "speaks version {}.", handoff.version(), VERSION);
+            return null;
+        }
+        return handoff.selection();
+    }
+
+    /** Whether anything is published. */
+    public static boolean isPending() {
+        return SLOT.get() != null;
+    }
+}

--- a/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
+++ b/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.gui;
 
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.setup.WorldSelectionHandoff;
 import dev.krona.urbex.setup.WorldStyleMix;
 import net.minecraft.SharedConstants;
 import net.minecraft.network.chat.Component;
@@ -17,6 +18,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -131,7 +133,7 @@ class PresetSelectionTest {
     }
 
     @Test
-    void disabledEntryPublishesAllThreeConfigFieldsNull() {
+    void theDisabledEntryPublishesNothingAtAll() {
         PresetSelection selection = new PresetSelection();
         selection.setAvailablePresets(List.of(entry("cavern")));
         selection.select(id("cavern"));
@@ -139,9 +141,11 @@ class PresetSelectionTest {
 
         selection.publish();
 
-        assertNull(Config.presetFromClient);
-        assertNull(Config.worldStyleMixFromClient);
-        assertNull(Config.overridesFromClient);
+        // One absence, not three nulls that a reader has to agree about. Publishing Disabled after
+        // publishing something else has to clear it, which is why publish() discards rather than
+        // returning early.
+        assertNull(WorldSelectionHandoff.pending());
+        assertFalse(WorldSelectionHandoff.isPending());
     }
 
     @Test
@@ -152,9 +156,9 @@ class PresetSelectionTest {
 
         selection.publish();
 
-        assertEquals(id("cavern"), Config.presetFromClient);
-        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, Config.worldStyleMixFromClient);
-        assertNull(Config.overridesFromClient);
+        assertEquals(id("cavern"), WorldSelectionHandoff.pending().preset());
+        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, WorldSelectionHandoff.pending().worldStyles());
+        assertTrue(WorldSelectionHandoff.pending().patch().isEmpty());
     }
 
     @Test
@@ -167,9 +171,9 @@ class PresetSelectionTest {
 
         selection.publish();
 
-        assertEquals(id("cavern"), Config.presetFromClient);
-        assertEquals(WorldStyleMix.of(id("lcmt")), Config.worldStyleMixFromClient);
-        assertNull(Config.overridesFromClient);
+        assertEquals(id("cavern"), WorldSelectionHandoff.pending().preset());
+        assertEquals(WorldStyleMix.of(id("lcmt")), WorldSelectionHandoff.pending().worldStyles());
+        assertTrue(WorldSelectionHandoff.pending().patch().isEmpty());
     }
 
     @Test
@@ -183,14 +187,14 @@ class PresetSelectionTest {
         selection.applyCustomized(copy);
         selection.publish();
 
-        assertEquals(id("default"), Config.presetFromClient, "the base preset id, not the sentinel");
-        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, Config.worldStyleMixFromClient);
-        assertNotNull(Config.overridesFromClient);
+        assertEquals(id("default"), WorldSelectionHandoff.pending().preset(), "the base preset id, not the sentinel");
+        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, WorldSelectionHandoff.pending().worldStyles());
+        assertNotNull(WorldSelectionHandoff.pending().patch().orElse(null));
 
         // The published JSON is a real, parseable PresetDefinition overlay (not a stringified profile).
         com.mojang.serialization.DataResult<dev.krona.urbex.worldgen.lost.regassets.PresetDefinition> parsed =
                 dev.krona.urbex.worldgen.lost.regassets.PresetDefinition.CODEC.parse(com.mojang.serialization.JsonOps.INSTANCE,
-                        com.google.gson.JsonParser.parseString(Config.overridesFromClient));
+                        com.google.gson.JsonParser.parseString(WorldSelectionHandoff.pending().patch().orElse(null)));
         assertTrue(parsed.isSuccess(), "overridesFromClient must decode as a PresetDefinition: " + parsed);
         assertEquals(0.5, parsed.getOrThrow().cities().orElseThrow().cityChance().orElseThrow(), 1e-9);
     }
@@ -206,7 +210,7 @@ class PresetSelectionTest {
 
         selection.publish();
 
-        assertEquals(WorldStyleMix.of(id("lcmt")), Config.worldStyleMixFromClient);
+        assertEquals(WorldStyleMix.of(id("lcmt")), WorldSelectionHandoff.pending().worldStyles());
     }
 
     // ---- restore() (Re-Create flow, issue #85) --------------------------------------------------
@@ -217,7 +221,7 @@ class PresetSelectionTest {
 
         selection.restore("", "", "");
 
-        assertNull(Config.presetFromClient);
+        assertNull(WorldSelectionHandoff.pending());
     }
 
     @Test
@@ -226,7 +230,7 @@ class PresetSelectionTest {
 
         selection.restore("not a valid identifier!!", "", "");
 
-        assertNull(Config.presetFromClient);
+        assertNull(WorldSelectionHandoff.pending());
     }
 
     @Test
@@ -237,9 +241,9 @@ class PresetSelectionTest {
 
         selection.restore("urbex:rare", "", "");
 
-        assertEquals(id("rare"), Config.presetFromClient);
-        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, Config.worldStyleMixFromClient);
-        assertNull(Config.overridesFromClient);
+        assertEquals(id("rare"), WorldSelectionHandoff.pending().preset());
+        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, WorldSelectionHandoff.pending().worldStyles());
+        assertTrue(WorldSelectionHandoff.pending().patch().isEmpty());
     }
 
     @Test
@@ -248,7 +252,7 @@ class PresetSelectionTest {
 
         selection.restore("urbex:rare", "urbex:lcmt", "");
 
-        assertEquals(WorldStyleMix.of(id("lcmt")), Config.worldStyleMixFromClient);
+        assertEquals(WorldStyleMix.of(id("lcmt")), WorldSelectionHandoff.pending().worldStyles());
     }
 
     @Test
@@ -257,12 +261,12 @@ class PresetSelectionTest {
 
         selection.restore("urbex:default", "", "{\"cities\":{\"cityChance\":0.9}}");
 
-        assertEquals(id("default"), Config.presetFromClient);
-        assertEquals("{\"cities\":{\"cityChance\":0.9}}", Config.overridesFromClient);
+        assertEquals(id("default"), WorldSelectionHandoff.pending().preset());
+        assertEquals("{\"cities\":{\"cityChance\":0.9}}", WorldSelectionHandoff.pending().patch().orElse(null));
     }
 
     /**
-     * Regression: an unparseable overridesJson must never reach {@code Config.overridesFromClient} -
+     * Regression: an unparseable overridesJson must never reach {@code WorldSelectionHandoff.pending().patch().orElse(null)} -
      * that field is read when a level loads and its runtime is built
      * ({@code DimensionRuntime.create}'s {@code PresetDefinition.CODEC.parse(...).getOrThrow()}), so a
      * corrupted/hand-edited save's garbage JSON must be rejected before publish, not after.
@@ -273,9 +277,9 @@ class PresetSelectionTest {
 
         selection.restore("urbex:default", "", "{not valid json at all");
 
-        assertEquals(id("default"), Config.presetFromClient, "the preset id itself is still restored");
-        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, Config.worldStyleMixFromClient);
-        assertNull(Config.overridesFromClient, "malformed overrides must never reach Config");
+        assertEquals(id("default"), WorldSelectionHandoff.pending().preset(), "the preset id itself is still restored");
+        assertEquals(Config.DEFAULT_WORLD_STYLE_MIX, WorldSelectionHandoff.pending().worldStyles());
+        assertTrue(WorldSelectionHandoff.pending().patch().isEmpty(), "malformed overrides must never reach Config");
     }
 
     @Test

--- a/src/test/java/dev/krona/urbex/gui/WorldStyleSelectionTest.java
+++ b/src/test/java/dev/krona/urbex/gui/WorldStyleSelectionTest.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.gui;
 
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.setup.WorldSelectionHandoff;
 import dev.krona.urbex.setup.WorldStyleMix;
 import net.minecraft.SharedConstants;
 import net.minecraft.resources.Identifier;
@@ -16,11 +17,12 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * worldStyle is orthogonal to the chosen preset (spec 1a): since Task 4 a {@link Preset} carries no
  * worldStyle field of its own at all, so switching styles never edits or clones a preset - it is
- * simply its own value published alongside {@code Config.presetFromClient}. The enumeration of
+ * simply its own value published alongside {@code WorldSelectionHandoff.pending().preset()}. The enumeration of
  * registered styles needs a live datapack registry that can't be built headless, so the state under
  * test takes the available style ids injected via {@link PresetSelection#setAvailableWorldStyles(List)} -
  * exactly what the Cities tab feeds it from the real registry. Everything else here is pure state.
@@ -80,10 +82,10 @@ class WorldStyleSelectionTest {
         assertEquals("urbex:lcmt", selection.effectiveWorldStyle());
 
         selection.publish();
-        // A worldStyle choice publishes as its own Config field - no preset customization involved.
-        assertEquals(id("default"), Config.presetFromClient);
-        assertEquals(WorldStyleMix.parse("urbex:lcmt"), Config.worldStyleMixFromClient);
-        assertNull(Config.overridesFromClient);
+        // A worldStyle choice publishes alongside the preset - no customization involved.
+        assertEquals(id("default"), WorldSelectionHandoff.pending().preset());
+        assertEquals(WorldStyleMix.parse("urbex:lcmt"), WorldSelectionHandoff.pending().worldStyles());
+        assertTrue(WorldSelectionHandoff.pending().patch().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Config.presetFromClient, worldStyleMixFromClient and overridesFromClient were
three public static fields written individually from the GUI, read individually
from a worldgen worker, and cleared individually in three places. Nothing said
they belonged together, so "is a selection pending" was spelled three ways and
a clear that missed one field left a partial selection behind.

WorldSelectionHandoff is one slot holding one WorldSelection, atomically, so a
reader sees a whole selection or none. It has a version, checked on read.

**What this is and is not.** It is not client/server synchronization. It works
because the create-world screen and the integrated server it starts are the same
process; a dedicated server has no client to hear from and never reads it, and a
client connecting to one neither publishes nor learns the server's selection.
That gap is what #73 is actually about and it stays open here - closing it needs
a configuration-phase handshake, with a version on the wire and an answer for a
client without the mod. The version is the first half of that groundwork; until
the rest exists, this boundary at least says out loud that it is singleplayer-
only rather than looking like a sync that quietly does not work.

The other half of #73's "Decide:" is already settled: the half-registered
PacketReturnProfileToClient and the network package are gone. What remains of
that half is the HORIZON/FOG_* preset fields, which no renderer reads on any
side - dead in singleplayer too, not only in multiplayer. Removing them is a
datapack schema change, so it is filed rather than smuggled in here.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>