### PR TITLE
refactor: every read of a preset field goes through an accessor (#10, 10a)

### DIFF
--- a/src/main/java/dev/krona/urbex/commands/CommandDebug.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandDebug.java
@@ -91,9 +91,9 @@ public class CommandDebug implements Command<CommandSourceStack> {
         ChunkHeightmap heightmap = dimInfo.heightmap(info.coord);
         line(context, "Chunk height (heightmap): " + heightmap.getHeight());
 
-        line(context, "dimInfo.preset().BUILDING_MINFLOORS = " + dimInfo.preset().BUILDING_MINFLOORS);
-        line(context, "dimInfo.preset().BUILDING_MAXFLOORS = " + dimInfo.preset().BUILDING_MAXFLOORS);
-        line(context, "dimInfo.preset().CITY_CHANCE = " + dimInfo.preset().CITY_CHANCE);
+        line(context, "buildingMinFloors = " + dimInfo.preset().buildingMinFloors());
+        line(context, "buildingMaxFloors = " + dimInfo.preset().buildingMaxFloors());
+        line(context, "cityChance = " + dimInfo.preset().cityChance());
         line(context, "info.isOcean() = " + info.isOcean());
 
         printRoadDebug(context, info, dimInfo);
@@ -141,7 +141,7 @@ public class CommandDebug implements Command<CommandSourceStack> {
             line(context, "road.bridgeSpan = " + span.orientation()
                     + " (" + span.fromX() + ", " + span.fromZ() + ") -> (" + span.toX() + ", " + span.toZ() + ")");
         }
-        line(context, "road.conflictPolicy = " + dimInfo.preset().MULTI_BUILDING_STREET_CONFLICT);
+        line(context, "road.conflictPolicy = " + dimInfo.preset().multiBuildingStreetConflict());
         if (info.multiBuildingPos.isMulti() && info.multiBuilding != null) {
             line(context, "road.multiBuilding = " + info.multiBuilding.getName());
         } else {

--- a/src/main/java/dev/krona/urbex/commands/CommandEditPart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandEditPart.java
@@ -41,7 +41,7 @@ public class CommandEditPart implements Command<CommandSourceStack> {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        if (!dimInfo.preset().EDITMODE) {
+        if (!dimInfo.preset().editMode()) {
             context.getSource().sendFailure(Component.literal("This world was not created with edit mode enabled. This command is not possible!"));
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/commands/CommandListParts.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandListParts.java
@@ -40,7 +40,7 @@ public class CommandListParts implements Command<CommandSourceStack> {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        if (!dimInfo.preset().EDITMODE) {
+        if (!dimInfo.preset().editMode()) {
             context.getSource().sendFailure(Component.literal("This world was not created with edit mode enabled. This command is not possible!"));
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/commands/CommandLocatePart.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandLocatePart.java
@@ -54,7 +54,7 @@ public class CommandLocatePart implements Command<CommandSourceStack> {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        if (!dimInfo.preset().EDITMODE) {
+        if (!dimInfo.preset().editMode()) {
             context.getSource().sendFailure(Component.literal("This world was not created with edit mode enabled. This command is not possible!"));
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/commands/CommandResumeEdit.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandResumeEdit.java
@@ -40,7 +40,7 @@ public class CommandResumeEdit implements Command<CommandSourceStack> {
             context.getSource().sendFailure(Component.literal("This dimension doesn't support Urbex!"));
             return 0;
         }
-        if (!dimInfo.preset().EDITMODE) {
+        if (!dimInfo.preset().editMode()) {
             context.getSource().sendFailure(Component.literal("This world was not created with edit mode enabled. This command is not possible!"));
             return 0;
         }

--- a/src/main/java/dev/krona/urbex/config/Preset.java
+++ b/src/main/java/dev/krona/urbex/config/Preset.java
@@ -583,4 +583,488 @@ public class Preset {
                 Optional.of(spawn),
                 Optional.of(misc));
     }
+
+    // ------------------------------------------------------------------------ accessors
+
+    /*
+     * One per field, named for the JSON key its codec reads it from - the name a datapack author
+     * already uses for it. Step 1 of issue #10: the fields are still public here, so nothing changes
+     * except that no caller depends on them being. Making them private is the next commit, and that
+     * is the one where the compiler enumerates every writer.
+     */
+    public LandscapeType landscapeType() {
+        return LANDSCAPE_TYPE;
+    }
+
+    public int groundLevel() {
+        return GROUNDLEVEL;
+    }
+
+    public int seaLevel() {
+        return SEALEVEL;
+    }
+
+    public String liquidBlock() {
+        return LIQUID_BLOCK;
+    }
+
+    public String baseBlock() {
+        return BASE_BLOCK;
+    }
+
+    public int bedrockLayer() {
+        return BEDROCK_LAYER;
+    }
+
+    public int terrainFixLowerMinOffset() {
+        return TERRAIN_FIX_LOWER_MIN_OFFSET;
+    }
+
+    public int terrainFixLowerMaxOffset() {
+        return TERRAIN_FIX_LOWER_MAX_OFFSET;
+    }
+
+    public int terrainFixUpperMinOffset() {
+        return TERRAIN_FIX_UPPER_MIN_OFFSET;
+    }
+
+    public int terrainFixUpperMaxOffset() {
+        return TERRAIN_FIX_UPPER_MAX_OFFSET;
+    }
+
+    public int oceanCorrectionBorder() {
+        return OCEAN_CORRECTION_BORDER;
+    }
+
+    public boolean avoidWater() {
+        return AVOID_WATER;
+    }
+
+    public boolean useAvgHeightmap() {
+        return USE_AVG_HEIGHTMAP;
+    }
+
+    public double cityChance() {
+        return CITY_CHANCE;
+    }
+
+    public int cityMinRadius() {
+        return CITY_MINRADIUS;
+    }
+
+    public int cityMaxRadius() {
+        return CITY_MAXRADIUS;
+    }
+
+    public double cityPerlinScale() {
+        return CITY_PERLIN_SCALE;
+    }
+
+    public double cityPerlinOffset() {
+        return CITY_PERLIN_OFFSET;
+    }
+
+    public double cityPerlinInnerScale() {
+        return CITY_PERLIN_INNERSCALE;
+    }
+
+    public float cityThreshold() {
+        return CITY_THRESHOLD;
+    }
+
+    public int citySpawnDistance1() {
+        return CITY_SPAWN_DISTANCE1;
+    }
+
+    public int citySpawnDistance2() {
+        return CITY_SPAWN_DISTANCE2;
+    }
+
+    public double citySpawnMultiplier1() {
+        return CITY_SPAWN_MULTIPLIER1;
+    }
+
+    public double citySpawnMultiplier2() {
+        return CITY_SPAWN_MULTIPLIER2;
+    }
+
+    public float cityStyleThreshold() {
+        return CITY_STYLE_THRESHOLD;
+    }
+
+    public String cityStyleAlternative() {
+        return CITY_STYLE_ALTERNATIVE;
+    }
+
+    public boolean cityAvoidVoid() {
+        return CITY_AVOID_VOID;
+    }
+
+    public int cityLevel0Height() {
+        return CITY_LEVEL0_HEIGHT;
+    }
+
+    public int cityLevel1Height() {
+        return CITY_LEVEL1_HEIGHT;
+    }
+
+    public int cityLevel2Height() {
+        return CITY_LEVEL2_HEIGHT;
+    }
+
+    public int cityLevel3Height() {
+        return CITY_LEVEL3_HEIGHT;
+    }
+
+    public int cityLevel4Height() {
+        return CITY_LEVEL4_HEIGHT;
+    }
+
+    public int cityLevel5Height() {
+        return CITY_LEVEL5_HEIGHT;
+    }
+
+    public int cityLevel6Height() {
+        return CITY_LEVEL6_HEIGHT;
+    }
+
+    public int cityLevel7Height() {
+        return CITY_LEVEL7_HEIGHT;
+    }
+
+    public int cityMinHeight() {
+        return CITY_MINHEIGHT;
+    }
+
+    public int cityMaxHeight() {
+        return CITY_MAXHEIGHT;
+    }
+
+    public float scatteredChanceMultiplier() {
+        return SCATTERED_CHANCE_MULTIPLIER;
+    }
+
+    public float buildingChance() {
+        return BUILDING_CHANCE;
+    }
+
+    public int buildingMinFloors() {
+        return BUILDING_MINFLOORS;
+    }
+
+    public int buildingMaxFloors() {
+        return BUILDING_MAXFLOORS;
+    }
+
+    public int buildingMinFloorsChance() {
+        return BUILDING_MINFLOORS_CHANCE;
+    }
+
+    public int buildingMaxFloorsChance() {
+        return BUILDING_MAXFLOORS_CHANCE;
+    }
+
+    public int buildingMinCellars() {
+        return BUILDING_MINCELLARS;
+    }
+
+    public int buildingMaxCellars() {
+        return BUILDING_MAXCELLARS;
+    }
+
+    public float buildingDoorwayChance() {
+        return BUILDING_DOORWAYCHANCE;
+    }
+
+    public float buildingFrontChance() {
+        return BUILDING_FRONTCHANCE;
+    }
+
+    public boolean multiUseCorner() {
+        return MULTI_USE_CORNER;
+    }
+
+    public MultiBuildingStreetConflict multiBuildingStreetConflict() {
+        return MULTI_BUILDING_STREET_CONFLICT;
+    }
+
+    public boolean generateSpawners() {
+        return GENERATE_SPAWNERS;
+    }
+
+    public int primaryRoadSpacingX() {
+        return PRIMARY_ROAD_SPACING_X;
+    }
+
+    public int primaryRoadSpacingZ() {
+        return PRIMARY_ROAD_SPACING_Z;
+    }
+
+    public float primaryRoadOptionalChance() {
+        return PRIMARY_ROAD_OPTIONAL_CHANCE;
+    }
+
+    public int primaryRoadForceEvery() {
+        return PRIMARY_ROAD_FORCE_EVERY;
+    }
+
+    public int secondaryRoadMinCountX() {
+        return SECONDARY_ROAD_MIN_COUNT_X;
+    }
+
+    public int secondaryRoadMaxCountX() {
+        return SECONDARY_ROAD_MAX_COUNT_X;
+    }
+
+    public int secondaryRoadMinCountZ() {
+        return SECONDARY_ROAD_MIN_COUNT_Z;
+    }
+
+    public int secondaryRoadMaxCountZ() {
+        return SECONDARY_ROAD_MAX_COUNT_Z;
+    }
+
+    public int minimumRoadSeparation() {
+        return MINIMUM_ROAD_SEPARATION;
+    }
+
+    public int minimumRoadEdgeDistance() {
+        return MINIMUM_ROAD_EDGE_DISTANCE;
+    }
+
+    public float tertiaryRoadChance() {
+        return TERTIARY_ROAD_CHANCE;
+    }
+
+    public int tertiaryRoadMinLength() {
+        return TERTIARY_ROAD_MIN_LENGTH;
+    }
+
+    public int tertiaryRoadMaxLength() {
+        return TERTIARY_ROAD_MAX_LENGTH;
+    }
+
+    public float plannedPrimaryBridgeChance() {
+        return PLANNED_PRIMARY_BRIDGE_CHANCE;
+    }
+
+    public int plannedPrimaryBridgeMaxLength() {
+        return PLANNED_PRIMARY_BRIDGE_MAX_LENGTH;
+    }
+
+    public float openLotParkChance() {
+        return OPEN_LOT_PARK_CHANCE;
+    }
+
+    public boolean parkElevation() {
+        return PARK_ELEVATION;
+    }
+
+    public boolean parkBorder() {
+        return PARK_BORDER;
+    }
+
+    public int parkStreetThreshold() {
+        return PARK_STREET_THRESHOLD;
+    }
+
+    public float fountainChance() {
+        return FOUNTAIN_CHANCE;
+    }
+
+    public float corridorChance() {
+        return CORRIDOR_CHANCE;
+    }
+
+    public float bridgeChance() {
+        return BRIDGE_CHANCE;
+    }
+
+    public boolean bridgeSupports() {
+        return BRIDGE_SUPPORTS;
+    }
+
+    public boolean highwayRequiresTwoCities() {
+        return HIGHWAY_REQUIRES_TWO_CITIES;
+    }
+
+    public int highwayLevelFromCities() {
+        return HIGHWAY_LEVEL_FROM_CITIES_MODE;
+    }
+
+    public int highwayDistanceMask() {
+        return HIGHWAY_DISTANCE_MASK;
+    }
+
+    public float highwayMainPerlinScale() {
+        return HIGHWAY_MAINPERLIN_SCALE;
+    }
+
+    public float highwaySecondaryPerlinScale() {
+        return HIGHWAY_SECONDARYPERLIN_SCALE;
+    }
+
+    public float highwayPerlinFactor() {
+        return HIGHWAY_PERLIN_FACTOR;
+    }
+
+    public boolean highwaySupports() {
+        return HIGHWAY_SUPPORTS;
+    }
+
+    public boolean railwaysEnabled() {
+        return RAILWAYS_ENABLED;
+    }
+
+    public boolean railwayStationsEnabled() {
+        return RAILWAY_STATIONS_ENABLED;
+    }
+
+    public boolean railwaySurfaceStationsEnabled() {
+        return RAILWAY_SURFACE_STATIONS_ENABLED;
+    }
+
+    public boolean railwaysCanEnd() {
+        return RAILWAYS_CAN_END;
+    }
+
+    public float railwayDungeonChance() {
+        return RAILWAY_DUNGEON_CHANCE;
+    }
+
+    public float ruinChance() {
+        return RUIN_CHANCE;
+    }
+
+    public float ruinMinlevelPercent() {
+        return RUIN_MINLEVEL_PERCENT;
+    }
+
+    public float ruinMaxlevelPercent() {
+        return RUIN_MAXLEVEL_PERCENT;
+    }
+
+    public boolean rubbleLayer() {
+        return RUBBLELAYER;
+    }
+
+    public float rubbleDirtScale() {
+        return RUBBLE_DIRT_SCALE;
+    }
+
+    public float rubbleLeaveScale() {
+        return RUBBLE_LEAVE_SCALE;
+    }
+
+    public float explosionChance() {
+        return EXPLOSION_CHANCE;
+    }
+
+    public int explosionMinRadius() {
+        return EXPLOSION_MINRADIUS;
+    }
+
+    public int explosionMaxRadius() {
+        return EXPLOSION_MAXRADIUS;
+    }
+
+    public int explosionMinHeight() {
+        return EXPLOSION_MINHEIGHT;
+    }
+
+    public int explosionMaxHeight() {
+        return EXPLOSION_MAXHEIGHT;
+    }
+
+    public float miniExplosionChance() {
+        return MINI_EXPLOSION_CHANCE;
+    }
+
+    public int miniExplosionMinRadius() {
+        return MINI_EXPLOSION_MINRADIUS;
+    }
+
+    public int miniExplosionMaxRadius() {
+        return MINI_EXPLOSION_MAXRADIUS;
+    }
+
+    public int miniExplosionMinHeight() {
+        return MINI_EXPLOSION_MINHEIGHT;
+    }
+
+    public int miniExplosionMaxHeight() {
+        return MINI_EXPLOSION_MAXHEIGHT;
+    }
+
+    public boolean explosionsInCitiesOnly() {
+        return EXPLOSIONS_IN_CITIES_ONLY;
+    }
+
+    public int debrisToNearbyChunkFactor() {
+        return DEBRIS_TO_NEARBYCHUNK_FACTOR;
+    }
+
+    public float randomLeafBlockChance() {
+        return CHANCE_OF_RANDOM_LEAFBLOCKS;
+    }
+
+    public int randomLeafBlockThickness() {
+        return THICKNESS_OF_RANDOM_LEAFBLOCKS;
+    }
+
+    public boolean avoidFoliage() {
+        return AVOID_FOLIAGE;
+    }
+
+    public float lightingDensity() {
+        return LIGHTING_DENSITY;
+    }
+
+    public float lootDensity() {
+        return LOOT_DENSITY;
+    }
+
+    public String spawnBiome() {
+        return SPAWN_BIOME;
+    }
+
+    public String spawnCity() {
+        return SPAWN_CITY;
+    }
+
+    public boolean spawnNotInBuilding() {
+        return SPAWN_NOT_IN_BUILDING;
+    }
+
+    public boolean forceSpawnInBuilding() {
+        return FORCE_SPAWN_IN_BUILDING;
+    }
+
+    public List<String> forceSpawnBuildings() {
+        return FORCE_SPAWN_BUILDINGS;
+    }
+
+    public List<String> forceSpawnParts() {
+        return FORCE_SPAWN_PARTS;
+    }
+
+    public int spawnCheckRadius() {
+        return SPAWN_CHECK_RADIUS;
+    }
+
+    public int spawnRadiusIncrease() {
+        return SPAWN_RADIUS_INCREASE;
+    }
+
+    public int spawnCheckAttempts() {
+        return SPAWN_CHECK_ATTEMPTS;
+    }
+
+    public boolean editMode() {
+        return EDITMODE;
+    }
+
+    public boolean generateNether() {
+        return GENERATE_NETHER;
+    }
 }

--- a/src/main/java/dev/krona/urbex/config/PresetRoadGrid.java
+++ b/src/main/java/dev/krona/urbex/config/PresetRoadGrid.java
@@ -29,18 +29,18 @@ public final class PresetRoadGrid {
      */
     public static GridSettings of(Preset preset) {
         return new GridSettings(
-                preset.PRIMARY_ROAD_SPACING_X,
-                preset.PRIMARY_ROAD_SPACING_Z,
-                preset.PRIMARY_ROAD_OPTIONAL_CHANCE,
-                preset.PRIMARY_ROAD_FORCE_EVERY,
-                preset.SECONDARY_ROAD_MIN_COUNT_X,
-                preset.SECONDARY_ROAD_MAX_COUNT_X,
-                preset.SECONDARY_ROAD_MIN_COUNT_Z,
-                preset.SECONDARY_ROAD_MAX_COUNT_Z,
-                preset.MINIMUM_ROAD_SEPARATION,
-                preset.MINIMUM_ROAD_EDGE_DISTANCE,
-                preset.TERTIARY_ROAD_CHANCE,
-                preset.TERTIARY_ROAD_MIN_LENGTH,
-                preset.TERTIARY_ROAD_MAX_LENGTH);
+                preset.primaryRoadSpacingX(),
+                preset.primaryRoadSpacingZ(),
+                preset.primaryRoadOptionalChance(),
+                preset.primaryRoadForceEvery(),
+                preset.secondaryRoadMinCountX(),
+                preset.secondaryRoadMaxCountX(),
+                preset.secondaryRoadMinCountZ(),
+                preset.secondaryRoadMaxCountZ(),
+                preset.minimumRoadSeparation(),
+                preset.minimumRoadEdgeDistance(),
+                preset.tertiaryRoadChance(),
+                preset.tertiaryRoadMinLength(),
+                preset.tertiaryRoadMaxLength());
     }
 }

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -417,18 +417,18 @@ public class CityPreview implements AutoCloseable {
                 factor = (radius - dist) / radius;
             }
             if (factor > 0 && x > 0) {
-                int maxfloors = profile.BUILDING_MAXFLOORS;
-                int randdist = (int) (profile.BUILDING_MINFLOORS_CHANCE
-                        + (factor + .1f) * (profile.BUILDING_MAXFLOORS_CHANCE - profile.BUILDING_MINFLOORS_CHANCE));
+                int maxfloors = profile.buildingMaxFloors();
+                int randdist = (int) (profile.buildingMinFloorsChance()
+                        + (factor + .1f) * (profile.buildingMaxFloorsChance() - profile.buildingMinFloorsChance()));
                 if (randdist < 1) {
                     randdist = 1;
                 }
-                int f = profile.BUILDING_MINFLOORS + rand.nextInt(randdist);
+                int f = profile.buildingMinFloors() + rand.nextInt(randdist);
                 f++;
                 if (f > maxfloors + 1) {
                     f = maxfloors + 1;
                 }
-                int minfloors = profile.BUILDING_MINFLOORS + 1;
+                int minfloors = profile.buildingMinFloors() + 1;
                 if (f < minfloors) {
                     f = minfloors;
                 }
@@ -437,8 +437,8 @@ public class CityPreview implements AutoCloseable {
                             dimHor * x + dimHor - 1, base - i * dimVer + dimVer - 1 - dimVer, FLOOR_COLOR);
                 }
 
-                int maxcellars = profile.BUILDING_MAXCELLARS;
-                int fb = profile.BUILDING_MINCELLARS + ((maxcellars <= 0) ? 0 : rand.nextInt(maxcellars + 1));
+                int maxcellars = profile.buildingMaxCellars();
+                int fb = profile.buildingMinCellars() + ((maxcellars <= 0) ? 0 : rand.nextInt(maxcellars + 1));
                 for (int i = 0; i < fb; i++) {
                     fillRect(dimHor * x, base + i * dimVer,
                             dimHor * x + dimHor - 1, base + i * dimVer + dimVer - 1, CELLAR_COLOR);
@@ -453,9 +453,9 @@ public class CityPreview implements AutoCloseable {
         Random rnd = new Random(333);
         // Old centres were leftRender+75 and leftRender+35 within a 150-wide canvas (0.5 and ~0.233).
         drawExplosion(base, horFactor, verFactor, Math.round(WIDTH * 0.5f),
-                profile.EXPLOSION_MINHEIGHT, profile.EXPLOSION_MAXRADIUS, rnd);
+                profile.explosionMinHeight(), profile.explosionMaxRadius(), rnd);
         drawExplosion(base, horFactor, verFactor, Math.round(WIDTH * 0.233f),
-                profile.MINI_EXPLOSION_MINHEIGHT, profile.MINI_EXPLOSION_MAXRADIUS, rnd);
+                profile.miniExplosionMinHeight(), profile.miniExplosionMaxRadius(), rnd);
     }
 
     private void drawExplosion(int base, float horFactor, float verFactor, int cx,

--- a/src/main/java/dev/krona/urbex/gui/preview/PreviewTerrain.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/PreviewTerrain.java
@@ -118,7 +118,7 @@ public final class PreviewTerrain implements TerrainSampler {
 
     @Override
     public ChunkHeightmap heightmap(ChunkCoord coord) {
-        ChunkHeightmap heightmap = new ChunkHeightmap(preset.LANDSCAPE_TYPE, preset.GROUNDLEVEL);
+        ChunkHeightmap heightmap = new ChunkHeightmap(preset.landscapeType(), preset.groundLevel());
         heightmap.update(groundAt(coord.chunkX(), coord.chunkZ()));
         return heightmap;
     }

--- a/src/main/java/dev/krona/urbex/gui/settings/SettingDescriptor.java
+++ b/src/main/java/dev/krona/urbex/gui/settings/SettingDescriptor.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
  * and how to read/write the backing field.
  *
  * <p><b>Direct field access, on purpose.</b> The {@link #getter} and {@link #setter} read and write the public
- * {@code Preset} field directly (e.g. {@code p -> p.CITY_CHANCE}) rather than routing through a config-file
+ * {@code Preset} field directly (e.g. {@code p -> p.cityChance()}) rather than routing through a config-file
  * bridge class. This was deliberate: it let issue #75 part 2 delete the old {@code Configuration} bridge
  * (Task 5) without having to touch this framework.</p>
  *

--- a/src/main/java/dev/krona/urbex/gui/settings/Settings.java
+++ b/src/main/java/dev/krona/urbex/gui/settings/Settings.java
@@ -121,35 +121,35 @@ public final class Settings {
         // perlin-city-map toggle for its -1 sentinel.
         r.section("city");
         r.chancePerlin("CITY_CHANCE", SettingCategory.GENERAL, 0.0001, 1.0, 0.0001,
-                p -> p.CITY_CHANCE, (p, v) -> p.CITY_CHANCE = (Double) v);
+                p -> p.cityChance(), (p, v) -> p.CITY_CHANCE = (Double) v);
         r.slider("CITY_MINRADIUS", SettingCategory.GENERAL, 1, 2000, 1,
-                p -> (double) p.CITY_MINRADIUS, (p, v) -> p.CITY_MINRADIUS = (int) Math.round((Double) v));
+                p -> (double) p.cityMinRadius(), (p, v) -> p.CITY_MINRADIUS = (int) Math.round((Double) v));
         r.slider("CITY_MAXRADIUS", SettingCategory.GENERAL, 1, 2000, 1,
-                p -> (double) p.CITY_MAXRADIUS, (p, v) -> p.CITY_MAXRADIUS = (int) Math.round((Double) v));
+                p -> (double) p.cityMaxRadius(), (p, v) -> p.CITY_MAXRADIUS = (int) Math.round((Double) v));
 
         r.section("buildings");
         r.slider("BUILDING_MINFLOORS", SettingCategory.GENERAL, 0, 60, 1,
-                p -> (double) p.BUILDING_MINFLOORS, (p, v) -> p.BUILDING_MINFLOORS = (int) Math.round((Double) v));
+                p -> (double) p.buildingMinFloors(), (p, v) -> p.BUILDING_MINFLOORS = (int) Math.round((Double) v));
         r.slider("BUILDING_MAXFLOORS", SettingCategory.GENERAL, 0, 60, 1,
-                p -> (double) p.BUILDING_MAXFLOORS, (p, v) -> p.BUILDING_MAXFLOORS = (int) Math.round((Double) v));
+                p -> (double) p.buildingMaxFloors(), (p, v) -> p.BUILDING_MAXFLOORS = (int) Math.round((Double) v));
 
         r.section("damage");
         r.slider("RUIN_CHANCE", SettingCategory.GENERAL, 0.0, 1.0, 0.01,
-                p -> (double) p.RUIN_CHANCE, (p, v) -> p.RUIN_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.ruinChance(), (p, v) -> p.RUIN_CHANCE = ((Double) v).floatValue());
         r.logSlider("EXPLOSION_CHANCE", SettingCategory.GENERAL, 0.0001, 1.0, 0.0001,
-                p -> (double) p.EXPLOSION_CHANCE, (p, v) -> p.EXPLOSION_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.explosionChance(), (p, v) -> p.EXPLOSION_CHANCE = ((Double) v).floatValue());
         r.logSlider("MINI_EXPLOSION_CHANCE", SettingCategory.GENERAL, 0.0001, 1.0, 0.0001,
-                p -> (double) p.MINI_EXPLOSION_CHANCE, (p, v) -> p.MINI_EXPLOSION_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.miniExplosionChance(), (p, v) -> p.MINI_EXPLOSION_CHANCE = ((Double) v).floatValue());
 
         r.section("interior");
         r.slider("LOOT_DENSITY", SettingCategory.GENERAL, 0.0, 1.0, 0.01,
-                p -> (double) p.LOOT_DENSITY, (p, v) -> p.LOOT_DENSITY = ((Double) v).floatValue());
+                p -> (double) p.lootDensity(), (p, v) -> p.LOOT_DENSITY = ((Double) v).floatValue());
         r.slider("LIGHTING_DENSITY", SettingCategory.GENERAL, 0.0, 1.0, 0.01,
-                p -> (double) p.LIGHTING_DENSITY, (p, v) -> p.LIGHTING_DENSITY = ((Double) v).floatValue());
+                p -> (double) p.lightingDensity(), (p, v) -> p.LIGHTING_DENSITY = ((Double) v).floatValue());
 
         r.section("world");
         r.cycle("LANDSCAPE_TYPE", SettingCategory.GENERAL,
-                p -> p.LANDSCAPE_TYPE, (p, v) -> p.LANDSCAPE_TYPE = (LandscapeType) v);
+                p -> p.landscapeType(), (p, v) -> p.LANDSCAPE_TYPE = (LandscapeType) v);
 
         // ==== CITIES =========================================================
         // City placement thresholds, per-level heights and spawn distances. (Chance and radii live in GENERAL.)
@@ -161,157 +161,157 @@ public final class Settings {
         // Coordinate divisor: larger = the noise varies more slowly = larger, rarer city regions. Default 3 sits ~10%
         // in; up to 25 gives continent-scale regions, 0.5 gives tight ones. Half-unit steps are fine for a divisor.
         r.slider("CITY_PERLIN_SCALE", SettingCategory.CITIES, 0.5, 25.0, 0.5,
-                p -> p.CITY_PERLIN_SCALE, (p, v) -> p.CITY_PERLIN_SCALE = (Double) v);
+                p -> p.cityPerlinScale(), (p, v) -> p.CITY_PERLIN_SCALE = (Double) v);
         // Noise amplitude multiplier: default 0.1 (10% in). 0 flattens the map; ~0.3+ starts clearing the threshold;
         // >1 makes nearly everywhere a city. 0.01 steps give precise control near the useful low end.
         r.slider("CITY_PERLIN_INNERSCALE", SettingCategory.CITIES, 0.0, 1.0, 0.01,
-                p -> p.CITY_PERLIN_INNERSCALE, (p, v) -> p.CITY_PERLIN_INNERSCALE = (Double) v);
+                p -> p.cityPerlinInnerScale(), (p, v) -> p.CITY_PERLIN_INNERSCALE = (Double) v);
         // Noise shift (subtracted before the threshold): default 0.1 (mid-track). Symmetric ±1 spans the noise range —
         // positive raises the city bar, negative lowers it. 0.01 steps match INNERSCALE's resolution.
         r.slider("CITY_PERLIN_OFFSET", SettingCategory.CITIES, -1.0, 1.0, 0.01,
-                p -> p.CITY_PERLIN_OFFSET, (p, v) -> p.CITY_PERLIN_OFFSET = (Double) v);
+                p -> p.cityPerlinOffset(), (p, v) -> p.CITY_PERLIN_OFFSET = (Double) v);
         r.slider("CITY_THRESHOLD", SettingCategory.CITIES, 0.0, 1.0, 0.01,
-                p -> (double) p.CITY_THRESHOLD, (p, v) -> p.CITY_THRESHOLD = ((Double) v).floatValue());
+                p -> (double) p.cityThreshold(), (p, v) -> p.CITY_THRESHOLD = ((Double) v).floatValue());
 
         // Distance-based spawn scaling: block distances up to millions (0 = disabled, so a slider would pin the
         // default uselessly) paired with the multiplier applied past each ring.
         r.section("spawn_scaling");
         r.number("CITY_SPAWN_DISTANCE1", SettingCategory.CITIES, 0, 10000000, true,
-                p -> (double) p.CITY_SPAWN_DISTANCE1, (p, v) -> p.CITY_SPAWN_DISTANCE1 = (int) Math.round((Double) v));
+                p -> (double) p.citySpawnDistance1(), (p, v) -> p.CITY_SPAWN_DISTANCE1 = (int) Math.round((Double) v));
         r.number("CITY_SPAWN_DISTANCE2", SettingCategory.CITIES, 0, 10000000, true,
-                p -> (double) p.CITY_SPAWN_DISTANCE2, (p, v) -> p.CITY_SPAWN_DISTANCE2 = (int) Math.round((Double) v));
+                p -> (double) p.citySpawnDistance2(), (p, v) -> p.CITY_SPAWN_DISTANCE2 = (int) Math.round((Double) v));
         r.slider("CITY_SPAWN_MULTIPLIER1", SettingCategory.CITIES, 0.0, 1.0, 0.01,
-                p -> p.CITY_SPAWN_MULTIPLIER1, (p, v) -> p.CITY_SPAWN_MULTIPLIER1 = (Double) v);
+                p -> p.citySpawnMultiplier1(), (p, v) -> p.CITY_SPAWN_MULTIPLIER1 = (Double) v);
         r.slider("CITY_SPAWN_MULTIPLIER2", SettingCategory.CITIES, 0.0, 1.0, 0.01,
-                p -> p.CITY_SPAWN_MULTIPLIER2, (p, v) -> p.CITY_SPAWN_MULTIPLIER2 = (Double) v);
+                p -> p.citySpawnMultiplier2(), (p, v) -> p.CITY_SPAWN_MULTIPLIER2 = (Double) v);
 
         r.section("style");
         r.slider("CITY_STYLE_THRESHOLD", SettingCategory.CITIES, 0.0, 1.0, 0.01,
-                p -> (double) p.CITY_STYLE_THRESHOLD, (p, v) -> p.CITY_STYLE_THRESHOLD = ((Double) v).floatValue());
+                p -> (double) p.cityStyleThreshold(), (p, v) -> p.CITY_STYLE_THRESHOLD = ((Double) v).floatValue());
 
         // Where a city is allowed to sit: the terrain-height gate in City.getCityFactor plus the void guard. The
         // config ceiling (-1024..2048) is far past any real world Y, so min/max height are tightened to the
         // vanilla buildable range so the handle tracks meaningful heights.
         r.section("placement");
         r.toggle("CITY_AVOID_VOID", SettingCategory.CITIES,
-                p -> p.CITY_AVOID_VOID, (p, v) -> p.CITY_AVOID_VOID = (Boolean) v);
+                p -> p.cityAvoidVoid(), (p, v) -> p.CITY_AVOID_VOID = (Boolean) v);
         r.slider("CITY_MINHEIGHT", SettingCategory.CITIES, -64, 384, 1,
-                p -> (double) p.CITY_MINHEIGHT, (p, v) -> p.CITY_MINHEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityMinHeight(), (p, v) -> p.CITY_MINHEIGHT = (int) Math.round((Double) v));
         r.slider("CITY_MAXHEIGHT", SettingCategory.CITIES, -64, 384, 1,
-                p -> (double) p.CITY_MAXHEIGHT, (p, v) -> p.CITY_MAXHEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityMaxHeight(), (p, v) -> p.CITY_MAXHEIGHT = (int) Math.round((Double) v));
 
         // The eight per-level Y offsets a city can stamp its floors at.
         r.section("levels");
         r.slider("CITY_LEVEL0_HEIGHT", SettingCategory.CITIES, 1, 384, 1,
-                p -> (double) p.CITY_LEVEL0_HEIGHT, (p, v) -> p.CITY_LEVEL0_HEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityLevel0Height(), (p, v) -> p.CITY_LEVEL0_HEIGHT = (int) Math.round((Double) v));
         r.slider("CITY_LEVEL1_HEIGHT", SettingCategory.CITIES, 1, 384, 1,
-                p -> (double) p.CITY_LEVEL1_HEIGHT, (p, v) -> p.CITY_LEVEL1_HEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityLevel1Height(), (p, v) -> p.CITY_LEVEL1_HEIGHT = (int) Math.round((Double) v));
         r.slider("CITY_LEVEL2_HEIGHT", SettingCategory.CITIES, 1, 384, 1,
-                p -> (double) p.CITY_LEVEL2_HEIGHT, (p, v) -> p.CITY_LEVEL2_HEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityLevel2Height(), (p, v) -> p.CITY_LEVEL2_HEIGHT = (int) Math.round((Double) v));
         r.slider("CITY_LEVEL3_HEIGHT", SettingCategory.CITIES, 1, 384, 1,
-                p -> (double) p.CITY_LEVEL3_HEIGHT, (p, v) -> p.CITY_LEVEL3_HEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityLevel3Height(), (p, v) -> p.CITY_LEVEL3_HEIGHT = (int) Math.round((Double) v));
         r.slider("CITY_LEVEL4_HEIGHT", SettingCategory.CITIES, 1, 384, 1,
-                p -> (double) p.CITY_LEVEL4_HEIGHT, (p, v) -> p.CITY_LEVEL4_HEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityLevel4Height(), (p, v) -> p.CITY_LEVEL4_HEIGHT = (int) Math.round((Double) v));
         r.slider("CITY_LEVEL5_HEIGHT", SettingCategory.CITIES, 1, 384, 1,
-                p -> (double) p.CITY_LEVEL5_HEIGHT, (p, v) -> p.CITY_LEVEL5_HEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityLevel5Height(), (p, v) -> p.CITY_LEVEL5_HEIGHT = (int) Math.round((Double) v));
         r.slider("CITY_LEVEL6_HEIGHT", SettingCategory.CITIES, 1, 384, 1,
-                p -> (double) p.CITY_LEVEL6_HEIGHT, (p, v) -> p.CITY_LEVEL6_HEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityLevel6Height(), (p, v) -> p.CITY_LEVEL6_HEIGHT = (int) Math.round((Double) v));
         r.slider("CITY_LEVEL7_HEIGHT", SettingCategory.CITIES, 1, 384, 1,
-                p -> (double) p.CITY_LEVEL7_HEIGHT, (p, v) -> p.CITY_LEVEL7_HEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.cityLevel7Height(), (p, v) -> p.CITY_LEVEL7_HEIGHT = (int) Math.round((Double) v));
 
         // ==== BUILDINGS ======================================================
         // Buildings, ruins, city features and foliage/rubble. (Floors and loot/lighting density live in GENERAL.)
         r.section("buildings");
         r.slider("BUILDING_CHANCE", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.BUILDING_CHANCE, (p, v) -> p.BUILDING_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.buildingChance(), (p, v) -> p.BUILDING_CHANCE = ((Double) v).floatValue());
         r.slider("BUILDING_MINFLOORS_CHANCE", SettingCategory.BUILDINGS, 1, 60, 1,
-                p -> (double) p.BUILDING_MINFLOORS_CHANCE, (p, v) -> p.BUILDING_MINFLOORS_CHANCE = (int) Math.round((Double) v));
+                p -> (double) p.buildingMinFloorsChance(), (p, v) -> p.BUILDING_MINFLOORS_CHANCE = (int) Math.round((Double) v));
         r.slider("BUILDING_MAXFLOORS_CHANCE", SettingCategory.BUILDINGS, 1, 60, 1,
-                p -> (double) p.BUILDING_MAXFLOORS_CHANCE, (p, v) -> p.BUILDING_MAXFLOORS_CHANCE = (int) Math.round((Double) v));
+                p -> (double) p.buildingMaxFloorsChance(), (p, v) -> p.BUILDING_MAXFLOORS_CHANCE = (int) Math.round((Double) v));
         r.slider("BUILDING_MINCELLARS", SettingCategory.BUILDINGS, 0, 20, 1,
-                p -> (double) p.BUILDING_MINCELLARS, (p, v) -> p.BUILDING_MINCELLARS = (int) Math.round((Double) v));
+                p -> (double) p.buildingMinCellars(), (p, v) -> p.BUILDING_MINCELLARS = (int) Math.round((Double) v));
         r.slider("BUILDING_MAXCELLARS", SettingCategory.BUILDINGS, 0, 20, 1,
-                p -> (double) p.BUILDING_MAXCELLARS, (p, v) -> p.BUILDING_MAXCELLARS = (int) Math.round((Double) v));
+                p -> (double) p.buildingMaxCellars(), (p, v) -> p.BUILDING_MAXCELLARS = (int) Math.round((Double) v));
         r.slider("BUILDING_DOORWAYCHANCE", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.BUILDING_DOORWAYCHANCE, (p, v) -> p.BUILDING_DOORWAYCHANCE = ((Double) v).floatValue());
+                p -> (double) p.buildingDoorwayChance(), (p, v) -> p.BUILDING_DOORWAYCHANCE = ((Double) v).floatValue());
         r.slider("BUILDING_FRONTCHANCE", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.BUILDING_FRONTCHANCE, (p, v) -> p.BUILDING_FRONTCHANCE = ((Double) v).floatValue());
+                p -> (double) p.buildingFrontChance(), (p, v) -> p.BUILDING_FRONTCHANCE = ((Double) v).floatValue());
 
         r.section("ruins");
         r.slider("RUIN_MINLEVEL_PERCENT", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.RUIN_MINLEVEL_PERCENT, (p, v) -> p.RUIN_MINLEVEL_PERCENT = ((Double) v).floatValue());
+                p -> (double) p.ruinMinlevelPercent(), (p, v) -> p.RUIN_MINLEVEL_PERCENT = ((Double) v).floatValue());
         r.slider("RUIN_MAXLEVEL_PERCENT", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.RUIN_MAXLEVEL_PERCENT, (p, v) -> p.RUIN_MAXLEVEL_PERCENT = ((Double) v).floatValue());
+                p -> (double) p.ruinMaxlevelPercent(), (p, v) -> p.RUIN_MAXLEVEL_PERCENT = ((Double) v).floatValue());
 
         // Parks, bridges, corridors and fountains: the non-building structures that fill the streets between them.
         r.section("features");
         r.slider("OPEN_LOT_PARK_CHANCE", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.OPEN_LOT_PARK_CHANCE, (p, v) -> p.OPEN_LOT_PARK_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.openLotParkChance(), (p, v) -> p.OPEN_LOT_PARK_CHANCE = ((Double) v).floatValue());
         r.slider("CORRIDOR_CHANCE", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.CORRIDOR_CHANCE, (p, v) -> p.CORRIDOR_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.corridorChance(), (p, v) -> p.CORRIDOR_CHANCE = ((Double) v).floatValue());
         r.slider("BRIDGE_CHANCE", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.BRIDGE_CHANCE, (p, v) -> p.BRIDGE_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.bridgeChance(), (p, v) -> p.BRIDGE_CHANCE = ((Double) v).floatValue());
         r.slider("FOUNTAIN_CHANCE", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.FOUNTAIN_CHANCE, (p, v) -> p.FOUNTAIN_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.fountainChance(), (p, v) -> p.FOUNTAIN_CHANCE = ((Double) v).floatValue());
         r.toggle("BRIDGE_SUPPORTS", SettingCategory.BUILDINGS,
-                p -> p.BRIDGE_SUPPORTS, (p, v) -> p.BRIDGE_SUPPORTS = (Boolean) v);
+                p -> p.bridgeSupports(), (p, v) -> p.BRIDGE_SUPPORTS = (Boolean) v);
         r.toggle("PARK_ELEVATION", SettingCategory.BUILDINGS,
-                p -> p.PARK_ELEVATION, (p, v) -> p.PARK_ELEVATION = (Boolean) v);
+                p -> p.parkElevation(), (p, v) -> p.PARK_ELEVATION = (Boolean) v);
         r.toggle("PARK_BORDER", SettingCategory.BUILDINGS,
-                p -> p.PARK_BORDER, (p, v) -> p.PARK_BORDER = (Boolean) v);
+                p -> p.parkBorder(), (p, v) -> p.PARK_BORDER = (Boolean) v);
         r.slider("PARK_STREET_THRESHOLD", SettingCategory.BUILDINGS, 0, 8, 1,
-                p -> (double) p.PARK_STREET_THRESHOLD, (p, v) -> p.PARK_STREET_THRESHOLD = (int) Math.round((Double) v));
+                p -> (double) p.parkStreetThreshold(), (p, v) -> p.PARK_STREET_THRESHOLD = (int) Math.round((Double) v));
 
         // Overgrowth and debris: stray leaf blocks, the scattered-structure multiplier and the rubble layer.
         r.section("foliage");
         r.slider("CHANCE_OF_RANDOM_LEAFBLOCKS", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
-                p -> (double) p.CHANCE_OF_RANDOM_LEAFBLOCKS, (p, v) -> p.CHANCE_OF_RANDOM_LEAFBLOCKS = ((Double) v).floatValue());
+                p -> (double) p.randomLeafBlockChance(), (p, v) -> p.CHANCE_OF_RANDOM_LEAFBLOCKS = ((Double) v).floatValue());
         r.slider("THICKNESS_OF_RANDOM_LEAFBLOCKS", SettingCategory.BUILDINGS, 1, 8, 1,
-                p -> (double) p.THICKNESS_OF_RANDOM_LEAFBLOCKS, (p, v) -> p.THICKNESS_OF_RANDOM_LEAFBLOCKS = (int) Math.round((Double) v));
+                p -> (double) p.randomLeafBlockThickness(), (p, v) -> p.THICKNESS_OF_RANDOM_LEAFBLOCKS = (int) Math.round((Double) v));
         r.toggle("AVOID_FOLIAGE", SettingCategory.BUILDINGS,
-                p -> p.AVOID_FOLIAGE, (p, v) -> p.AVOID_FOLIAGE = (Boolean) v);
+                p -> p.avoidFoliage(), (p, v) -> p.AVOID_FOLIAGE = (Boolean) v);
         r.slider("SCATTERED_CHANCE_MULTIPLIER", SettingCategory.BUILDINGS, 0.0, 100.0, 0.1,
-                p -> (double) p.SCATTERED_CHANCE_MULTIPLIER, (p, v) -> p.SCATTERED_CHANCE_MULTIPLIER = ((Double) v).floatValue());
+                p -> (double) p.scatteredChanceMultiplier(), (p, v) -> p.SCATTERED_CHANCE_MULTIPLIER = ((Double) v).floatValue());
         r.toggle("RUBBLELAYER", SettingCategory.BUILDINGS,
-                p -> p.RUBBLELAYER, (p, v) -> p.RUBBLELAYER = (Boolean) v);
+                p -> p.rubbleLayer(), (p, v) -> p.RUBBLELAYER = (Boolean) v);
         r.slider("RUBBLE_DIRT_SCALE", SettingCategory.BUILDINGS, 0.0, 100.0, 0.1,
-                p -> (double) p.RUBBLE_DIRT_SCALE, (p, v) -> p.RUBBLE_DIRT_SCALE = ((Double) v).floatValue());
+                p -> (double) p.rubbleDirtScale(), (p, v) -> p.RUBBLE_DIRT_SCALE = ((Double) v).floatValue());
         r.slider("RUBBLE_LEAVE_SCALE", SettingCategory.BUILDINGS, 0.0, 100.0, 0.1,
-                p -> (double) p.RUBBLE_LEAVE_SCALE, (p, v) -> p.RUBBLE_LEAVE_SCALE = ((Double) v).floatValue());
+                p -> (double) p.rubbleLeaveScale(), (p, v) -> p.RUBBLE_LEAVE_SCALE = ((Double) v).floatValue());
 
         r.section("spawners");
         r.toggle("GENERATE_SPAWNERS", SettingCategory.BUILDINGS,
-                p -> p.GENERATE_SPAWNERS, (p, v) -> p.GENERATE_SPAWNERS = (Boolean) v);
+                p -> p.generateSpawners(), (p, v) -> p.GENERATE_SPAWNERS = (Boolean) v);
 
         // ==== DAMAGE =========================================================
         // Explosion radii/heights and debris overflow. (Explosion chances live in GENERAL.)
         r.section("explosions");
         r.slider("EXPLOSION_MINRADIUS", SettingCategory.DAMAGE, 1, 256, 1,
-                p -> (double) p.EXPLOSION_MINRADIUS, (p, v) -> p.EXPLOSION_MINRADIUS = (int) Math.round((Double) v));
+                p -> (double) p.explosionMinRadius(), (p, v) -> p.EXPLOSION_MINRADIUS = (int) Math.round((Double) v));
         r.slider("EXPLOSION_MAXRADIUS", SettingCategory.DAMAGE, 1, 256, 1,
-                p -> (double) p.EXPLOSION_MAXRADIUS, (p, v) -> p.EXPLOSION_MAXRADIUS = (int) Math.round((Double) v));
+                p -> (double) p.explosionMaxRadius(), (p, v) -> p.EXPLOSION_MAXRADIUS = (int) Math.round((Double) v));
         r.slider("EXPLOSION_MINHEIGHT", SettingCategory.DAMAGE, 1, 256, 1,
-                p -> (double) p.EXPLOSION_MINHEIGHT, (p, v) -> p.EXPLOSION_MINHEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.explosionMinHeight(), (p, v) -> p.EXPLOSION_MINHEIGHT = (int) Math.round((Double) v));
         r.slider("EXPLOSION_MAXHEIGHT", SettingCategory.DAMAGE, 1, 256, 1,
-                p -> (double) p.EXPLOSION_MAXHEIGHT, (p, v) -> p.EXPLOSION_MAXHEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.explosionMaxHeight(), (p, v) -> p.EXPLOSION_MAXHEIGHT = (int) Math.round((Double) v));
         r.toggle("EXPLOSIONS_IN_CITIES_ONLY", SettingCategory.DAMAGE,
-                p -> p.EXPLOSIONS_IN_CITIES_ONLY, (p, v) -> p.EXPLOSIONS_IN_CITIES_ONLY = (Boolean) v);
+                p -> p.explosionsInCitiesOnly(), (p, v) -> p.EXPLOSIONS_IN_CITIES_ONLY = (Boolean) v);
 
         // Mini explosions are much smaller than the full-size ones (defaults 5/12), so their radii get a smaller
         // dedicated cap than the 1..256 above, keeping the default off the left edge.
         r.section("mini_explosions");
         r.slider("MINI_EXPLOSION_MINRADIUS", SettingCategory.DAMAGE, 1, 100, 1,
-                p -> (double) p.MINI_EXPLOSION_MINRADIUS, (p, v) -> p.MINI_EXPLOSION_MINRADIUS = (int) Math.round((Double) v));
+                p -> (double) p.miniExplosionMinRadius(), (p, v) -> p.MINI_EXPLOSION_MINRADIUS = (int) Math.round((Double) v));
         r.slider("MINI_EXPLOSION_MAXRADIUS", SettingCategory.DAMAGE, 1, 100, 1,
-                p -> (double) p.MINI_EXPLOSION_MAXRADIUS, (p, v) -> p.MINI_EXPLOSION_MAXRADIUS = (int) Math.round((Double) v));
+                p -> (double) p.miniExplosionMaxRadius(), (p, v) -> p.MINI_EXPLOSION_MAXRADIUS = (int) Math.round((Double) v));
         r.slider("MINI_EXPLOSION_MINHEIGHT", SettingCategory.DAMAGE, 1, 256, 1,
-                p -> (double) p.MINI_EXPLOSION_MINHEIGHT, (p, v) -> p.MINI_EXPLOSION_MINHEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.miniExplosionMinHeight(), (p, v) -> p.MINI_EXPLOSION_MINHEIGHT = (int) Math.round((Double) v));
         r.slider("MINI_EXPLOSION_MAXHEIGHT", SettingCategory.DAMAGE, 1, 256, 1,
-                p -> (double) p.MINI_EXPLOSION_MAXHEIGHT, (p, v) -> p.MINI_EXPLOSION_MAXHEIGHT = (int) Math.round((Double) v));
+                p -> (double) p.miniExplosionMaxHeight(), (p, v) -> p.MINI_EXPLOSION_MAXHEIGHT = (int) Math.round((Double) v));
 
         r.section("debris");
         r.slider("DEBRIS_TO_NEARBYCHUNK_FACTOR", SettingCategory.DAMAGE, 1, 2000, 1,
-                p -> (double) p.DEBRIS_TO_NEARBYCHUNK_FACTOR, (p, v) -> p.DEBRIS_TO_NEARBYCHUNK_FACTOR = (int) Math.round((Double) v));
+                p -> (double) p.debrisToNearbyChunkFactor(), (p, v) -> p.DEBRIS_TO_NEARBYCHUNK_FACTOR = (int) Math.round((Double) v));
 
         // ==== TRANSPORT ======================================================
         // The networks the Transport preview overlay actually draws: highways and railways.
@@ -321,36 +321,36 @@ public final class Settings {
         // are valid, so a slider is meaningless. Typed field instead.
         r.section("highways");
         r.toggle("HIGHWAY_REQUIRES_TWO_CITIES", SettingCategory.TRANSPORT,
-                p -> p.HIGHWAY_REQUIRES_TWO_CITIES, (p, v) -> p.HIGHWAY_REQUIRES_TWO_CITIES = (Boolean) v);
+                p -> p.highwayRequiresTwoCities(), (p, v) -> p.HIGHWAY_REQUIRES_TWO_CITIES = (Boolean) v);
         r.slider("HIGHWAY_LEVEL_FROM_CITIES_MODE", SettingCategory.TRANSPORT, 0, 3, 1,
-                p -> (double) p.HIGHWAY_LEVEL_FROM_CITIES_MODE, (p, v) -> p.HIGHWAY_LEVEL_FROM_CITIES_MODE = (int) Math.round((Double) v));
+                p -> (double) p.highwayLevelFromCities(), (p, v) -> p.HIGHWAY_LEVEL_FROM_CITIES_MODE = (int) Math.round((Double) v));
         r.slider("HIGHWAY_MAINPERLIN_SCALE", SettingCategory.TRANSPORT, 1.0, 200.0, 0.1,
-                p -> (double) p.HIGHWAY_MAINPERLIN_SCALE, (p, v) -> p.HIGHWAY_MAINPERLIN_SCALE = ((Double) v).floatValue());
+                p -> (double) p.highwayMainPerlinScale(), (p, v) -> p.HIGHWAY_MAINPERLIN_SCALE = ((Double) v).floatValue());
         r.slider("HIGHWAY_SECONDARYPERLIN_SCALE", SettingCategory.TRANSPORT, 1.0, 100.0, 0.1,
-                p -> (double) p.HIGHWAY_SECONDARYPERLIN_SCALE, (p, v) -> p.HIGHWAY_SECONDARYPERLIN_SCALE = ((Double) v).floatValue());
+                p -> (double) p.highwaySecondaryPerlinScale(), (p, v) -> p.HIGHWAY_SECONDARYPERLIN_SCALE = ((Double) v).floatValue());
         // Threshold compared against the highway perlin output (4-octave PerlinNoiseGenerator14,
         // default 2.0). Bounded to a non-negative useful band: raising it makes highways rarer, and
         // the floor of 0.0 keeps the editor from setting a value below the perlin's output range,
         // which would make every chunk a "highway" (the worldgen scan is bounded regardless, but this
         // keeps the pathological value out of easy reach). Fine step for precise tuning.
         r.slider("HIGHWAY_PERLIN_FACTOR", SettingCategory.TRANSPORT, 0.0, 10.0, 0.05,
-                p -> (double) p.HIGHWAY_PERLIN_FACTOR, (p, v) -> p.HIGHWAY_PERLIN_FACTOR = ((Double) v).floatValue());
+                p -> (double) p.highwayPerlinFactor(), (p, v) -> p.HIGHWAY_PERLIN_FACTOR = ((Double) v).floatValue());
         r.number("HIGHWAY_DISTANCE_MASK", SettingCategory.TRANSPORT, 0, Integer.MAX_VALUE, true,
-                p -> (double) p.HIGHWAY_DISTANCE_MASK, (p, v) -> p.HIGHWAY_DISTANCE_MASK = (int) Math.round((Double) v));
+                p -> (double) p.highwayDistanceMask(), (p, v) -> p.HIGHWAY_DISTANCE_MASK = (int) Math.round((Double) v));
         r.toggle("HIGHWAY_SUPPORTS", SettingCategory.TRANSPORT,
-                p -> p.HIGHWAY_SUPPORTS, (p, v) -> p.HIGHWAY_SUPPORTS = (Boolean) v);
+                p -> p.highwaySupports(), (p, v) -> p.HIGHWAY_SUPPORTS = (Boolean) v);
 
         r.section("railways");
         r.slider("RAILWAY_DUNGEON_CHANCE", SettingCategory.TRANSPORT, 0.0, 1.0, 0.01,
-                p -> (double) p.RAILWAY_DUNGEON_CHANCE, (p, v) -> p.RAILWAY_DUNGEON_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.railwayDungeonChance(), (p, v) -> p.RAILWAY_DUNGEON_CHANCE = ((Double) v).floatValue());
         r.toggle("RAILWAYS_CAN_END", SettingCategory.TRANSPORT,
-                p -> p.RAILWAYS_CAN_END, (p, v) -> p.RAILWAYS_CAN_END = (Boolean) v);
+                p -> p.railwaysCanEnd(), (p, v) -> p.RAILWAYS_CAN_END = (Boolean) v);
         r.toggle("RAILWAYS_ENABLED", SettingCategory.TRANSPORT,
-                p -> p.RAILWAYS_ENABLED, (p, v) -> p.RAILWAYS_ENABLED = (Boolean) v);
+                p -> p.railwaysEnabled(), (p, v) -> p.RAILWAYS_ENABLED = (Boolean) v);
         r.toggle("RAILWAY_STATIONS_ENABLED", SettingCategory.TRANSPORT,
-                p -> p.RAILWAY_STATIONS_ENABLED, (p, v) -> p.RAILWAY_STATIONS_ENABLED = (Boolean) v);
+                p -> p.railwayStationsEnabled(), (p, v) -> p.RAILWAY_STATIONS_ENABLED = (Boolean) v);
         r.toggle("RAILWAY_SURFACE_STATIONS_ENABLED", SettingCategory.TRANSPORT,
-                p -> p.RAILWAY_SURFACE_STATIONS_ENABLED, (p, v) -> p.RAILWAY_SURFACE_STATIONS_ENABLED = (Boolean) v);
+                p -> p.railwaySurfaceStationsEnabled(), (p, v) -> p.RAILWAY_SURFACE_STATIONS_ENABLED = (Boolean) v);
 
         // ==== ROADS ==========================================================
         // The hierarchical road field: primary corridors, the secondary streets filling the blocks between
@@ -363,59 +363,59 @@ public final class Settings {
         // going blank mid-drag; a profile still inconsistent at world creation fails there, field named.
         r.section("roads_primary");
         r.slider("PRIMARY_ROAD_SPACING_X", SettingCategory.ROADS, 8, 128, 1,
-                p -> (double) p.PRIMARY_ROAD_SPACING_X, (p, v) -> p.PRIMARY_ROAD_SPACING_X = (int) Math.round((Double) v));
+                p -> (double) p.primaryRoadSpacingX(), (p, v) -> p.PRIMARY_ROAD_SPACING_X = (int) Math.round((Double) v));
         r.slider("PRIMARY_ROAD_SPACING_Z", SettingCategory.ROADS, 8, 128, 1,
-                p -> (double) p.PRIMARY_ROAD_SPACING_Z, (p, v) -> p.PRIMARY_ROAD_SPACING_Z = (int) Math.round((Double) v));
+                p -> (double) p.primaryRoadSpacingZ(), (p, v) -> p.PRIMARY_ROAD_SPACING_Z = (int) Math.round((Double) v));
         r.slider("PRIMARY_ROAD_OPTIONAL_CHANCE", SettingCategory.ROADS, 0.0, 1.0, 0.01,
-                p -> (double) p.PRIMARY_ROAD_OPTIONAL_CHANCE, (p, v) -> p.PRIMARY_ROAD_OPTIONAL_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.primaryRoadOptionalChance(), (p, v) -> p.PRIMARY_ROAD_OPTIONAL_CHANCE = ((Double) v).floatValue());
         r.slider("PRIMARY_ROAD_FORCE_EVERY", SettingCategory.ROADS, 1, 16, 1,
-                p -> (double) p.PRIMARY_ROAD_FORCE_EVERY, (p, v) -> p.PRIMARY_ROAD_FORCE_EVERY = (int) Math.round((Double) v));
+                p -> (double) p.primaryRoadForceEvery(), (p, v) -> p.PRIMARY_ROAD_FORCE_EVERY = (int) Math.round((Double) v));
 
         r.section("roads_secondary");
         r.slider("SECONDARY_ROAD_MIN_COUNT_X", SettingCategory.ROADS, 0, 128, 1,
-                p -> (double) p.SECONDARY_ROAD_MIN_COUNT_X, (p, v) -> p.SECONDARY_ROAD_MIN_COUNT_X = (int) Math.round((Double) v));
+                p -> (double) p.secondaryRoadMinCountX(), (p, v) -> p.SECONDARY_ROAD_MIN_COUNT_X = (int) Math.round((Double) v));
         r.slider("SECONDARY_ROAD_MAX_COUNT_X", SettingCategory.ROADS, 0, 128, 1,
-                p -> (double) p.SECONDARY_ROAD_MAX_COUNT_X, (p, v) -> p.SECONDARY_ROAD_MAX_COUNT_X = (int) Math.round((Double) v));
+                p -> (double) p.secondaryRoadMaxCountX(), (p, v) -> p.SECONDARY_ROAD_MAX_COUNT_X = (int) Math.round((Double) v));
         r.slider("SECONDARY_ROAD_MIN_COUNT_Z", SettingCategory.ROADS, 0, 128, 1,
-                p -> (double) p.SECONDARY_ROAD_MIN_COUNT_Z, (p, v) -> p.SECONDARY_ROAD_MIN_COUNT_Z = (int) Math.round((Double) v));
+                p -> (double) p.secondaryRoadMinCountZ(), (p, v) -> p.SECONDARY_ROAD_MIN_COUNT_Z = (int) Math.round((Double) v));
         r.slider("SECONDARY_ROAD_MAX_COUNT_Z", SettingCategory.ROADS, 0, 128, 1,
-                p -> (double) p.SECONDARY_ROAD_MAX_COUNT_Z, (p, v) -> p.SECONDARY_ROAD_MAX_COUNT_Z = (int) Math.round((Double) v));
+                p -> (double) p.secondaryRoadMaxCountZ(), (p, v) -> p.SECONDARY_ROAD_MAX_COUNT_Z = (int) Math.round((Double) v));
         r.slider("MINIMUM_ROAD_SEPARATION", SettingCategory.ROADS, 2, 32, 1,
-                p -> (double) p.MINIMUM_ROAD_SEPARATION, (p, v) -> p.MINIMUM_ROAD_SEPARATION = (int) Math.round((Double) v));
+                p -> (double) p.minimumRoadSeparation(), (p, v) -> p.MINIMUM_ROAD_SEPARATION = (int) Math.round((Double) v));
         r.slider("MINIMUM_ROAD_EDGE_DISTANCE", SettingCategory.ROADS, 2, 32, 1,
-                p -> (double) p.MINIMUM_ROAD_EDGE_DISTANCE, (p, v) -> p.MINIMUM_ROAD_EDGE_DISTANCE = (int) Math.round((Double) v));
+                p -> (double) p.minimumRoadEdgeDistance(), (p, v) -> p.MINIMUM_ROAD_EDGE_DISTANCE = (int) Math.round((Double) v));
 
         r.section("roads_tertiary");
         r.slider("TERTIARY_ROAD_CHANCE", SettingCategory.ROADS, 0.0, 1.0, 0.01,
-                p -> (double) p.TERTIARY_ROAD_CHANCE, (p, v) -> p.TERTIARY_ROAD_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.tertiaryRoadChance(), (p, v) -> p.TERTIARY_ROAD_CHANCE = ((Double) v).floatValue());
         r.slider("TERTIARY_ROAD_MIN_LENGTH", SettingCategory.ROADS, 1, 32, 1,
-                p -> (double) p.TERTIARY_ROAD_MIN_LENGTH, (p, v) -> p.TERTIARY_ROAD_MIN_LENGTH = (int) Math.round((Double) v));
+                p -> (double) p.tertiaryRoadMinLength(), (p, v) -> p.TERTIARY_ROAD_MIN_LENGTH = (int) Math.round((Double) v));
         r.slider("TERTIARY_ROAD_MAX_LENGTH", SettingCategory.ROADS, 1, 32, 1,
-                p -> (double) p.TERTIARY_ROAD_MAX_LENGTH, (p, v) -> p.TERTIARY_ROAD_MAX_LENGTH = (int) Math.round((Double) v));
+                p -> (double) p.tertiaryRoadMaxLength(), (p, v) -> p.TERTIARY_ROAD_MAX_LENGTH = (int) Math.round((Double) v));
 
         r.section("roads_bridges");
         r.slider("PLANNED_PRIMARY_BRIDGE_CHANCE", SettingCategory.ROADS, 0.0, 1.0, 0.01,
-                p -> (double) p.PLANNED_PRIMARY_BRIDGE_CHANCE, (p, v) -> p.PLANNED_PRIMARY_BRIDGE_CHANCE = ((Double) v).floatValue());
+                p -> (double) p.plannedPrimaryBridgeChance(), (p, v) -> p.PLANNED_PRIMARY_BRIDGE_CHANCE = ((Double) v).floatValue());
         r.slider("PLANNED_PRIMARY_BRIDGE_MAX_LENGTH", SettingCategory.ROADS, 1, 64, 1,
-                p -> (double) p.PLANNED_PRIMARY_BRIDGE_MAX_LENGTH, (p, v) -> p.PLANNED_PRIMARY_BRIDGE_MAX_LENGTH = (int) Math.round((Double) v));
+                p -> (double) p.plannedPrimaryBridgeMaxLength(), (p, v) -> p.PLANNED_PRIMARY_BRIDGE_MAX_LENGTH = (int) Math.round((Double) v));
         r.cycle("MULTI_BUILDING_STREET_CONFLICT", SettingCategory.ROADS,
-                p -> p.MULTI_BUILDING_STREET_CONFLICT, (p, v) -> p.MULTI_BUILDING_STREET_CONFLICT = (MultiBuildingStreetConflict) v);
+                p -> p.multiBuildingStreetConflict(), (p, v) -> p.MULTI_BUILDING_STREET_CONFLICT = (MultiBuildingStreetConflict) v);
 
         // ==== TERRAIN ========================================================
         // Ground/sea level, terrain-adjustment offsets and bedrock. (Landscape type lives in GENERAL.)
         r.section("levels");
         r.slider("GROUNDLEVEL", SettingCategory.TERRAIN, 2, 256, 1,
-                p -> (double) p.GROUNDLEVEL, (p, v) -> p.GROUNDLEVEL = (int) Math.round((Double) v));
+                p -> (double) p.groundLevel(), (p, v) -> p.GROUNDLEVEL = (int) Math.round((Double) v));
         r.slider("SEALEVEL", SettingCategory.TERRAIN, -1, 256, 1,
-                p -> (double) p.SEALEVEL, (p, v) -> p.SEALEVEL = (int) Math.round((Double) v));
+                p -> (double) p.seaLevel(), (p, v) -> p.SEALEVEL = (int) Math.round((Double) v));
         r.slider("BEDROCK_LAYER", SettingCategory.TERRAIN, 0, 10, 1,
-                p -> (double) p.BEDROCK_LAYER, (p, v) -> p.BEDROCK_LAYER = (int) Math.round((Double) v));
+                p -> (double) p.bedrockLayer(), (p, v) -> p.BEDROCK_LAYER = (int) Math.round((Double) v));
 
         r.section("water");
         r.slider("OCEAN_CORRECTION_BORDER", SettingCategory.TERRAIN, -255, 255, 1,
-                p -> (double) p.OCEAN_CORRECTION_BORDER, (p, v) -> p.OCEAN_CORRECTION_BORDER = (int) Math.round((Double) v));
+                p -> (double) p.oceanCorrectionBorder(), (p, v) -> p.OCEAN_CORRECTION_BORDER = (int) Math.round((Double) v));
         r.toggle("AVOID_WATER", SettingCategory.TERRAIN,
-                p -> p.AVOID_WATER, (p, v) -> p.AVOID_WATER = (Boolean) v);
+                p -> p.avoidWater(), (p, v) -> p.AVOID_WATER = (Boolean) v);
 
         // Public on Preset since Task 3 (the runtime-generated profile format these replaced kept
         // both private and so never reachable from any editor) - datapack presets can already
@@ -423,65 +423,65 @@ public final class Settings {
         // than a silent gap.
         r.section("blocks");
         r.text("LIQUID_BLOCK", SettingCategory.TERRAIN,
-                p -> p.LIQUID_BLOCK, (p, v) -> p.LIQUID_BLOCK = (String) v);
+                p -> p.liquidBlock(), (p, v) -> p.LIQUID_BLOCK = (String) v);
         r.text("BASE_BLOCK", SettingCategory.TERRAIN,
-                p -> p.BASE_BLOCK, (p, v) -> p.BASE_BLOCK = (String) v);
+                p -> p.baseBlock(), (p, v) -> p.BASE_BLOCK = (String) v);
 
         // The min/max offsets that smooth city plots into surrounding terrain, split by lower and upper edge.
         r.section("adaptation");
         r.slider("TERRAIN_FIX_LOWER_MIN_OFFSET", SettingCategory.TERRAIN, -40, 40, 1,
-                p -> (double) p.TERRAIN_FIX_LOWER_MIN_OFFSET, (p, v) -> p.TERRAIN_FIX_LOWER_MIN_OFFSET = (int) Math.round((Double) v));
+                p -> (double) p.terrainFixLowerMinOffset(), (p, v) -> p.TERRAIN_FIX_LOWER_MIN_OFFSET = (int) Math.round((Double) v));
         r.slider("TERRAIN_FIX_LOWER_MAX_OFFSET", SettingCategory.TERRAIN, -40, 40, 1,
-                p -> (double) p.TERRAIN_FIX_LOWER_MAX_OFFSET, (p, v) -> p.TERRAIN_FIX_LOWER_MAX_OFFSET = (int) Math.round((Double) v));
+                p -> (double) p.terrainFixLowerMaxOffset(), (p, v) -> p.TERRAIN_FIX_LOWER_MAX_OFFSET = (int) Math.round((Double) v));
         r.slider("TERRAIN_FIX_UPPER_MIN_OFFSET", SettingCategory.TERRAIN, -40, 40, 1,
-                p -> (double) p.TERRAIN_FIX_UPPER_MIN_OFFSET, (p, v) -> p.TERRAIN_FIX_UPPER_MIN_OFFSET = (int) Math.round((Double) v));
+                p -> (double) p.terrainFixUpperMinOffset(), (p, v) -> p.TERRAIN_FIX_UPPER_MIN_OFFSET = (int) Math.round((Double) v));
         r.slider("TERRAIN_FIX_UPPER_MAX_OFFSET", SettingCategory.TERRAIN, -40, 40, 1,
-                p -> (double) p.TERRAIN_FIX_UPPER_MAX_OFFSET, (p, v) -> p.TERRAIN_FIX_UPPER_MAX_OFFSET = (int) Math.round((Double) v));
+                p -> (double) p.terrainFixUpperMaxOffset(), (p, v) -> p.TERRAIN_FIX_UPPER_MAX_OFFSET = (int) Math.round((Double) v));
 
         r.section("dimension");
         r.toggle("GENERATE_NETHER", SettingCategory.TERRAIN,
-                p -> p.GENERATE_NETHER, (p, v) -> p.GENERATE_NETHER = (Boolean) v);
+                p -> p.generateNether(), (p, v) -> p.GENERATE_NETHER = (Boolean) v);
 
         // ==== SPAWN ==========================================================
         // Player spawn placement (identifier fields live under ADVANCED as TEXT).
         r.section("placement");
         r.toggle("SPAWN_NOT_IN_BUILDING", SettingCategory.SPAWN,
-                p -> p.SPAWN_NOT_IN_BUILDING, (p, v) -> p.SPAWN_NOT_IN_BUILDING = (Boolean) v);
+                p -> p.spawnNotInBuilding(), (p, v) -> p.SPAWN_NOT_IN_BUILDING = (Boolean) v);
         r.toggle("FORCE_SPAWN_IN_BUILDING", SettingCategory.SPAWN,
-                p -> p.FORCE_SPAWN_IN_BUILDING, (p, v) -> p.FORCE_SPAWN_IN_BUILDING = (Boolean) v);
+                p -> p.forceSpawnInBuilding(), (p, v) -> p.FORCE_SPAWN_IN_BUILDING = (Boolean) v);
 
         // The spawn-search knobs all run to large validation ceilings (radii to 100000, attempts to a million)
         // with defaults sitting in a sliver of any slider track, so all three are typed NUMBER fields.
         r.section("search");
         r.number("SPAWN_CHECK_RADIUS", SettingCategory.SPAWN, 1, 100000, true,
-                p -> (double) p.SPAWN_CHECK_RADIUS, (p, v) -> p.SPAWN_CHECK_RADIUS = (int) Math.round((Double) v));
+                p -> (double) p.spawnCheckRadius(), (p, v) -> p.SPAWN_CHECK_RADIUS = (int) Math.round((Double) v));
         r.number("SPAWN_RADIUS_INCREASE", SettingCategory.SPAWN, 1, 100000, true,
-                p -> (double) p.SPAWN_RADIUS_INCREASE, (p, v) -> p.SPAWN_RADIUS_INCREASE = (int) Math.round((Double) v));
+                p -> (double) p.spawnRadiusIncrease(), (p, v) -> p.SPAWN_RADIUS_INCREASE = (int) Math.round((Double) v));
         r.number("SPAWN_CHECK_ATTEMPTS", SettingCategory.SPAWN, 1, 1000000, true,
-                p -> (double) p.SPAWN_CHECK_ATTEMPTS, (p, v) -> p.SPAWN_CHECK_ATTEMPTS = (int) Math.round((Double) v));
+                p -> (double) p.spawnCheckAttempts(), (p, v) -> p.SPAWN_CHECK_ATTEMPTS = (int) Math.round((Double) v));
 
         // ==== ADVANCED =======================================================
         // Identifier/list TEXT fields and low-level generation switches.
         r.section("identifiers");
         r.text("CITY_STYLE_ALTERNATIVE", SettingCategory.ADVANCED,
-                p -> p.CITY_STYLE_ALTERNATIVE, (p, v) -> p.CITY_STYLE_ALTERNATIVE = (String) v);
+                p -> p.cityStyleAlternative(), (p, v) -> p.CITY_STYLE_ALTERNATIVE = (String) v);
         r.text("SPAWN_BIOME", SettingCategory.ADVANCED,
-                p -> p.SPAWN_BIOME, (p, v) -> p.SPAWN_BIOME = (String) v);
+                p -> p.spawnBiome(), (p, v) -> p.SPAWN_BIOME = (String) v);
         r.text("SPAWN_CITY", SettingCategory.ADVANCED,
-                p -> p.SPAWN_CITY, (p, v) -> p.SPAWN_CITY = (String) v);
+                p -> p.spawnCity(), (p, v) -> p.SPAWN_CITY = (String) v);
         // Preset stores these as List<String> (the old profile format used String[]); the TEXT control's
         // boxing convention (SettingDescriptor's doc) stays String[] across the getter/setter boundary,
         // so the two are bridged right here rather than changing SettingControls' array handling.
         r.text("FORCE_SPAWN_BUILDINGS", SettingCategory.ADVANCED,
-                p -> p.FORCE_SPAWN_BUILDINGS.toArray(new String[0]), (p, v) -> p.FORCE_SPAWN_BUILDINGS = List.of((String[]) v));
+                p -> p.forceSpawnBuildings().toArray(new String[0]), (p, v) -> p.FORCE_SPAWN_BUILDINGS = List.of((String[]) v));
         r.text("FORCE_SPAWN_PARTS", SettingCategory.ADVANCED,
-                p -> p.FORCE_SPAWN_PARTS.toArray(new String[0]), (p, v) -> p.FORCE_SPAWN_PARTS = List.of((String[]) v));
+                p -> p.forceSpawnParts().toArray(new String[0]), (p, v) -> p.FORCE_SPAWN_PARTS = List.of((String[]) v));
 
         r.section("misc");
         r.toggle("MULTI_USE_CORNER", SettingCategory.ADVANCED,
-                p -> p.MULTI_USE_CORNER, (p, v) -> p.MULTI_USE_CORNER = (Boolean) v);
+                p -> p.multiUseCorner(), (p, v) -> p.MULTI_USE_CORNER = (Boolean) v);
         r.toggle("USE_AVG_HEIGHTMAP", SettingCategory.ADVANCED,
-                p -> p.USE_AVG_HEIGHTMAP, (p, v) -> p.USE_AVG_HEIGHTMAP = (Boolean) v);
+                p -> p.useAvgHeightmap(), (p, v) -> p.USE_AVG_HEIGHTMAP = (Boolean) v);
 
         return List.copyOf(r.all);
     }

--- a/src/main/java/dev/krona/urbex/setup/Config.java
+++ b/src/main/java/dev/krona/urbex/setup/Config.java
@@ -268,7 +268,7 @@ public class Config {
                             "the GENERATE_NETHER probe will see the un-overridden preset.", e);
                 }
             }
-            if (overworldPreset.GENERATE_NETHER) {
+            if (overworldPreset.generateNether()) {
                 cache.put(Level.NETHER, new PresetChoice(
                         Identifier.fromNamespaceAndPath("urbex", "cavern"), DEFAULT_WORLD_STYLE_MIX, Optional.empty()));
             }

--- a/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
+++ b/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
@@ -84,18 +84,18 @@ public class SpawnPlacement {
             Predicate<BlockPos> isSuitable = pos -> true;
             boolean needsCheck = false;
 
-            if (!profile.SPAWN_BIOME.isEmpty()) {
-                final Biome spawnBiome = serverLevel.registryAccess().lookupOrThrow(Registries.BIOME).getValue(Identifier.parse(profile.SPAWN_BIOME));
+            if (!profile.spawnBiome().isEmpty()) {
+                final Biome spawnBiome = serverLevel.registryAccess().lookupOrThrow(Registries.BIOME).getValue(Identifier.parse(profile.spawnBiome()));
                 if (spawnBiome == null) {
-                    ModSetup.getLogger().error("Cannot find biome '{}' for the player to spawn in !", profile.SPAWN_BIOME);
+                    ModSetup.getLogger().error("Cannot find biome '{}' for the player to spawn in !", profile.spawnBiome());
                 } else {
                     isSuitable = blockPos -> world.getBiome(blockPos).value() == spawnBiome;
                     needsCheck = true;
                 }
-            } else if (!profile.SPAWN_CITY.isEmpty()) {
-                final PredefinedCity city = dimensionInfo.assets().predefinedCities().get(profile.SPAWN_CITY);
+            } else if (!profile.spawnCity().isEmpty()) {
+                final PredefinedCity city = dimensionInfo.assets().predefinedCities().get(profile.spawnCity());
                 if (city == null) {
-                    ModSetup.getLogger().error("Cannot find city '{}' for the player to spawn in !", profile.SPAWN_CITY);
+                    ModSetup.getLogger().error("Cannot find city '{}' for the player to spawn in !", profile.spawnCity());
                 } else {
                     float sqradius = getSqRadius(city.getRadius(), 0.8f);
                     isSuitable = blockPos -> city.getDimension() == serverLevel.dimension() &&
@@ -104,12 +104,12 @@ public class SpawnPlacement {
                 }
             }
 
-            if (profile.SPAWN_NOT_IN_BUILDING) {
+            if (profile.spawnNotInBuilding()) {
                 isSuitable = isSuitable.and(blockPos -> isOutsideBuilding(dimensionInfo, blockPos));
                 needsCheck = true;
-            } else if (!profile.FORCE_SPAWN_BUILDINGS.isEmpty() || !profile.FORCE_SPAWN_PARTS.isEmpty()) {
-                Set<String> buildings = Set.copyOf(profile.FORCE_SPAWN_BUILDINGS);
-                Set<String> parts = Set.copyOf(profile.FORCE_SPAWN_PARTS);
+            } else if (!profile.forceSpawnBuildings().isEmpty() || !profile.forceSpawnParts().isEmpty()) {
+                Set<String> buildings = Set.copyOf(profile.forceSpawnBuildings());
+                Set<String> parts = Set.copyOf(profile.forceSpawnParts());
                 isSuitable = isSuitable.and(blockPos -> {
                     ChunkCoord coord = new ChunkCoord(dimensionInfo.dimension(), blockPos.getX() >> 4, blockPos.getZ() >> 4);
                     ChunkPlan info = ChunkPlan.getChunkPlan(coord, dimensionInfo);
@@ -136,7 +136,7 @@ public class SpawnPlacement {
                     return false;
                 });
                 needsCheck = true;
-            } else if (profile.FORCE_SPAWN_IN_BUILDING) {
+            } else if (profile.forceSpawnInBuilding()) {
                 isSuitable = isSuitable.and(blockPos -> !isOutsideBuilding(dimensionInfo, blockPos));
                 needsCheck = true;
             }
@@ -185,7 +185,7 @@ public class SpawnPlacement {
     private static BlockPos findSafeSpawnPoint(Level world, PlanningContext provider, @Nonnull Predicate<BlockPos> isSuitable,
                                     @Nonnull ServerLevelData serverLevelData) {
         Random rand = new Random(provider.seed());
-        int radius = provider.preset().SPAWN_CHECK_RADIUS;
+        int radius = provider.preset().spawnCheckRadius();
         int attempts = 0;
 //        int bottom = world.getWorldType().getMinimumSpawnHeight(world);
         while (true) {
@@ -201,7 +201,7 @@ public class SpawnPlacement {
                 ChunkCoord coord = new ChunkCoord(provider.dimension(), x >> 4, z >> 4);
                 Preset profile = provider.preset();
 
-                for (int y = profile.GROUNDLEVEL-5 ; y < 125 ; y++) {
+                for (int y = profile.groundLevel()-5 ; y < 125 ; y++) {
                     BlockPos pos = new BlockPos(x, y, z);
                     if (isValidStandingPosition(world, pos)) {
 //                        serverLevelData.setSpawn(pos.above(), 0.0f);
@@ -209,8 +209,8 @@ public class SpawnPlacement {
                     }
                 }
             }
-            radius += provider.preset().SPAWN_RADIUS_INCREASE;
-            if (attempts > provider.preset().SPAWN_CHECK_ATTEMPTS) {
+            radius += provider.preset().spawnRadiusIncrease();
+            if (attempts > provider.preset().spawnCheckAttempts()) {
                 Urbex.setup.getLogger().error("Can't find a valid spawn position!");
                 throw new RuntimeException("Can't find a valid spawn position!");
             }

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -83,7 +83,7 @@ public class CityGenerator {
     public CityGenerator(PlanningContext provider, Preset profile) {
         this.provider = provider;
         this.profile = profile;
-//        int waterLevel = provider.getWorld() == null ? 65 : Tools.getSeaLevel(provider.getWorld());// profile.GROUNDLEVEL - profile.WATERLEVEL_OFFSET;
+//        int waterLevel = provider.getWorld() == null ? 65 : Tools.getSeaLevel(provider.getWorld());// profile.groundLevel() - profile.WATERLEVEL_OFFSET;
         // Four independent noise fields, each seeded from the world seed alone. They describe the
         // whole dimension rather than one chunk, so they take a fixed coordinate and are built once.
         long seed = provider.seed();
@@ -295,7 +295,7 @@ public class CityGenerator {
         // If this chunk has a building or street but we're in a floating profile and
         // we happen to have a void chunk we detect that here and go back to normal chunk generation
         // anyway
-        if (doCity && provider.preset().CITY_AVOID_VOID && provider.preset().isFloating()) {
+        if (doCity && provider.preset().cityAvoidVoid() && provider.preset().isFloating()) {
             boolean v = isVoid(ctx, 2, 2) || isVoid(ctx, 2, 14) || isVoid(ctx, 14, 2) || isVoid(ctx, 14, 14) || isVoid(ctx, 8, 8);
             doCity = !v;
         }
@@ -744,7 +744,7 @@ public class CityGenerator {
      */
     private void fillSupportBelow(ChunkGenContext ctx, int x, int z, int y) {
         ChunkDriver driver = ctx.driver;
-        int lowest = provider.shape().minY() + profile.BEDROCK_LAYER;
+        int lowest = provider.shape().minY() + profile.bedrockLayer();
         driver.current(x, y, z);
         while (driver.getY() > lowest && isEmpty(driver.getBlock())) {
             driver.block(base);
@@ -890,7 +890,7 @@ public class CityGenerator {
             BlockState bedrock = Blocks.BEDROCK.defaultBlockState();
             for (int x = 0; x < 16; ++x) {
                 for (int z = 0; z < 16; ++z) {
-                    driver.setBlockRange(x, minHeight, z, minHeight + info.profile.BEDROCK_LAYER, bedrock);
+                    driver.setBlockRange(x, minHeight, z, minHeight + info.profile.bedrockLayer(), bedrock);
                 }
             }
 
@@ -924,7 +924,7 @@ public class CityGenerator {
             generateStreet(ctx, info, heightmap);
         }
 
-        if (info.profile.RUIN_CHANCE > 0.0) {
+        if (info.profile.ruinChance() > 0.0) {
             generateRuins(ctx, info);
         }
 
@@ -941,7 +941,7 @@ public class CityGenerator {
             Highways.generateHighways(ctx, this, info);
         }
 
-        if (info.profile.RUBBLELAYER) {
+        if (info.profile.rubbleLayer()) {
             if (!info.hasBuilding || info.ruinHeight >= 0) {
                 generateRubble(ctx, info);
             }
@@ -1035,8 +1035,8 @@ public class CityGenerator {
         Set<BlockState> possibleRandomDirts = getPossibleRandomDirts(ctx, info, info.getCompiledPalette());
         for (int x = 0; x < 16; ++x) {
             for (int z = 0; z < 16; ++z) {
-                double vr = info.profile.RUBBLE_DIRT_SCALE < 0.01f ? 0 : rubbleBuffer[x + z * 16] / info.profile.RUBBLE_DIRT_SCALE;
-                double vl = info.profile.RUBBLE_LEAVE_SCALE < 0.01f ? 0 : leavesBuffer[x + z * 16] / info.profile.RUBBLE_LEAVE_SCALE;
+                double vr = info.profile.rubbleDirtScale() < 0.01f ? 0 : rubbleBuffer[x + z * 16] / info.profile.rubbleDirtScale();
+                double vl = info.profile.rubbleLeaveScale() < 0.01f ? 0 : leavesBuffer[x + z * 16] / info.profile.rubbleLeaveScale();
                 if (vr > .5 || vl > .5) {
                     int height = getInterpolatedHeight(info, x, z);
                     driver.current(x, height, z);
@@ -1127,7 +1127,7 @@ public class CityGenerator {
         double d0 = 0.03125D;
         double[] ruinBuffer = ctx.buffers.ruin = this.ruinNoise.getRegion(ctx.buffers.ruin, (chunkX << 4), (chunkZ << 4), 16, 16, d0 * 2.0D, d0 * 2.0D, 1.0D);
         double[] leavesBuffer = ctx.buffers.leaves;
-        boolean doLeaves = info.profile.RUBBLELAYER;
+        boolean doLeaves = info.profile.rubbleLayer();
         if (doLeaves) {
             leavesBuffer = ctx.buffers.leaves = this.leavesNoise.getRegion(ctx.buffers.leaves, (chunkX << 6), (chunkZ << 6), 16, 16, 1.0 / 64.0, 1.0 / 64.0, 4.0D);
         }
@@ -1155,8 +1155,8 @@ public class CityGenerator {
                 }
                 int vl = 0;
                 if (doLeaves) {
-                    vl = (int) (info.profile.RUBBLE_LEAVE_SCALE < 0.01f ? 0 : leavesBuffer[x + z * 16] / info.profile.RUBBLE_LEAVE_SCALE);
-//                    vl = (int) (info.profile.RUBBLE_LEAVE_SCALE < 0.01f ? 0 : leavesNoise.getValue(x / 64.0, z / 64.0) / 4.0 * info.profile.RUBBLE_LEAVE_SCALE);
+                    vl = (int) (info.profile.rubbleLeaveScale() < 0.01f ? 0 : leavesBuffer[x + z * 16] / info.profile.rubbleLeaveScale());
+//                    vl = (int) (info.profile.rubbleLeaveScale() < 0.01f ? 0 : leavesNoise.getValue(x / 64.0, z / 64.0) / 4.0 * info.profile.rubbleLeaveScale());
                 }
                 boolean doRubble = palette.isDefined(rubbleBlock);
                 while (height > 0) {
@@ -1220,7 +1220,7 @@ public class CityGenerator {
                         driver.block(elevation).incZ();
                     }
                 }
-                boolean parkElevation = info.profile.PARK_ELEVATION;
+                boolean parkElevation = info.profile.parkElevation();
                 if (info.getCityStyle().getParkElevation() != null) {
                     parkElevation = info.getCityStyle().getParkElevation();
                 }
@@ -1321,11 +1321,11 @@ public class CityGenerator {
             for (int z = 0; z < 16; ++z) {
                 int y = info.getCityGroundLevel() - 1;
                 driver.current(x, y, z);
-                while (driver.getY() > (minHeight + info.profile.BEDROCK_LAYER) && isEmpty(driver.getBlock())) {
+                while (driver.getY() > (minHeight + info.profile.bedrockLayer()) && isEmpty(driver.getBlock())) {
                     driver.block(base);
                     driver.decY();
                 }
-//                driver.setBlockRange(x, info.profile.BEDROCK_LAYER, z, info.getCityGroundLevel(), baseChar);
+//                driver.setBlockRange(x, info.profile.bedrockLayer(), z, info.getCityGroundLevel(), baseChar);
             }
         }
     }
@@ -1412,7 +1412,7 @@ public class CityGenerator {
         ChunkDriver driver = ctx.driver;
 
         if (info.getXmin().hasBuilding) {
-            for (int x = 0; x < info.profile.THICKNESS_OF_RANDOM_LEAFBLOCKS; x++) {
+            for (int x = 0; x < info.profile.randomLeafBlockThickness(); x++) {
                 for (int z = 0; z < 16; z++) {
                     driver.current(x, height, z);
                     // @todo can be more optimal? Only go down to non air in case random succeeds?
@@ -1420,7 +1420,7 @@ public class CityGenerator {
                     while (driver.getBlockDown() == air && driver.getY() > 0) {
                         driver.decY();
                     }
-                    float v = Math.min(.8f, info.profile.CHANCE_OF_RANDOM_LEAFBLOCKS * (info.profile.THICKNESS_OF_RANDOM_LEAFBLOCKS + 1 - x));
+                    float v = Math.min(.8f, info.profile.randomLeafBlockChance() * (info.profile.randomLeafBlockThickness() + 1 - x));
                     int cnt = 0;
                     while (rollHere(ctx, driver, Rng.Purpose.VEGETATION) < v && cnt < 30) {
                         driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
@@ -1430,7 +1430,7 @@ public class CityGenerator {
             }
         }
         if (info.getXmax().hasBuilding) {
-            for (int x = 15 - info.profile.THICKNESS_OF_RANDOM_LEAFBLOCKS; x < 15; x++) {
+            for (int x = 15 - info.profile.randomLeafBlockThickness(); x < 15; x++) {
                 for (int z = 0; z < 16; z++) {
                     driver.current(x, height, z);
                     // @todo can be more optimal? Only go down to non air in case random succeeds?
@@ -1438,7 +1438,7 @@ public class CityGenerator {
                     while (driver.getBlockDown() == air && driver.getY() > 0) {
                         driver.decY();
                     }
-                    float v = Math.min(.8f, info.profile.CHANCE_OF_RANDOM_LEAFBLOCKS * (x - 14 + info.profile.THICKNESS_OF_RANDOM_LEAFBLOCKS));
+                    float v = Math.min(.8f, info.profile.randomLeafBlockChance() * (x - 14 + info.profile.randomLeafBlockThickness()));
                     int cnt = 0;
                     while (rollHere(ctx, driver, Rng.Purpose.VEGETATION_XMAX) < v && cnt < 30) {
                         driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
@@ -1448,7 +1448,7 @@ public class CityGenerator {
             }
         }
         if (info.getZmin().hasBuilding) {
-            for (int z = 0; z < info.profile.THICKNESS_OF_RANDOM_LEAFBLOCKS; z++) {
+            for (int z = 0; z < info.profile.randomLeafBlockThickness(); z++) {
                 for (int x = 0; x < 16; x++) {
                     driver.current(x, height, z);
                     // @todo can be more optimal? Only go down to non air in case random succeeds?
@@ -1456,7 +1456,7 @@ public class CityGenerator {
                     while (driver.getBlockDown() == air && driver.getY() > 0) {
                         driver.decY();
                     }
-                    float v = Math.min(.8f, info.profile.CHANCE_OF_RANDOM_LEAFBLOCKS * (info.profile.THICKNESS_OF_RANDOM_LEAFBLOCKS + 1 - z));
+                    float v = Math.min(.8f, info.profile.randomLeafBlockChance() * (info.profile.randomLeafBlockThickness() + 1 - z));
                     int cnt = 0;
                     while (rollHere(ctx, driver, Rng.Purpose.VEGETATION_ZMIN) < v && cnt < 30) {
                         driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
@@ -1466,7 +1466,7 @@ public class CityGenerator {
             }
         }
         if (info.getZmax().hasBuilding) {
-            for (int z = 15 - info.profile.THICKNESS_OF_RANDOM_LEAFBLOCKS; z < 15; z++) {
+            for (int z = 15 - info.profile.randomLeafBlockThickness(); z < 15; z++) {
                 for (int x = 0; x < 16; x++) {
                     driver.current(x, height, z);
                     // @todo can be more optimal? Only go down to non air in case random succeeds?
@@ -1474,7 +1474,7 @@ public class CityGenerator {
                     while (driver.getBlockDown() == air && driver.getY() > 0) {
                         driver.decY();
                     }
-                    float v = info.profile.CHANCE_OF_RANDOM_LEAFBLOCKS * (z - 14 + info.profile.THICKNESS_OF_RANDOM_LEAFBLOCKS);
+                    float v = info.profile.randomLeafBlockChance() * (z - 14 + info.profile.randomLeafBlockThickness());
                     int cnt = 0;
                     while (rollHere(ctx, driver, Rng.Purpose.VEGETATION_ZMAX) < v && cnt < 30) {
                         driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
@@ -1501,7 +1501,7 @@ public class CityGenerator {
 
         Character grassChar = info.getCityStyle().getGrassBlock();
         BlockState grassBlock = Blocks.GRASS_BLOCK.defaultBlockState();
-        boolean parkBorder = info.getCityStyle().getParkBorder() != null ? info.getCityStyle().getParkBorder() : info.profile.PARK_BORDER;
+        boolean parkBorder = info.getCityStyle().getParkBorder() != null ? info.getCityStyle().getParkBorder() : info.profile.parkBorder();
         for (int x = 0; x < 16; ++x) {
             for (int z = 0; z < 16; ++z) {
                 // Resolved per column, at the block it will be written to.
@@ -1771,7 +1771,7 @@ public class CityGenerator {
                              Transform transform,
                              int ox, int oy, int oz, HardAirSetting airWaterLevel) {
         ChunkDriver driver = ctx.driver;
-        if (profile.EDITMODE) {
+        if (profile.editMode()) {
             EditModeData.getData().addPartData(info.coord, oy, part.getName());
         }
         CompiledPalette compiledPalette = computePalette(info, part);
@@ -1802,7 +1802,7 @@ public class CityGenerator {
                         // We don't replace the world where the part is empty (air)
                         if (b != air) {
                             if (b == liquid) {
-                                if (info.profile.AVOID_WATER) {
+                                if (info.profile.avoidWater()) {
                                     b = air;
                                 }
                             } else if (b == hardAir) {
@@ -1811,7 +1811,7 @@ public class CityGenerator {
                                         b = air;
                                         break;
                                     case WATERLEVEL:
-                                        if (!info.profile.AVOID_FOLIAGE && !nowater && oy + y < info.waterLevel) {
+                                        if (!info.profile.avoidFoliage() && !nowater && oy + y < info.waterLevel) {
                                             b = liquid;
                                         } else {
                                             b = air;
@@ -1860,7 +1860,7 @@ public class CityGenerator {
     }
 
     public BlockState handleLightMarker(ChunkGenContext ctx, Palette.Info marker, BlockPos pos) {
-        if (DensitySelector.lighting(ctx.seed, pos, ctx.info.profile.LIGHTING_DENSITY)) {
+        if (DensitySelector.lighting(ctx.seed, pos, ctx.info.profile.lightingDensity())) {
             ctx.addLightTodo(pos, marker.light());
         }
         return air;
@@ -1989,7 +1989,7 @@ public class CityGenerator {
     private BlockState handleTodo(ChunkGenContext ctx, ChunkPlan info, int oy, WorldGenLevel world, int rx, int rz, int y, BlockState b) {
         Block block = b.getBlock();
         CityStyle cs = info.getCityStyle();
-        boolean avoidFoliage = info.profile.AVOID_FOLIAGE;
+        boolean avoidFoliage = info.profile.avoidFoliage();
         if (cs.getAvoidFoliage() != null) {
             avoidFoliage = cs.getAvoidFoliage();
         }
@@ -2073,7 +2073,7 @@ public class CityGenerator {
     public static Identifier getRandomSpawnerMob(Level world, RandomSource random, PlanningContext diminfo, ChunkPlan info, ChunkPlan.ConditionTodo todo, BlockPos pos) {
         String condition = todo.getCondition();
         Condition cnd = diminfo.assets().conditions().getOrThrow(condition);
-        int level = (pos.getY() - diminfo.preset().GROUNDLEVEL) / FLOORHEIGHT;
+        int level = (pos.getY() - diminfo.preset().groundLevel()) / FLOORHEIGHT;
         int floor = (pos.getY() - info.getCityGroundLevel()) / FLOORHEIGHT;
         String belowFloor = ConditionContext.NO_PART;
         ConditionContext conditionContext = new ConditionContext(level, floor, info.cellars, info.getNumFloors(),
@@ -2108,7 +2108,7 @@ public class CityGenerator {
         if (tileentity instanceof RandomizableContainerBlockEntity rcbe) {
             if (todo != null) {
                 String lootTable = todo.getCondition();
-                int level = (pos.getY() - diminfo.preset().GROUNDLEVEL) / FLOORHEIGHT;
+                int level = (pos.getY() - diminfo.preset().groundLevel()) / FLOORHEIGHT;
                 int floor = (pos.getY() - info.getCityGroundLevel()) / FLOORHEIGHT;
                 ConditionContext conditionContext = new ConditionContext(level, floor, info.cellars, info.getNumFloors(),
                         todo.getPart(), ConditionContext.NO_PART, todo.getBuilding(), info.coord) {
@@ -2157,7 +2157,7 @@ public class CityGenerator {
                 float damage = Math.max(1.0f, damageFactor * DamageArea.BLOCK_DAMAGE_CHANCE);
                 int destroyedBlocks = (int) (blocks * damage);
                 // How many go this direction (approx, based on cardinal directions from building as well as number that simply fall down)
-                destroyedBlocks /= info.profile.DEBRIS_TO_NEARBYCHUNK_FACTOR;
+                destroyedBlocks /= info.profile.debrisToNearbyChunkFactor();
                 int startHeight = adjacentInfo.getMaxHeight() + 10;
                 int maxBuildHeight = info.provider.shape().maxBuildHeight();
                 int minBuildHeight = info.provider.shape().minY();

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionRuntime.java
@@ -129,7 +129,7 @@ public record DimensionRuntime(ServerLevel level, @Nullable PlanningContext plan
         // deliberately not fail-soft like the overrides parse above: a malformed payload can be
         // ignored and the un-overridden preset used, but a style that cannot resolve has no such
         // fallback - City.getCityStyle would simply hand null on to generation.
-        requireCityStyle(assets, preset.CITY_STYLE_ALTERNATIVE, type.identifier());
+        requireCityStyle(assets, preset.cityStyleAlternative(), type.identifier());
         PlanningContext planning = planningFor(level, assets, preset, choice.worldStyles());
         return new DimensionRuntime(level, planning, new CityGenerator(planning, preset), tagEpoch);
     }

--- a/src/main/java/dev/krona/urbex/worldgen/LevelTerrain.java
+++ b/src/main/java/dev/krona/urbex/worldgen/LevelTerrain.java
@@ -65,7 +65,7 @@ public final class LevelTerrain implements TerrainSampler {
         if (cached != null) {
             return cached;
         }
-        ChunkHeightmap heightmap = new ChunkHeightmap(preset.LANDSCAPE_TYPE, preset.GROUNDLEVEL);
+        ChunkHeightmap heightmap = new ChunkHeightmap(preset.landscapeType(), preset.groundLevel());
         heightmap.update(baseHeight((sampler.chunkX() << 4) + 8, (sampler.chunkZ() << 4) + 8));
         if (heightSampleSize > 1) {
             for (int i = 0; i < heightSampleSize; i++) {

--- a/src/main/java/dev/krona/urbex/worldgen/SpecialMarkerPolicy.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SpecialMarkerPolicy.java
@@ -11,10 +11,10 @@ final class SpecialMarkerPolicy {
     }
 
     static boolean populateLoot(long seed, BlockPos marker, Preset profile) {
-        return DensitySelector.loot(seed, marker, profile.LOOT_DENSITY);
+        return DensitySelector.loot(seed, marker, profile.lootDensity());
     }
 
     static boolean generateSpawner(Preset profile) {
-        return profile.GENERATE_SPAWNERS;
+        return profile.generateSpawners();
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/WorldStyleField.java
+++ b/src/main/java/dev/krona/urbex/worldgen/WorldStyleField.java
@@ -155,12 +155,12 @@ public final class WorldStyleField {
         Preset profile = provider.preset();
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
-        if (profile.CITY_CHANCE < 0) {
+        if (profile.cityChance() < 0) {
             return draw(Math.floorDiv(chunkX, PERLIN_REGION_CHUNKS), Math.floorDiv(chunkZ, PERLIN_REGION_CHUNKS));
         }
         ChunkCoord best = null;
         float bestFactor = 0;
-        int offset = (profile.CITY_MAXRADIUS + 15) / 16;
+        int offset = (profile.cityMaxRadius() + 15) / 16;
         for (int cx = chunkX - offset; cx <= chunkX + offset; cx++) {
             for (int cz = chunkZ - offset; cz <= chunkZ + offset; cz++) {
                 ChunkCoord c = new ChunkCoord(provider.dimension(), cx, cz);

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Bridges.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Bridges.java
@@ -36,8 +36,8 @@ public class Bridges {
         // slung over a gap. A planned primary bridge is the road itself carried onward, so its deck
         // sits at the street surface and its markings line up with the road at either end.
         int bridgeLevel = info.getPlannedBridge() != null
-                ? info.profile.GROUNDLEVEL
-                : info.profile.GROUNDLEVEL + 1;
+                ? info.profile.groundLevel()
+                : info.profile.groundLevel() + 1;
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
                 driver.current(x, bridgeLevel, z);
@@ -58,7 +58,7 @@ public class Bridges {
         }
 
         Character support = bt.getMetaChar(BuildingPart.META_SUPPORT);
-        if (info.profile.BRIDGE_SUPPORTS && support != null) {
+        if (info.profile.bridgeSupports() && support != null) {
             BlockState sup = ctx.paletteAt(compiledPalette, support, 7, info.groundLevel, 7);
             // Everything below the deck is measured from the deck, not from the ground: the pillar
             // and the two side lips belong one block under whichever level the deck landed on. Read

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Highways.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Highways.java
@@ -83,7 +83,7 @@ public class Highways {
         }
 
         Character support = part.getMetaChar(BuildingPart.META_SUPPORT);
-        if (info.profile.HIGHWAY_SUPPORTS && support != null) {
+        if (info.profile.highwaySupports() && support != null) {
             BlockState sup = ctx.paletteAt(info.getCompiledPalette(), support, 0, highwayGroundLevel - 1, 0);
             if (sup == null) {
                 throw new RuntimeException("Cannot find support block '" + support + "' for highway part '" + part.getName() + "'!");

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Scattered.java
@@ -77,7 +77,7 @@ public class Scattered {
 
         RandomSource scatteredRandom = Rng.at(provider.seed(), ax, az, Rng.Purpose.SCATTERED);
 
-        if (scatteredRandom.nextFloat() >= (scatteredSettings.getChance() * provider.preset().SCATTERED_CHANCE_MULTIPLIER)) {
+        if (scatteredRandom.nextFloat() >= (scatteredSettings.getChance() * provider.preset().scatteredChanceMultiplier())) {
             // No scattered structure in this area
             return;
         }
@@ -156,7 +156,7 @@ public class Scattered {
             if (lowestLevel < -4000) {
                 Preset profile = feature.provider.preset();
                 if (profile.isCavern()) {
-                    lowestLevel = profile.GROUNDLEVEL;
+                    lowestLevel = profile.groundLevel();
                 } else {
                     lowestLevel = provider.shape().minY() + 2;  // @todo is this right?
                 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkContentResolver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkContentResolver.java
@@ -144,7 +144,7 @@ public final class ChunkContentResolver {
         }
 
         CityStyle style = facts.cityStyle().get();
-        float buildingChance = profile.BUILDING_CHANCE;
+        float buildingChance = profile.buildingChance();
         if (style.getBuildingChance() != null) {
             buildingChance = style.getBuildingChance();
         }
@@ -222,7 +222,7 @@ public final class ChunkContentResolver {
         // Every open lot is grass, unconditionally - that is the point of the whole road field. A lot
         // is what is left over between the planned roads, and rendering some of them as street parts
         // would scatter road fragments through the middle of city blocks, which is the artefact the
-        // hierarchical roads exist to remove. OPEN_LOT_PARK_CHANCE decides only whether the lot is
+        // hierarchical roads exist to remove. openLotParkChance() decides only whether the lot is
         // furnished with a park part; it never reaches the surface underneath.
         //
         // The roll has its own GridPurpose key rather than sharing an address with a neighbouring
@@ -230,7 +230,7 @@ public final class ChunkContentResolver {
         // decision.
         boolean parkPart = openLot
                 && Hash.unit(Hash.at(seed, coord.chunkX(), coord.chunkZ(), GridPurpose.OPEN_LOT_PARK.key()))
-                        < profile.OPEN_LOT_PARK_CHANCE;
+                        < profile.openLotParkChance();
 
         // Settled whether or not a building claimed the chunk: see the draw discipline note above.
         // A non-top-left multi-building chunk copies the top-left's street type instead.

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -317,7 +317,7 @@ public class ChunkPlan {
         boolean isCity = isCityRaw(key, provider, profile);
         int cityLevel = getCityLevelGui(key, provider);
         RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
-        boolean couldHaveBuilding = isCity && rand.nextFloat() < profile.BUILDING_CHANCE;
+        boolean couldHaveBuilding = isCity && rand.nextFloat() < profile.buildingChance();
         // The preview resolves neither a multi-building section nor a style, exactly as before -
         // those three stay null here rather than being computed for a screen that does not use them.
         return new ChunkCandidate(isCity, couldHaveBuilding, null, cityLevel, null, null, null);
@@ -351,7 +351,7 @@ public class ChunkPlan {
         if (multiPos.isSingle()) {
             cityLevel = getCityLevel(coord, provider);
         } else {
-            cityLevel = profile.MULTI_USE_CORNER ? getTopLeftCityLevel(multiPos, coord, provider)
+            cityLevel = profile.multiUseCorner() ? getTopLeftCityLevel(multiPos, coord, provider)
                     : getAverageCityLevel(multiPos, coord, provider);
         }
         RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
@@ -431,7 +431,7 @@ public class ChunkPlan {
         }
 
         float cityFactor = City.getCityFactor(coord, provider, profile);
-        return cityFactor > profile.CITY_THRESHOLD;
+        return cityFactor > profile.cityThreshold();
     }
 
     public static boolean isCity(ChunkCoord coord, PlanningContext provider) {
@@ -671,8 +671,8 @@ public class ChunkPlan {
                 candidate.buildingType().getName());
         hasBuilding = override != null || content.hasBuilding();
 
-        groundLevel = override != null ? override.groundLevel() : profile.GROUNDLEVEL;
-        int wl = profile.SEALEVEL;
+        groundLevel = override != null ? override.groundLevel() : profile.groundLevel();
+        int wl = profile.seaLevel();
         waterLevel = wl == -1 ? provider.shape().seaLevel() : wl;
         WorldSettings.RailwayAvoidance avoidance = provider.worldStyles().primary().getWorldSettings().railwayAvoidance();
 
@@ -699,7 +699,7 @@ public class ChunkPlan {
             highwayZLevel = Highway.getZHighwayLevel(key, provider, profile);
 
             streetType = content.streetType();
-            float fountainChance = cs.getFountainChance() != null ? cs.getFountainChance() : profile.FOUNTAIN_CHANCE;
+            float fountainChance = cs.getFountainChance() != null ? cs.getFountainChance() : profile.fountainChance();
             if (rand.nextFloat() < fountainChance) {
                 fountainType = provider.assets().parts().getOrWarn(cs.getRandomFountain(rand, this.coord));
             } else {
@@ -714,7 +714,7 @@ public class ChunkPlan {
             float cityFactor = City.getCityFactor(coord, provider, profile);
 
             int maxfloors = getMaxfloors(cs);
-            int f = profile.BUILDING_MINFLOORS + rand.nextInt((int) (profile.BUILDING_MINFLOORS_CHANCE + (cityFactor + .1f) * (profile.BUILDING_MAXFLOORS_CHANCE - profile.BUILDING_MINFLOORS_CHANCE)));
+            int f = profile.buildingMinFloors() + rand.nextInt((int) (profile.buildingMinFloorsChance() + (cityFactor + .1f) * (profile.buildingMaxFloorsChance() - profile.buildingMinFloorsChance())));
             f++;
             if (f > maxfloors) {
                 f = maxfloors;
@@ -731,7 +731,7 @@ public class ChunkPlan {
             floors = override != null ? override.floors() : f;
 
             int maxcellars = getMaxcellars(cs);
-            int mincellars = Math.max(profile.BUILDING_MINCELLARS, buildingType.getMinCellars());
+            int mincellars = Math.max(profile.buildingMinCellars(), buildingType.getMinCellars());
             int fb = mincellars + ((maxcellars <= 0) ? 0 : rand.nextInt(maxcellars + 1));
             boolean checkHighway = getMaxHighwayLevel() >= 0;
             boolean checkRailway = avoidance != WorldSettings.RailwayAvoidance.BLOCK_RAILWAY && getRailInfo() != Railway.RailChunkInfo.NOTHING;
@@ -765,8 +765,8 @@ public class ChunkPlan {
             // Preserve the legacy building stream slot formerly used by buildingWithoutLootChance.
             rand.nextFloat();
             float r = rand.nextFloat();
-            if (rand.nextFloat() < profile.RUIN_CHANCE && (predefinedBuilding == null || !predefinedBuilding.preventRuins())) {
-                ruinHeight = profile.RUIN_MINLEVEL_PERCENT + (profile.RUIN_MAXLEVEL_PERCENT - profile.RUIN_MINLEVEL_PERCENT) * r;
+            if (rand.nextFloat() < profile.ruinChance() && (predefinedBuilding == null || !predefinedBuilding.preventRuins())) {
+                ruinHeight = profile.ruinMinlevelPercent() + (profile.ruinMaxlevelPercent() - profile.ruinMinlevelPercent()) * r;
             } else {
                 ruinHeight = -1;
             }
@@ -826,11 +826,11 @@ public class ChunkPlan {
             // Last in the body: what still reads this local is the *next* iteration's parts[]
             // context, at the top of the loop, which must see the floor below rather than this one.
             belowPart = part;
-            connectionAtX[i] = isCity(coord.west(), provider) && (rand.nextFloat() < profile.BUILDING_DOORWAYCHANCE);
-            connectionAtZ[i] = isCity(coord.north(), provider) && (rand.nextFloat() < profile.BUILDING_DOORWAYCHANCE);
+            connectionAtX[i] = isCity(coord.west(), provider) && (rand.nextFloat() < profile.buildingDoorwayChance());
+            connectionAtZ[i] = isCity(coord.north(), provider) && (rand.nextFloat() < profile.buildingDoorwayChance());
         }
 
-        float corridorChance = cs.getCorridorChance() != null ? cs.getCorridorChance() : profile.CORRIDOR_CHANCE;
+        float corridorChance = cs.getCorridorChance() != null ? cs.getCorridorChance() : profile.corridorChance();
         if (hasBuilding && cellars > 0) {
             xRailCorridor = false;
             zRailCorridor = false;
@@ -843,11 +843,11 @@ public class ChunkPlan {
             xBridge = false;
             zBridge = false;
         } else {
-            xBridge = rand.nextFloat() < profile.BRIDGE_CHANCE;
-            zBridge = rand.nextFloat() < profile.BRIDGE_CHANCE;
+            xBridge = rand.nextFloat() < profile.bridgeChance();
+            zBridge = rand.nextFloat() < profile.bridgeChance();
         }
 
-        if (rand.nextFloat() < profile.RAILWAY_DUNGEON_CHANCE) {
+        if (rand.nextFloat() < profile.railwayDungeonChance()) {
             if (!hasBuilding || (Railway.RAILWAY_LEVEL_OFFSET < (cityLevel - cellars))) {
                 railDungeon = provider.assets().parts().getOrWarn(getCityStyle().getRandomRailDungeon(rand, this.coord));
             } else {
@@ -857,7 +857,7 @@ public class ChunkPlan {
             railDungeon = null;
         }
 
-        float frontChance = cs.getFrontChance() != null ? cs.getFrontChance() : profile.BUILDING_FRONTCHANCE;
+        float frontChance = cs.getFrontChance() != null ? cs.getFrontChance() : profile.buildingFrontChance();
         if (rand.nextFloat() < frontChance) {
             frontType = provider.assets().parts().getOrWarn(getCityStyle().getRandomFront(rand, this.coord));
         } else {
@@ -866,7 +866,7 @@ public class ChunkPlan {
     }
 
     private int getMaxcellars(CityStyle cs) {
-        int maxcellars = profile.BUILDING_MAXCELLARS + cityLevel;
+        int maxcellars = profile.buildingMaxCellars() + cityLevel;
         if (buildingType.getMaxCellars() != -1 && buildingType.getOverrideFloors()) {
             maxcellars = buildingType.getMaxCellars();
             return maxcellars;
@@ -891,7 +891,7 @@ public class ChunkPlan {
     }
 
     private int getMinfloors(CityStyle cs) {
-        int minfloors = profile.BUILDING_MINFLOORS + 1;    // +1 because this doesn't count the top
+        int minfloors = profile.buildingMinFloors() + 1;    // +1 because this doesn't count the top
         if (buildingType.getMinFloors() != -1 && buildingType.getOverrideFloors()) {
             minfloors = buildingType.getMinFloors();
             return minfloors;
@@ -906,7 +906,7 @@ public class ChunkPlan {
     }
 
     private int getMaxfloors(CityStyle cs) {
-        int maxfloors = profile.BUILDING_MAXFLOORS;
+        int maxfloors = profile.buildingMaxFloors();
         if (buildingType.getMaxFloors() != -1 && buildingType.getOverrideFloors()) {
             maxfloors = buildingType.getMaxFloors();
             return maxfloors;
@@ -1006,7 +1006,7 @@ public class ChunkPlan {
     private static int getCityLevelNormal(ChunkCoord coord, PlanningContext provider, Preset profile) {
         ChunkHeightmap heightmap = provider.heightmap(coord);
         int height = heightmap.getHeight();
-        if (profile.USE_AVG_HEIGHTMAP && Config.heightSampleSize() > 2) {
+        if (profile.useAvgHeightmap() && Config.heightSampleSize() > 2) {
             int sampleSize = Config.heightSampleSize();
             int constX = coord.chunkX() < 0 ? -1 : 1;
             int constZ = coord.chunkZ() < 0 ? -1 : 1;
@@ -1050,21 +1050,21 @@ public class ChunkPlan {
     }
 
     private static int getLevelBasedOnHeight(int height, Preset profile) {
-        if (height < profile.CITY_LEVEL0_HEIGHT) {
+        if (height < profile.cityLevel0Height()) {
             return 0;
-        } else if (height < profile.CITY_LEVEL1_HEIGHT) {
+        } else if (height < profile.cityLevel1Height()) {
             return 1;
-        } else if (height < profile.CITY_LEVEL2_HEIGHT) {
+        } else if (height < profile.cityLevel2Height()) {
             return 2;
-        } else if (height < profile.CITY_LEVEL3_HEIGHT) {
+        } else if (height < profile.cityLevel3Height()) {
             return 3;
-        } else if (height < profile.CITY_LEVEL4_HEIGHT) {
+        } else if (height < profile.cityLevel4Height()) {
             return 4;
-        } else if (height < profile.CITY_LEVEL5_HEIGHT) {
+        } else if (height < profile.cityLevel5Height()) {
             return 5;
-        } else if (height < profile.CITY_LEVEL6_HEIGHT) {
+        } else if (height < profile.cityLevel6Height()) {
             return 6;
-        } else if (height < profile.CITY_LEVEL7_HEIGHT) {
+        } else if (height < profile.cityLevel7Height()) {
             return 7;
         } else {
             return 8;
@@ -1182,7 +1182,7 @@ public class ChunkPlan {
         if (!isStreetOrParkSection() || (streetType != StreetType.PARK)) {
             return false;
         }
-        int threshold = getCityStyle().getParkStreetThreshold() != null ? getCityStyle().getParkStreetThreshold() : profile.PARK_STREET_THRESHOLD;
+        int threshold = getCityStyle().getParkStreetThreshold() != null ? getCityStyle().getParkStreetThreshold() : profile.parkStreetThreshold();
         int counter = 0;
         counter += getXmin().isStreetOrParkSection() ? 1 : 0;
         counter += getXmax().isStreetOrParkSection() ? 1 : 0;
@@ -1762,7 +1762,7 @@ public class ChunkPlan {
             return getCityGroundLevel();
         } else {
             if (isOcean()) {
-                return groundLevel - profile.OCEAN_CORRECTION_BORDER;
+                return groundLevel - profile.oceanCorrectionBorder();
             } else {
                 return 100000;
             }
@@ -1785,8 +1785,8 @@ public class ChunkPlan {
             if (h < provider.shape().maxBuildHeight()) {
                 // The L0 height at this corner is fixed so we return that
                 desiredMaxHeight1 = new MinMax(
-                        h + CityGenerator.getRandomizedOffset(provider.seed(), cx, cz, profile.TERRAIN_FIX_LOWER_MIN_OFFSET, profile.TERRAIN_FIX_LOWER_MAX_OFFSET, Rng.Purpose.TERRAIN_FIX_LOWER),
-                        h + CityGenerator.getRandomizedOffset(provider.seed(), cx, cz, profile.TERRAIN_FIX_UPPER_MIN_OFFSET, profile.TERRAIN_FIX_UPPER_MAX_OFFSET, Rng.Purpose.TERRAIN_FIX_UPPER));
+                        h + CityGenerator.getRandomizedOffset(provider.seed(), cx, cz, profile.terrainFixLowerMinOffset(), profile.terrainFixLowerMaxOffset(), Rng.Purpose.TERRAIN_FIX_LOWER),
+                        h + CityGenerator.getRandomizedOffset(provider.seed(), cx, cz, profile.terrainFixUpperMinOffset(), profile.terrainFixUpperMaxOffset(), Rng.Purpose.TERRAIN_FIX_UPPER));
                 return desiredMaxHeight1;
             }
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/City.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/City.java
@@ -73,7 +73,7 @@ public class City {
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
         RandomSource cityCenterRandom = Rng.at(provider.seed(), chunkX, chunkZ, Rng.Purpose.CITY_CENTER);
-        return cityCenterRandom.nextDouble() < provider.preset().CITY_CHANCE;
+        return cityCenterRandom.nextDouble() < provider.preset().cityChance();
     }
 
     /**
@@ -88,11 +88,11 @@ public class City {
         int chunkZ = coord.chunkZ();
         RandomSource cityRadiusRandom = Rng.at(provider.seed(), chunkX, chunkZ, Rng.Purpose.CITY_RADIUS);
         Preset profile = provider.preset();
-        int cityRange = profile.CITY_MAXRADIUS - profile.CITY_MINRADIUS;
+        int cityRange = profile.cityMaxRadius() - profile.cityMinRadius();
         if (cityRange < 1) {
             cityRange = 1;
         }
-        return profile.CITY_MINRADIUS + cityRadiusRandom.nextInt(cityRange);
+        return profile.cityMinRadius() + cityRadiusRandom.nextInt(cityRange);
     }
 
     // Call this on a city center to get the style of that city
@@ -129,17 +129,17 @@ public class City {
         // and this method calls it, so one purpose would make the blend agree with the centre.
         RandomSource cityStyleRandom = Rng.at(provider.seed(), chunkX, chunkZ, Rng.Purpose.CITY_STYLE_LOCAL);
 
-        if (profile.CITY_CHANCE < 0) {
+        if (profile.cityChance() < 0) {
             CityRarityMap rarityMap = provider.caches().getCityRarityMap(provider.seed(),
-                    profile.CITY_PERLIN_SCALE, profile.CITY_PERLIN_OFFSET, profile.CITY_PERLIN_INNERSCALE);
+                    profile.cityPerlinScale(), profile.cityPerlinOffset(), profile.cityPerlinInnerScale());
             float factor = rarityMap.getCityFactor(chunkX, chunkZ);
-            if (factor < profile.CITY_STYLE_THRESHOLD) {
-                styles.add(Pair.of(factor, profile.CITY_STYLE_ALTERNATIVE));
+            if (factor < profile.cityStyleThreshold()) {
+                styles.add(Pair.of(factor, profile.cityStyleAlternative()));
             } else {
                 styles.add(Pair.of(factor, getCityStyleForCityCenter(coord, provider)));
             }
         } else {
-            int offset = (profile.CITY_MAXRADIUS + 15) / 16;
+            int offset = (profile.cityMaxRadius() + 15) / 16;
             for (int cx = chunkX - offset; cx <= chunkX + offset; cx++) {
                 for (int cz = chunkZ - offset; cz <= chunkZ + offset; cz++) {
                     ChunkCoord c = new ChunkCoord(provider.dimension(), cx, cz);
@@ -149,8 +149,8 @@ public class City {
                         if (sqdist < radius * radius) {
                             float dist = (float) Math.sqrt(sqdist);
                             float factor = (radius - dist) / radius;
-                            if (factor < profile.CITY_STYLE_THRESHOLD) {
-                                styles.add(Pair.of(factor, profile.CITY_STYLE_ALTERNATIVE));
+                            if (factor < profile.cityStyleThreshold()) {
+                                styles.add(Pair.of(factor, profile.cityStyleAlternative()));
                             } else {
                                 // The centre's style, not the observing chunk's: asking at
                                 // `coord` gave every chunk of one city its own roll, so a
@@ -207,12 +207,12 @@ public class City {
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
         float factor = 0;
-        if (profile.CITY_CHANCE < 0) {
+        if (profile.cityChance() < 0) {
             CityRarityMap rarityMap = provider.caches().getCityRarityMap(provider.seed(),
-                    profile.CITY_PERLIN_SCALE, profile.CITY_PERLIN_OFFSET, profile.CITY_PERLIN_INNERSCALE);
+                    profile.cityPerlinScale(), profile.cityPerlinOffset(), profile.cityPerlinInnerScale());
             factor = rarityMap.getCityFactor(chunkX, chunkZ);
         } else {
-            int offset = (profile.CITY_MAXRADIUS + 15) / 16;
+            int offset = (profile.cityMaxRadius() + 15) / 16;
             for (int cx = chunkX - offset; cx <= chunkX + offset; cx++) {
                 for (int cz = chunkZ - offset; cz <= chunkZ + offset; cz++) {
                     ChunkCoord c = new ChunkCoord(type, cx, cz);
@@ -237,10 +237,10 @@ public class City {
             if (heightmap == null) {
                 return 0;
             }
-            if (heightmap.getHeight() < profile.CITY_MINHEIGHT) {
+            if (heightmap.getHeight() < profile.cityMinHeight()) {
                 return 0;
             }
-            if (heightmap.getHeight() > profile.CITY_MAXHEIGHT) {
+            if (heightmap.getHeight() > profile.cityMaxHeight()) {
                 return 0;
             }
         }
@@ -256,16 +256,16 @@ public class City {
             factor *= multiplier;
         }
 
-        if (profile.CITY_SPAWN_DISTANCE2 > 0) {
+        if (profile.citySpawnDistance2() > 0) {
             float dist = (float) Math.sqrt((chunkX << 4) * (chunkX << 4) + (chunkZ << 4) * (chunkZ << 4));
             double factorDist;
-            if (dist <= profile.CITY_SPAWN_DISTANCE1) {
-                factorDist = profile.CITY_SPAWN_MULTIPLIER1;
-            } else if (dist >= profile.CITY_SPAWN_DISTANCE2) {
-                factorDist = profile.CITY_SPAWN_MULTIPLIER2;
+            if (dist <= profile.citySpawnDistance1()) {
+                factorDist = profile.citySpawnMultiplier1();
+            } else if (dist >= profile.citySpawnDistance2()) {
+                factorDist = profile.citySpawnMultiplier2();
             } else {
-                float f = (dist - profile.CITY_SPAWN_DISTANCE1) / (profile.CITY_SPAWN_DISTANCE2 - profile.CITY_SPAWN_DISTANCE1);
-                factorDist = profile.CITY_SPAWN_MULTIPLIER1 + f * (profile.CITY_SPAWN_MULTIPLIER2 - profile.CITY_SPAWN_MULTIPLIER1);
+                float f = (dist - profile.citySpawnDistance1()) / (profile.citySpawnDistance2() - profile.citySpawnDistance1());
+                factorDist = profile.citySpawnMultiplier1() + f * (profile.citySpawnMultiplier2() - profile.citySpawnMultiplier1());
             }
             factor *= (float) factorDist;
         }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/DamageArea.java
@@ -42,11 +42,11 @@ public class DamageArea {
         this.minSectionY = provider.shape().minSection();
         this.maxSectionY = provider.shape().maxSection();
 
-        int offset = (Math.max(info.profile.EXPLOSION_MAXRADIUS, info.profile.MINI_EXPLOSION_MAXRADIUS)+15) / 16;
+        int offset = (Math.max(info.profile.explosionMaxRadius(), info.profile.miniExplosionMaxRadius())+15) / 16;
         for (int cx = chunkX - offset; cx <= chunkX + offset; cx++) {
             for (int cz = chunkZ - offset; cz <= chunkZ + offset; cz++) {
                 ChunkCoord coord = new ChunkCoord(provider.dimension(), cx, cz);
-                if ((!info.profile.EXPLOSIONS_IN_CITIES_ONLY) || ChunkPlan.isCity(coord, provider)) {
+                if ((!info.profile.explosionsInCitiesOnly()) || ChunkPlan.isCity(coord, provider)) {
                     Explosion explosion = getExplosionAt(coord, provider);
                     if (explosion != null) {
                         if (intersectsWith(explosion.getCenter(), explosion.getRadius())) {
@@ -108,7 +108,7 @@ public class DamageArea {
         }
         if (Rng.floatAtPos(seed, x, y, z, Rng.Purpose.DAMAGE) <= damage) {
             BlockState damaged = palette.canBeDamagedToIronBars(b);
-            int waterlevel = provider.shape().seaLevel();//profile.GROUNDLEVEL - profile.WATERLEVEL_OFFSET;
+            int waterlevel = provider.shape().seaLevel();//profile.groundLevel() - profile.WATERLEVEL_OFFSET;
             if (damage < BLOCK_DAMAGE_CHANCE && damaged != null) {
                 if (Rng.floatAtPos(seed, x, y, z, Rng.Purpose.DAMAGE_VARIANT) < .7f) {
                     b = damaged;
@@ -129,10 +129,10 @@ public class DamageArea {
 
     private Explosion getExplosionAt(ChunkCoord coord, PlanningContext provider) {
         RandomSource randomExplosion = Rng.at(seed, coord.chunkX(), coord.chunkZ(), Rng.Purpose.EXPLOSION);
-        if (randomExplosion.nextFloat() < profile.EXPLOSION_CHANCE) {
-            return new Explosion(Tools.randomBetween(randomExplosion, profile.EXPLOSION_MINRADIUS, profile.EXPLOSION_MAXRADIUS),
+        if (randomExplosion.nextFloat() < profile.explosionChance()) {
+            return new Explosion(Tools.randomBetween(randomExplosion, profile.explosionMinRadius(), profile.explosionMaxRadius()),
                     new BlockPos((coord.chunkX() << 4) + randomExplosion.nextInt(16),
-                            ChunkPlan.getChunkPlan(coord, provider).cityLevel * 6 + Tools.randomBetween(randomExplosion, profile.EXPLOSION_MINHEIGHT, profile.EXPLOSION_MAXHEIGHT),
+                            ChunkPlan.getChunkPlan(coord, provider).cityLevel * 6 + Tools.randomBetween(randomExplosion, profile.explosionMinHeight(), profile.explosionMaxHeight()),
                             (coord.chunkZ() << 4) + randomExplosion.nextInt(16)));
         }
         return null;
@@ -140,10 +140,10 @@ public class DamageArea {
 
     private Explosion getMiniExplosionAt(ChunkCoord coord, PlanningContext provider) {
         RandomSource randomMiniExplosion = Rng.at(seed, coord.chunkX(), coord.chunkZ(), Rng.Purpose.EXPLOSION_MINI);
-        if (randomMiniExplosion.nextFloat() < profile.MINI_EXPLOSION_CHANCE) {
-            return new Explosion(Tools.randomBetween(randomMiniExplosion, profile.MINI_EXPLOSION_MINRADIUS, profile.MINI_EXPLOSION_MAXRADIUS),
+        if (randomMiniExplosion.nextFloat() < profile.miniExplosionChance()) {
+            return new Explosion(Tools.randomBetween(randomMiniExplosion, profile.miniExplosionMinRadius(), profile.miniExplosionMaxRadius()),
                     new BlockPos((coord.chunkX() << 4) + randomMiniExplosion.nextInt(16),
-                            ChunkPlan.getChunkPlan(coord, provider).cityLevel * 6 + Tools.randomBetween(randomMiniExplosion, profile.MINI_EXPLOSION_MINHEIGHT, profile.MINI_EXPLOSION_MAXHEIGHT),
+                            ChunkPlan.getChunkPlan(coord, provider).cityLevel * 6 + Tools.randomBetween(randomMiniExplosion, profile.miniExplosionMinHeight(), profile.miniExplosionMaxHeight()),
                             (coord.chunkZ() << 4) + randomMiniExplosion.nextInt(16)));
         }
         return null;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Highway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Highway.java
@@ -62,7 +62,7 @@ public class Highway {
         }
 
         // Highways can only occur at chunkZ that is a multiple of 8
-        int mask = profile.HIGHWAY_DISTANCE_MASK;
+        int mask = profile.highwayDistanceMask();
         if (mask <= 0) {
             cache.put(cp, -1);
             return -1;
@@ -95,14 +95,14 @@ public class Highway {
             int level = -1;
             if (higher.getCoord(orientation)-lower.getCoord(orientation) >= 5) {
                 boolean valid;
-                if (profile.HIGHWAY_REQUIRES_TWO_CITIES) {
+                if (profile.highwayRequiresTwoCities()) {
                     valid = ChunkPlan.isCityRaw(lower, provider, profile) && ChunkPlan.isCityRaw(higher, provider, profile);
                 } else {
                     valid = ChunkPlan.isCityRaw(lower, provider, profile) || ChunkPlan.isCityRaw(higher, provider, profile);
                 }
                 if (valid) {
                     // We have at least one city. Valid highway:
-                    level = switch (profile.HIGHWAY_LEVEL_FROM_CITIES_MODE) {
+                    level = switch (profile.highwayLevelFromCities()) {
                         case 0 -> ChunkPlan.getCityLevel(lower, provider);
                         case 1 -> Math.min(ChunkPlan.getCityLevel(lower, provider),
                                 ChunkPlan.getCityLevel(higher, provider));
@@ -152,13 +152,13 @@ public class Highway {
     }
 
     private static boolean hasXHighway(PlanningContext provider, ChunkCoord cp, Preset profile) {
-        return provider.caches().highwayPerlinX.getValue(cp.chunkX() / profile.HIGHWAY_MAINPERLIN_SCALE, cp.chunkZ() / profile.HIGHWAY_SECONDARYPERLIN_SCALE)
-                > profile.HIGHWAY_PERLIN_FACTOR;
+        return provider.caches().highwayPerlinX.getValue(cp.chunkX() / profile.highwayMainPerlinScale(), cp.chunkZ() / profile.highwaySecondaryPerlinScale())
+                > profile.highwayPerlinFactor();
     }
 
     private static boolean hasZHighway(PlanningContext provider, ChunkCoord cp, Preset profile) {
-        return provider.caches().highwayPerlinZ.getValue(cp.chunkX() / profile.HIGHWAY_SECONDARYPERLIN_SCALE, cp.chunkZ() / profile.HIGHWAY_MAINPERLIN_SCALE)
-                > profile.HIGHWAY_PERLIN_FACTOR;
+        return provider.caches().highwayPerlinZ.getValue(cp.chunkX() / profile.highwaySecondaryPerlinScale(), cp.chunkZ() / profile.highwayMainPerlinScale())
+                > profile.highwayPerlinFactor();
     }
 
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
@@ -224,7 +224,7 @@ public class MultiChunk {
                 // multi-building acceptance depend on ChunkPlan, which depends on multi-building
                 // acceptance. Predefined multi-buildings never reach here at all.
                 RoadType rawRoad = provider.roadField().typeAt(coord.chunkX(), coord.chunkZ());
-                if (profile.MULTI_BUILDING_STREET_CONFLICT.roadBlocks(rawRoad)) {
+                if (profile.multiBuildingStreetConflict().roadBlocks(rawRoad)) {
                     return false;
                 }
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/PrimaryBridgePlanner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/PrimaryBridgePlanner.java
@@ -81,8 +81,8 @@ public final class PrimaryBridgePlanner {
         // Dimension-wide, not per-chunk: a span's length limit and acceptance chance must be the
         // same number for every chunk in it.
         Preset profile = provider.preset();
-        float chance = profile.PLANNED_PRIMARY_BRIDGE_CHANCE;
-        int maxGapLength = profile.PLANNED_PRIMARY_BRIDGE_MAX_LENGTH;
+        float chance = profile.plannedPrimaryBridgeChance();
+        int maxGapLength = profile.plannedPrimaryBridgeMaxLength();
         if (chance <= 0.0f) {
             return Optional.empty();
         }
@@ -311,7 +311,7 @@ public final class PrimaryBridgePlanner {
                 if (CityGenerator.isWaterBiome(provider, coord)) {
                     return true;
                 }
-                int sealevel = provider.preset().SEALEVEL;
+                int sealevel = provider.preset().seaLevel();
                 int waterLevel = sealevel == -1 ? provider.shape().seaLevel() : sealevel;
                 return provider.heightmap(coord).getHeight() < waterLevel;
             }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
@@ -110,7 +110,7 @@ public class Railway {
             if (!ChunkPlan.isCityRaw(key, provider, profile)) {
                 // There is no city here. So no station. But we still need a railway. A station at this
                 // point will get a three line rail through it
-                if (profile.RAILWAYS_CAN_END) {
+                if (profile.railwaysCanEnd()) {
                     // Check if there are stations at either side
                     boolean cityEast = ChunkPlan.isCityRaw(key.offset(10, 0), provider, profile) ||
                             ChunkPlan.isCityRaw(key.offset(10, - 10), provider, profile) ||
@@ -137,7 +137,7 @@ public class Railway {
             if (!ChunkPlan.isCityRaw(key, provider, profile)) {
                 // There is no city here. So no station either. But we still need a railway. A station at this
                 // point will get a two line rail through it
-                if (profile.RAILWAYS_CAN_END) {
+                if (profile.railwaysCanEnd()) {
                     // Check if there are stations at either side
                     boolean cityEast = ChunkPlan.isCityRaw(key.offset(10, -10), provider, profile) ||
                             ChunkPlan.isCityRaw(key.offset(10, 10), provider, profile);
@@ -162,7 +162,7 @@ public class Railway {
             if (!ChunkPlan.isCityRaw(key, provider, profile)) {
                 // There is no city here. So no station either. But we still need a railway. A station at this
                 // point will get a single line rail through it
-                if (profile.RAILWAYS_CAN_END) {
+                if (profile.railwaysCanEnd()) {
                     // Check if there are stations at either side
                     boolean cityEast = ChunkPlan.isCityRaw(key.offset(10, 0), provider, profile);
                     boolean cityWest = ChunkPlan.isCityRaw(key.offset(-10, 0), provider, profile);
@@ -206,7 +206,7 @@ public class Railway {
                 return testAdjacentRailChunk(r, adjacent, direction, key.east(), provider, profile);
             }
             if (mz == 0 && mx == 5) {
-                if (profile.RAILWAYS_CAN_END) {
+                if (profile.railwaysCanEnd()) {
                     boolean cityWest = ChunkPlan.isCityRaw(key.offset(-5, -10), provider, profile) ||
                             ChunkPlan.isCityRaw(key.offset(-5, 10), provider, profile);
                     boolean cityEast = ChunkPlan.isCityRaw(key.offset(5, 0), provider, profile);
@@ -217,7 +217,7 @@ public class Railway {
                 return new RailChunkInfo(DOUBLE_BEND, EAST, RAILWAY_LEVEL_OFFSET, 1);
             }
             if (mz == 0 && mx == 15) {
-                if (profile.RAILWAYS_CAN_END) {
+                if (profile.railwaysCanEnd()) {
                     boolean cityEast = ChunkPlan.isCityRaw(key.offset(5, -10), provider, profile) ||
                             ChunkPlan.isCityRaw(key.offset(5, 10), provider, profile);
                     boolean cityWest = ChunkPlan.isCityRaw(key.offset(-5, 0), provider, profile);
@@ -228,7 +228,7 @@ public class Railway {
                 return new RailChunkInfo(DOUBLE_BEND, WEST, RAILWAY_LEVEL_OFFSET, 1);
             }
             if (mz == 10 && mx == 5) {
-                if (profile.RAILWAYS_CAN_END) {
+                if (profile.railwaysCanEnd()) {
                     boolean cityEast = ChunkPlan.isCityRaw(key.offset(5, 0), provider, profile);
                     boolean cityWest = ChunkPlan.isCityRaw(key.offset(-5, 0), provider, profile);
                     if (!cityEast && !cityWest) {
@@ -245,7 +245,7 @@ public class Railway {
                 return new RailChunkInfo(THREE_SPLIT, EAST, RAILWAY_LEVEL_OFFSET, 3);
             }
             if (mz == 10 && mx == 15) {
-                if (profile.RAILWAYS_CAN_END) {
+                if (profile.railwaysCanEnd()) {
                     boolean cityEast = ChunkPlan.isCityRaw(key.offset(5, 0), provider, profile);
                     boolean cityWest = ChunkPlan.isCityRaw(key.offset(-5, 0), provider, profile);
                     if (!cityEast && !cityWest) {
@@ -264,7 +264,7 @@ public class Railway {
             return RailChunkInfo.NOTHING;
         }
         if (mx == 5) {
-            if (profile.RAILWAYS_CAN_END) {
+            if (profile.railwaysCanEnd()) {
                 RailChunkInfo typeNorth = getRailChunkType(key.offset(0, - (mz % 10)), provider, profile);
                 RailChunkInfo typeSouth = getRailChunkType(key.offset(0, - (mz % 10) + 10), provider, profile);
                 if (typeNorth.getType() == NONE || typeSouth.getType() == NONE) {
@@ -274,7 +274,7 @@ public class Railway {
             return new RailChunkInfo(VERTICAL, EAST, RAILWAY_LEVEL_OFFSET, 1);
         }
         if (mx == 15) {
-            if (profile.RAILWAYS_CAN_END) {
+            if (profile.railwaysCanEnd()) {
                 RailChunkInfo typeNorth = getRailChunkType(key.offset(0, - (mz % 10)), provider, profile);
                 RailChunkInfo typeSouth = getRailChunkType(key.offset(0, - (mz % 10) + 10), provider, profile);
                 if (typeNorth.getType() == NONE || typeSouth.getType() == NONE) {
@@ -289,7 +289,7 @@ public class Railway {
 
     private static RailChunkInfo getStationType(ChunkCoord coord, PlanningContext provider, Preset profile, float r, int rails, List<String> part) {
         int cityLevel = ChunkPlan.getCityLevel(coord, provider);
-        if (cityLevel > 2 || !profile.RAILWAY_SURFACE_STATIONS_ENABLED) {
+        if (cityLevel > 2 || !profile.railwaySurfaceStationsEnabled()) {
             // We are too high here. We need an underground station
             return new RailChunkInfo(STATION_UNDERGROUND, BI, RAILWAY_LEVEL_OFFSET, rails);
         }
@@ -323,11 +323,11 @@ public class Railway {
         }
         RailChunkInfo info = getRailChunkTypeInternal(coord, provider);
         if (info.getType().isStation()) {
-            if (!profile.RAILWAY_STATIONS_ENABLED) {
+            if (!profile.railwayStationsEnabled()) {
                 info = RailChunkInfo.NOTHING;
             }
         } else {
-            if (!profile.RAILWAYS_ENABLED) {
+            if (!profile.railwaysEnabled()) {
                 info = RailChunkInfo.NOTHING;
             }
         }

--- a/src/test/java/dev/krona/urbex/config/PresetResolutionTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetResolutionTest.java
@@ -41,9 +41,9 @@ class PresetResolutionTest {
 
         Preset p = Presets.resolve(presetId, lookup::get);
 
-        assertTrue(p.USE_AVG_HEIGHTMAP);
-        assertEquals(0.15f, p.LIGHTING_DENSITY);
-        assertEquals(71, p.GROUNDLEVEL);
+        assertTrue(p.useAvgHeightmap());
+        assertEquals(0.15f, p.lightingDensity());
+        assertEquals(71, p.groundLevel());
     }
 
     @Test
@@ -57,11 +57,11 @@ class PresetResolutionTest {
 
         Preset p = Presets.resolve(childId, lookup::get);
 
-        assertEquals(0.5, p.CITY_CHANCE);
-        assertEquals(0.9f, p.RUIN_CHANCE);
+        assertEquals(0.5, p.cityChance());
+        assertEquals(0.9f, p.ruinChance());
         // untouched fields keep their code defaults
-        assertEquals(0.3f, p.BUILDING_CHANCE);
-        assertEquals(0.8f, p.RUIN_MINLEVEL_PERCENT);
+        assertEquals(0.3f, p.buildingChance());
+        assertEquals(0.8f, p.ruinMinlevelPercent());
     }
 
     @Test
@@ -78,8 +78,8 @@ class PresetResolutionTest {
 
         Preset p = Presets.resolve(leafId, lookup::get);
 
-        assertEquals(0.2, p.CITY_CHANCE);       // middle overrides root; leaf doesn't touch it
-        assertEquals(0.4f, p.BUILDING_CHANCE);  // leaf wins over middle
+        assertEquals(0.2, p.cityChance());       // middle overrides root; leaf doesn't touch it
+        assertEquals(0.4f, p.buildingChance());  // leaf wins over middle
     }
 
     @Test
@@ -138,13 +138,13 @@ class PresetResolutionTest {
         lookup.put(presetId, decode("{\"cities\":{\"cityChance\":0.1}}"));
 
         Preset first = Presets.resolve(presetId, lookup::get);
-        assertEquals(0.1, first.CITY_CHANCE);
+        assertEquals(0.1, first.cityChance());
 
         // Simulates a datapack toggle / new registry context redefining the same id - nothing about
         // the pure core remembers the first call.
         lookup.put(presetId, decode("{\"cities\":{\"cityChance\":0.9}}"));
         Preset second = Presets.resolve(presetId, lookup::get);
 
-        assertEquals(0.9, second.CITY_CHANCE);
+        assertEquals(0.9, second.cityChance());
     }
 }

--- a/src/test/java/dev/krona/urbex/config/PresetRoundTripTest.java
+++ b/src/test/java/dev/krona/urbex/config/PresetRoundTripTest.java
@@ -85,15 +85,15 @@ class PresetRoundTripTest {
 
         Preset resolved = Presets.resolve(ID, i -> i.equals(ID) ? decoded : null);
 
-        assertEquals(80, resolved.GROUNDLEVEL);
-        assertEquals(0.55, resolved.CITY_CHANCE);
-        assertEquals(0.66f, resolved.BUILDING_CHANCE);
-        assertEquals(20, resolved.PRIMARY_ROAD_SPACING_X);
-        assertEquals(15, resolved.HIGHWAY_DISTANCE_MASK);
-        assertEquals(0.5f, resolved.RAILWAY_DUNGEON_CHANCE);
-        assertEquals(0.77f, resolved.RUIN_CHANCE);
-        assertEquals(0.9f, resolved.LIGHTING_DENSITY);
-        assertEquals(500, resolved.SPAWN_CHECK_RADIUS);
-        assertTrue(resolved.EDITMODE);
+        assertEquals(80, resolved.groundLevel());
+        assertEquals(0.55, resolved.cityChance());
+        assertEquals(0.66f, resolved.buildingChance());
+        assertEquals(20, resolved.primaryRoadSpacingX());
+        assertEquals(15, resolved.highwayDistanceMask());
+        assertEquals(0.5f, resolved.railwayDungeonChance());
+        assertEquals(0.77f, resolved.ruinChance());
+        assertEquals(0.9f, resolved.lightingDensity());
+        assertEquals(500, resolved.spawnCheckRadius());
+        assertTrue(resolved.editMode());
     }
 }

--- a/src/test/java/dev/krona/urbex/config/ShippedPresetsTest.java
+++ b/src/test/java/dev/krona/urbex/config/ShippedPresetsTest.java
@@ -81,7 +81,7 @@ class ShippedPresetsTest {
         for (var entry : presets.entrySet()) {
             Identifier id = entry.getKey();
             Preset resolved = Presets.resolve(id, presets::get);
-            assertTrue(resolved.USE_AVG_HEIGHTMAP,
+            assertTrue(resolved.useAvgHeightmap(),
                     "Preset " + id + " does not have USE_AVG_HEIGHTMAP=true after resolution");
         }
     }

--- a/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
+++ b/src/test/java/dev/krona/urbex/gui/PresetSelectionTest.java
@@ -305,7 +305,7 @@ class PresetSelectionTest {
         selection.setAvailablePresets(List.of(entry("default")));
 
         assertEquals(PresetSelection.CUSTOMIZED_ID, selection.selected().id());
-        assertEquals(0.9, selection.selected().preset().CITY_CHANCE, 1e-9);
+        assertEquals(0.9, selection.selected().preset().cityChance(), 1e-9);
     }
 
     @Test

--- a/src/test/java/dev/krona/urbex/gui/settings/SettingsCompletenessTest.java
+++ b/src/test/java/dev/krona/urbex/gui/settings/SettingsCompletenessTest.java
@@ -293,7 +293,7 @@ class SettingsCompletenessTest {
 
     /**
      * A key naming the right field is not enough: a copy-paste slip like
-     * {@code slider("CITY_CHANCE", ..., p -> p.CITY_MINRADIUS, ...)} would pass every other test while silently
+     * {@code slider("CITY_CHANCE", ..., p -> p.cityMinRadius(), ...)} would pass every other test while silently
      * orphaning one field and double-exposing another.
      *
      * <p>A single sentinel is also not enough: comparing one flipped value against the field's own default lets a

--- a/src/test/java/dev/krona/urbex/worldgen/lost/ChunkContentResolverTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/ChunkContentResolverTest.java
@@ -472,7 +472,7 @@ class ChunkContentResolverTest {
         @Test
         void multiBuildingAcceptanceWouldDifferIfItReadTheEffectiveRoadInsteadOfTheRawOne() {
             GridRoadField roadField = new GridRoadField(1337L, "urbex:test", GridSettings.defaults());
-            MultiBuildingStreetConflict conflict = profileWithBuildingChance(0.5f).MULTI_BUILDING_STREET_CONFLICT;
+            MultiBuildingStreetConflict conflict = profileWithBuildingChance(0.5f).multiBuildingStreetConflict();
 
             int divergences = 0;
             for (int x = -40; x < 40; x++) {


### PR DESCRIPTION
Step 1 of five, and the only large one. 119 accessors on Preset, and the 707
reads across 34 files moved onto them. Nothing else changes: the fields are
still public, so this is a rename with a compiler behind it.

It is its own commit because of what comes next. Making the fields private is
how the compiler enumerates every writer - the eleven applyTo methods, copy(),
and SettingDescriptor's setters - and that diff is worth reading. It would not
be, if it also touched every reader.

The accessor names are not invented. Each one is the JSON key its codec reads
the field from, taken out of the *Settings.apply(Preset) methods, so
cityChance() is what a datapack author already calls CITY_CHANCE. That mapping
is total: all 119 fields are named by a codec, none collide with each other, and
none collide with a method Preset already had.

One trap the mechanical pass hit and the guard now covers: Rng.Purpose has
LIGHTING_DENSITY and LOOT_DENSITY constants that share a name with two Preset
fields. Rewriting those would have compiled - Purpose.lightingDensity() does not
exist, so in fact it would not have - but the shape of the mistake is a silently
different RNG address, so the rewrite skips any type-qualified constant rather
than relying on that.

Digest goldens all unchanged, which is the check that matters here: a
transcription error in a mechanical pass over 707 sites shows up as a moved
golden, not as a compile failure.
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>