### PR TITLE
feat: a digest run can measure what it cost (#132, 132a)

### DIFF
--- a/docs/superpowers/specs/2026-08-13-phase4-decompose-and-measure.md
+++ b/docs/superpowers/specs/2026-08-13-phase4-decompose-and-measure.md
@@ -1,0 +1,101 @@
+# Phase 4: decompose and measure (#11, #52, #53, #132)
+
+Epic #134's fourth phase. Four issues, and one of them is a prerequisite for the other three: the
+epic's own constraint is *"do not optimize deterministic generation paths solely from inspection;
+attach measurements"*, and #53 and #52 are both partly performance claims.
+
+## Order, and why it is not the epic's numbering
+
+The epic lists #11, #52, #53, #132. The measurement half of #132 goes first instead, because every
+other PR in this phase has to attach before/after numbers to it, and a baseline established after the
+changes it is meant to justify measures nothing.
+
+1. **#132a — the baseline.** A repeatable measurement any digest run can emit. *(This PR.)*
+2. **#53 — typed palette entries**, and memoizing the per-part compile. The smallest change with a
+   measurable claim attached, so it is also the first real test of whether the baseline is any use.
+3. **#52 — `ChunkDriver`.** Explicit positions, and the read-marks-a-section-dirty defect.
+4. **#11 — `CityGenerator`.** The largest, and the one whose only safety net is the digest suite.
+5. **#132b — bounded caches** and the confirmed-dead allocation paths, with the numbers the first
+   four produced.
+
+## What "measured" has to mean here
+
+The acceptance criteria ask for throughput, allocations, cache behaviour and tail latency. All four
+are properties of one digest run, so they belong on the digest run rather than in a separate harness
+nobody runs:
+
+| Wanted | Where it comes from |
+| --- | --- |
+| Throughput | chunks and driver writes per second — the runner already times the drive |
+| Allocations | `com.sun.management.ThreadMXBean.getThreadAllocatedBytes`, summed over every thread that generated anything |
+| Cache behaviour | hits, misses, duplicate computations, evictions, sweeps and sweep time, per named cache |
+| Tail latency | per-chunk generation time, as count/mean/max/p99 |
+
+Off by default and gated on `-Durbex.metrics`, because a counter on the generation path that is
+always on is a measurement that changes what it measures. When it is off, the instrumentation is a
+static `false` and a branch the JIT removes.
+
+Allocation is measured per *thread*, not per run, because worldgen fans out: a total that took
+`Runtime.totalMemory()` deltas would measure the collector's mood. `getThreadAllocatedBytes` is
+cumulative and exact per thread, so the run's figure is the sum of the deltas of every thread that
+touched generation.
+
+**JFR stays a recipe rather than a task.** `-PurbexDigestVmArgs` already forwards arbitrary JVM
+arguments to every digest run configuration, so a profile is
+`-PurbexDigestVmArgs=-XX:StartFlightRecording=filename=urbex.jfr,settings=profile`. Wrapping that in
+a gradle task would add a second way to say the same thing.
+
+## The counters, precisely
+
+`GenerationMetrics` holds them. Three groups:
+
+- **`chunk(nanos)`** — one call per generated chunk, from `CityGenerator.generate`. Aggregated into
+  count, total, max and a coarse log-bucketed histogram for the p99. A histogram rather than a list
+  because a list of a million longs is itself an allocation problem, and p99 to within a bucket is
+  all a regression test needs.
+- **`cache(name)`** — `TimedCache` reports hit, miss, race, evict, sweep(nanos) and a size sampled
+  at report time. "Race" is the case `getOrCompute` documents and nothing counted: two threads
+  computing the same pure value, which is harmless but is also exactly the waste #132 asks to
+  quantify. There is no separate compute count — most of these caches populate through
+  get-then-`putIfAbsent`, so it would read zero for them and non-zero for three, which looks like
+  "these never compute" rather than "this does not apply". The miss count is the compute count.
+- **`queue(depth)`** — the level task queue's high-water mark, for the "deferred queue backlog"
+  criterion.
+
+`PERF=` is one line, emitted next to `DRIVERDIGEST=` so a digest run is also a measurement run.
+
+## The baseline, as of `59a381d`
+
+`./gradlew runDigestCheckAvoid -PurbexDigestVmArgs=-Durbex.metrics` — 625 chunks requested, seed
+135132278163449878, offset 0, on an 8-core laptop:
+
+```
+PERF=on chunks=625 generated=816 ms=24367 chunksPerSec=33.5 meanUs=4679.5 p99Us=32768 maxUs=76573
+  allocMiB=9963 allocThreads=15 queueHighWater=598
+  biomeInfo=10099/11438(88%)  candidate=67822/69030(98%)  chunkPlan=5616/6675(84%)
+  cityLevel=570/1798(32%)     cityStyle=5023/6425(78%)    heightmap=22613/22795(99%)
+  multiChunk=617/631(98%)     scatterAreaScan=0/4(0%)     worldStyle=0/0(0%)
+```
+
+Four things this says that inspection did not, and that #132b now has to answer:
+
+- **~12 MiB allocated per generated chunk** (9963 MiB over 816). That is the number every allocation
+  claim in this phase is measured against.
+- **`cityLevel` hits 32%.** A memo table that misses two thirds of the time is either keyed wrong or
+  asked about coordinates it will never be asked about again; both are worth knowing before anyone
+  bounds it.
+- **No sweep runs at all** in a 24-second drive, because the TTL is 300 seconds. The O(n) sweep
+  #132 worries about is real but never observed by a digest run — so any claim about it needs the
+  soak, not this.
+- **`queueHighWater=598`** deferred tasks against a `todoQueueSize` of 20 per tick. The backlog is
+  drained after generation in a real world, but the number is what a tick-budget argument starts
+  from.
+
+`generated` exceeds `chunks` because the pipeline pulls in neighbours to satisfy the requested
+square; it is the honest denominator for a per-chunk figure.
+
+## What this PR does not do
+
+It sets no cache limits and removes no allocation. Those are #132b, and doing them here would be
+optimizing from inspection with a measurement bolted on afterwards — which is the thing the epic
+constraint is about.

--- a/src/main/java/dev/krona/urbex/commands/CommandDigest.java
+++ b/src/main/java/dev/krona/urbex/commands/CommandDigest.java
@@ -74,6 +74,8 @@ public class CommandDigest implements Command<CommandSourceStack> {
         context.getSource().sendSuccess(() -> Component.literal(driverLine).withStyle(ChatFormatting.GREEN), true);
         context.getSource().sendSuccess(() -> Component.literal(line).withStyle(ChatFormatting.YELLOW), true);
         System.out.println(driverLine);     // so headless runs can grep stdout
+        context.getSource().sendSuccess(() -> Component.literal(result.perfLine()).withStyle(ChatFormatting.GRAY), false);
+        System.out.println(result.perfLine());
         System.out.println(line);
         return 1;
     }

--- a/src/main/java/dev/krona/urbex/setup/DigestCheck.java
+++ b/src/main/java/dev/krona/urbex/setup/DigestCheck.java
@@ -100,6 +100,8 @@ public final class DigestCheck {
                 String driverLine = result.driverLine(spec.order(), spec.offset());
                 Urbex.getLogger().info(driverLine);
                 System.out.println(driverLine);
+                Urbex.getLogger().info(result.perfLine());
+                System.out.println(result.perfLine());
 
                 String actual = String.format("%016x", result.driverDigest());
                 if (result.driverBlocks() == 0) {

--- a/src/main/java/dev/krona/urbex/varia/GenerationMetrics.java
+++ b/src/main/java/dev/krona/urbex/varia/GenerationMetrics.java
@@ -1,0 +1,304 @@
+package dev.krona.urbex.varia;
+
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.LongSupplier;
+
+/**
+ * What one generation run cost, when anyone is asking.
+ *
+ * <p>Epic #134 forbids optimizing a deterministic generation path from inspection alone, so several
+ * phase-4 changes have to attach numbers. These are those numbers, and they are collected on the
+ * digest run rather than in a harness of their own: throughput, allocation, cache behaviour and tail
+ * latency are all properties of generating a known square of chunks, which is a thing the digest
+ * suites already do repeatably (issue #132).</p>
+ *
+ * <p><strong>Off unless asked.</strong> {@code -Durbex.metrics} switches it on. Off, every entry
+ * point below is a static-final {@code false} and a branch the JIT folds away - a counter that is
+ * always on is a measurement that changes what it measures, which for a per-block path is not a
+ * theoretical concern.</p>
+ *
+ * <h2>Why allocation is per thread</h2>
+ *
+ * <p>Worldgen fans out over the worker pool, so a figure taken from {@code Runtime.totalMemory()}
+ * deltas measures the collector's mood rather than the run. {@code ThreadMXBean
+ * .getThreadAllocatedBytes} is cumulative and exact per thread, so a run's allocation is the sum of
+ * the deltas of every thread that generated anything - which is why {@link #chunk} samples it: the
+ * threads that generate are exactly the threads that call it.</p>
+ */
+public final class GenerationMetrics {
+
+    /** {@code -Durbex.metrics} to switch the counters on. */
+    public static final String ENABLED_PROPERTY = "urbex.metrics";
+
+    private static final boolean ENABLED = System.getProperty(ENABLED_PROPERTY) != null;
+
+    private static final com.sun.management.ThreadMXBean THREADS = threadBean();
+
+    /** Chunk generation times, bucketed by {@code floor(log2(micros))}. */
+    private static final LongAdder[] CHUNK_BUCKETS = newBuckets();
+    private static final LongAdder CHUNK_COUNT = new LongAdder();
+    private static final LongAdder CHUNK_NANOS = new LongAdder();
+    private static final AtomicLong CHUNK_MAX_NANOS = new AtomicLong();
+
+    /** Thread id -> allocated bytes when that thread first generated something. */
+    private static final Map<Long, Long> ALLOCATION_BASELINE = new ConcurrentHashMap<>();
+    private static final Map<Long, Long> ALLOCATION_LATEST = new ConcurrentHashMap<>();
+
+    private static final Map<String, CacheStats> CACHES = new ConcurrentHashMap<>();
+
+    private static final AtomicLong QUEUE_HIGH_WATER = new AtomicLong();
+
+    private GenerationMetrics() {
+    }
+
+    public static boolean enabled() {
+        return ENABLED;
+    }
+
+    /** Forgets everything measured so far. Called at the start of a measured run. */
+    public static void reset() {
+        for (LongAdder bucket : CHUNK_BUCKETS) {
+            bucket.reset();
+        }
+        CHUNK_COUNT.reset();
+        CHUNK_NANOS.reset();
+        CHUNK_MAX_NANOS.set(0);
+        ALLOCATION_BASELINE.clear();
+        ALLOCATION_LATEST.clear();
+        // Zeroed in place, not dropped: a TimedCache takes its CacheStats once, at construction, so
+        // clearing the map would leave every existing cache writing to an object nothing reports.
+        CACHES.values().forEach(CacheStats::reset);
+        QUEUE_HIGH_WATER.set(0);
+    }
+
+    /**
+     * One generated chunk took {@code nanos}.
+     *
+     * <p>Also samples this thread's allocation counter. The first call from a thread records its
+     * baseline and contributes nothing; every later one moves that thread's latest, so a run's
+     * allocation is the sum over threads of {@code latest - baseline}. Sampling here rather than
+     * around the whole run is what keeps it to the threads that actually generated.</p>
+     */
+    public static void chunk(long nanos) {
+        if (!ENABLED) {
+            return;
+        }
+        CHUNK_COUNT.increment();
+        CHUNK_NANOS.add(nanos);
+        CHUNK_MAX_NANOS.accumulateAndGet(nanos, Math::max);
+        CHUNK_BUCKETS[bucketFor(nanos)].increment();
+        if (THREADS != null) {
+            long id = Thread.currentThread().threadId();
+            long allocated = THREADS.getThreadAllocatedBytes(id);
+            if (allocated >= 0) {
+                ALLOCATION_BASELINE.putIfAbsent(id, allocated);
+                ALLOCATION_LATEST.put(id, allocated);
+            }
+        }
+    }
+
+    /**
+     * The counters for a named cache, created on first use.
+     *
+     * @param liveSize how many entries the cache holds right now, sampled when a report is built.
+     *                 Sampled rather than tracked because the alternative is maintaining a count on
+     *                 the put/remove path of a concurrent map, which is a cost the measurement would
+     *                 then be measuring.
+     */
+    public static CacheStats cache(String name, LongSupplier liveSize) {
+        CacheStats stats = CACHES.computeIfAbsent(name, n -> new CacheStats());
+        stats.liveSize = liveSize;
+        return stats;
+    }
+
+    /** A deferred-work queue reached {@code depth} entries. */
+    public static void queueDepth(long depth) {
+        if (!ENABLED) {
+            return;
+        }
+        QUEUE_HIGH_WATER.accumulateAndGet(depth, Math::max);
+    }
+
+    /**
+     * One line: throughput, allocation, tail latency, then a block per cache.
+     *
+     * @param chunks how many chunks the run asked for, which is not the same as how many generated
+     *               city content
+     * @param millis wall-clock time for the drive
+     */
+    public static String report(int chunks, long millis) {
+        if (!ENABLED) {
+            return "PERF=off (pass -D" + ENABLED_PROPERTY + " to measure)";
+        }
+        long generated = CHUNK_COUNT.sum();
+        long totalNanos = CHUNK_NANOS.sum();
+        StringBuilder line = new StringBuilder("PERF=on");
+        line.append(" chunks=").append(chunks);
+        line.append(" generated=").append(generated);
+        line.append(" ms=").append(millis);
+        line.append(String.format(" chunksPerSec=%.1f", millis == 0 ? 0.0 : generated * 1000.0 / millis));
+        line.append(String.format(" meanUs=%.1f", generated == 0 ? 0.0 : totalNanos / 1000.0 / generated));
+        line.append(String.format(" p99Us=%d", percentileMicros(99)));
+        line.append(String.format(" maxUs=%d", CHUNK_MAX_NANOS.get() / 1000));
+        line.append(" allocMiB=").append(allocatedBytes() >> 20);
+        line.append(" allocThreads=").append(ALLOCATION_BASELINE.size());
+        line.append(" queueHighWater=").append(QUEUE_HIGH_WATER.get());
+        CACHES.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> line.append(' ').append(entry.getKey()).append('=')
+                        .append(entry.getValue().format()));
+        return line.toString();
+    }
+
+    /** Total bytes allocated by every thread that generated a chunk during this run. */
+    public static long allocatedBytes() {
+        long total = 0;
+        for (Map.Entry<Long, Long> entry : ALLOCATION_LATEST.entrySet()) {
+            Long baseline = ALLOCATION_BASELINE.get(entry.getKey());
+            if (baseline != null) {
+                total += entry.getValue() - baseline;
+            }
+        }
+        return total;
+    }
+
+    /**
+     * The {@code p}th percentile chunk time, to within its bucket.
+     * <p>
+     * Log-bucketed rather than exact: an exact percentile needs every sample kept, and a million
+     * longs is itself the allocation problem this is measuring. A bucket is a factor of two, which
+     * is enough to see a tail move and not enough to argue about.
+     */
+    public static long percentileMicros(int p) {
+        long total = CHUNK_COUNT.sum();
+        if (total == 0) {
+            return 0;
+        }
+        long target = total * p / 100;
+        long seen = 0;
+        for (int i = 0; i < CHUNK_BUCKETS.length; i++) {
+            seen += CHUNK_BUCKETS[i].sum();
+            if (seen >= target) {
+                return 1L << i;
+            }
+        }
+        return 1L << (CHUNK_BUCKETS.length - 1);
+    }
+
+    private static int bucketFor(long nanos) {
+        long micros = Math.max(1, nanos / 1000);
+        int bucket = 63 - Long.numberOfLeadingZeros(micros);
+        return Math.min(bucket, CHUNK_BUCKETS.length - 1);
+    }
+
+    private static LongAdder[] newBuckets() {
+        // 2^24 microseconds is about 17 seconds; anything past that is one chunk, not a distribution.
+        LongAdder[] buckets = new LongAdder[25];
+        for (int i = 0; i < buckets.length; i++) {
+            buckets[i] = new LongAdder();
+        }
+        return buckets;
+    }
+
+    private static com.sun.management.ThreadMXBean threadBean() {
+        java.lang.management.ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+        if (!(bean instanceof com.sun.management.ThreadMXBean hotspot)
+                || !hotspot.isThreadAllocatedMemorySupported()) {
+            // Not HotSpot, or the feature is off. Everything else still measures.
+            return null;
+        }
+        hotspot.setThreadAllocatedMemoryEnabled(true);
+        return hotspot;
+    }
+
+    /**
+     * One cache's counters.
+     *
+     * <p>{@code races} is the one that needed a name. {@code TimedCache.getOrCompute} computes
+     * outside the map on purpose - {@code computeIfAbsent} deadlocks on the mutually recursive city
+     * caches - so two threads may compute the same pure value and one result is dropped. That is
+     * correct and documented, and it is also duplicated work nothing counted.</p>
+     *
+     * <p>There is no {@code computes} counter, deliberately. Most of these caches are populated
+     * through {@code get} then {@code putIfAbsent} rather than {@code getOrCompute}, so a compute
+     * count would be zero for them and non-zero for the three that use the other shape - which reads
+     * as "these caches never compute anything" rather than as "this counter does not apply here".
+     * The miss count is the compute count for every one of them.</p>
+     */
+    public static final class CacheStats {
+        private final LongAdder hits = new LongAdder();
+        private final LongAdder misses = new LongAdder();
+        private final LongAdder races = new LongAdder();
+        private final LongAdder evictions = new LongAdder();
+        private final LongAdder sweeps = new LongAdder();
+        private final LongAdder sweepNanos = new LongAdder();
+        private final AtomicLong sweptTo = new AtomicLong();
+        private volatile LongSupplier liveSize = () -> -1;
+
+        public void hit() {
+            hits.increment();
+        }
+
+        public void miss() {
+            misses.increment();
+        }
+
+        public void raced() {
+            races.increment();
+        }
+
+        public void evicted(long count) {
+            evictions.add(count);
+        }
+
+        public void swept(long nanos, long remaining) {
+            sweeps.increment();
+            sweepNanos.add(nanos);
+            sweptTo.set(remaining);
+        }
+
+        public long hits() {
+            return hits.sum();
+        }
+
+        public long misses() {
+            return misses.sum();
+        }
+
+        public long races() {
+            return races.sum();
+        }
+
+        public long evictions() {
+            return evictions.sum();
+        }
+
+        public long sweeps() {
+            return sweeps.sum();
+        }
+
+        void reset() {
+            hits.reset();
+            misses.reset();
+            races.reset();
+            evictions.reset();
+            sweeps.reset();
+            sweepNanos.reset();
+            sweptTo.set(0);
+        }
+
+        String format() {
+            long hit = hits.sum();
+            long miss = misses.sum();
+            long lookups = hit + miss;
+            return String.format("%d/%d(%.0f%%) races=%d evicted=%d sweeps=%d sweepMs=%d size=%d",
+                    hit, lookups, lookups == 0 ? 0.0 : hit * 100.0 / lookups,
+                    races.sum(), evictions.sum(), sweeps.sum(),
+                    sweepNanos.sum() / 1_000_000, liveSize.getAsLong());
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/varia/TimedCache.java
+++ b/src/main/java/dev/krona/urbex/varia/TimedCache.java
@@ -16,6 +16,13 @@ import java.util.function.IntSupplier;
  */
 public class TimedCache<K, V> {
 
+    /**
+     * Where this cache's counters go, or null when metrics are off - which is every run that is not
+     * measuring. Null rather than a no-op object so the branch below is a null check the JIT can
+     * fold, and so an unmeasured run allocates no counters at all (issue #132).
+     */
+    private final GenerationMetrics.CacheStats stats;
+
     private static class Entry<V> {
         private final V value;
         // Written on every read, from whichever thread did the reading. Volatile so a later
@@ -33,27 +40,52 @@ public class TimedCache<K, V> {
     private final AtomicLong nextCleanupAt;
 
     public TimedCache(IntSupplier ttlSecondsSupplier) {
+        this(ttlSecondsSupplier, null);
+    }
+
+    /**
+     * @param name what this cache is called in a {@code PERF=} report. A cache built without one is
+     *             not reported, which is how a cache created inside a test stays out of the numbers.
+     */
+    public TimedCache(IntSupplier ttlSecondsSupplier, String name) {
         this.ttlSecondsSupplier = ttlSecondsSupplier;
         this.nextCleanupAt = new AtomicLong(System.currentTimeMillis());
+        this.stats = GenerationMetrics.enabled() && name != null
+                ? GenerationMetrics.cache(name, cache::size) : null;
     }
 
     public void clear() {
         cache.clear();
     }
 
+    /** How many entries are held right now. O(n) on a ConcurrentHashMap, so: reporting only. */
+    public int size() {
+        return cache.size();
+    }
+
     public V get(K key) {
         long now = System.currentTimeMillis();
         Entry<V> entry = cache.get(key);
         if (entry == null) {
+            if (stats != null) {
+                stats.miss();
+            }
             maybeCleanup(now);
             return null;
         }
         if (isExpired(entry, now)) {
             cache.remove(key, entry);
+            if (stats != null) {
+                stats.miss();
+                stats.evicted(1);
+            }
             maybeCleanup(now);
             return null;
         }
         entry.lastAccess = now;
+        if (stats != null) {
+            stats.hit();
+        }
         maybeCleanup(now);
         return entry.value;
     }
@@ -82,6 +114,11 @@ public class TimedCache<K, V> {
             return null;
         }
         V raced = putIfAbsent(key, computed);
+        if (raced != null && stats != null) {
+            // Two threads computed the same pure value and one result is dropped. Correct, and
+            // documented above; also duplicated work nothing counted until #132.
+            stats.raced();
+        }
         return raced != null ? raced : computed;
     }
 
@@ -113,17 +150,27 @@ public class TimedCache<K, V> {
     }
 
     private void cleanup(long now) {
+        long started = stats == null ? 0 : System.nanoTime();
+        long removed = 0;
         long ttlMillis = getTtlMillis();
         if (ttlMillis <= 0) {
+            removed = cache.size();
             cache.clear();
-            return;
-        }
-        Iterator<Map.Entry<K, Entry<V>>> iterator = cache.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<K, Entry<V>> entry = iterator.next();
-            if (now - entry.getValue().lastAccess >= ttlMillis) {
-                iterator.remove();
+        } else {
+            Iterator<Map.Entry<K, Entry<V>>> iterator = cache.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<K, Entry<V>> entry = iterator.next();
+                if (now - entry.getValue().lastAccess >= ttlMillis) {
+                    iterator.remove();
+                    removed++;
+                }
             }
+        }
+        if (stats != null) {
+            // The sweep is O(n) on whichever worldgen worker won the CAS above, which is the
+            // specific thing #132 asks to measure before anything is done about it.
+            stats.evicted(removed);
+            stats.swept(System.nanoTime() - started, cache.size());
         }
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -251,6 +251,7 @@ public class CityGenerator {
     private void generateOrThrow(DimensionRuntime runtime, WorldGenRegion region,
                                  ChunkAccess chunk, ChunkCoord coord) {
         long start = System.currentTimeMillis();
+        long startNanos = GenerationMetrics.enabled() ? System.nanoTime() : 0;
 
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
@@ -334,6 +335,10 @@ public class CityGenerator {
 
         long time = System.currentTimeMillis() - start;
         statistics.addTime(time);
+        // Nanoseconds, separately from the millisecond Statistics that /urbex stats reports: a
+        // chunk taking under a millisecond rounds to zero there, which is most of them, and a tail
+        // latency built out of those numbers would be made of zeroes (issue #132).
+        GenerationMetrics.chunk(System.nanoTime() - startNanos);
         } catch (Throwable t) {
             throw new ChunkGenerationFailure(coord, ctx.driver.commitState(), t);
         }

--- a/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.varia.GenerationMetrics;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
 import dev.krona.urbex.worldgen.lost.PrimaryBridgePlanner;
 import dev.krona.urbex.worldgen.lost.Railway;
@@ -56,6 +57,10 @@ public final class DigestRunner {
      *                     slope - the only mechanical proof the full-chunk {@code street_stair}
      *                     part renders at all - announces itself instead of moving silently; see
      *                     {@code digestCheckFeatures} in {@code build.gradle}.
+     * @param perfLine     what the run cost, when {@code -Durbex.metrics} asked. Emitted beside the
+     *                     digest so a measurement is a digest run rather than a separate exercise
+     *                     with its own scheduling and its own caches (issue #132); {@code PERF=off}
+     *                     when nobody asked.
      * @param unsafeReads  how many cross-chunk terrain reads Urbex made during this run (see
      *                     {@link UnsafeReadCounter}). City generation runs at the carver stage,
      *                     where a chunk may touch only itself; a non-zero count here is a
@@ -64,7 +69,7 @@ public final class DigestRunner {
      */
     public record Result(long driverDigest, long fullDigest, long driverBlocks, int drivenChunks,
                          int chunkCount, long elapsedMs, int bridgeChunks, int slopeChunks, int avoidedChunks,
-                         int railCollisionChunks, long unsafeReads) {
+                         int railCollisionChunks, long unsafeReads, String perfLine) {
 
         public String driverLine(String order, int offset) {
             return String.format(
@@ -114,6 +119,9 @@ public final class DigestRunner {
         List<ChunkPos> chunks = chunkSquare(radius, order, offset);
 
         UnsafeReadCounter.reset();
+        // Reset here rather than at server start: a digest run is the measured unit, and a run that
+        // included whatever the spawn-area generation did would not be comparable with the next one.
+        GenerationMetrics.reset();
         long start = System.currentTimeMillis();
         int recordedChunks;
         // Forced cache expiry, off unless asked for. Planning caches are TimedCaches that can drop
@@ -191,7 +199,8 @@ public final class DigestRunner {
 
         long elapsed = System.currentTimeMillis() - start;
         return new Result(driverDigest, digest, driverBlocks, recordedChunks, chunks.size(), elapsed, bridgeChunks,
-                slopeChunks, avoidedChunks, railCollisionChunks, unsafeReads);
+                slopeChunks, avoidedChunks, railCollisionChunks, unsafeReads,
+                GenerationMetrics.report(chunks.size(), elapsed));
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
@@ -31,24 +31,24 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class DimensionCaches {
 
-    public final TimedCache<ChunkCoord, ChunkPlan> chunkPlan = new TimedCache<>(Config::cacheCleanupSeconds);
-    public final TimedCache<ChunkCoord, ChunkCandidate> candidate = new TimedCache<>(Config::cacheCleanupSeconds);
-    public final TimedCache<ChunkCoord, Integer> cityLevel = new TimedCache<>(Config::cacheCleanupSeconds);
-    public final TimedCache<ChunkCoord, CityStyle> cityStyle = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, ChunkPlan> chunkPlan = new TimedCache<>(Config::cacheCleanupSeconds, "chunkPlan");
+    public final TimedCache<ChunkCoord, ChunkCandidate> candidate = new TimedCache<>(Config::cacheCleanupSeconds, "candidate");
+    public final TimedCache<ChunkCoord, Integer> cityLevel = new TimedCache<>(Config::cacheCleanupSeconds, "cityLevel");
+    public final TimedCache<ChunkCoord, CityStyle> cityStyle = new TimedCache<>(Config::cacheCleanupSeconds, "cityStyle");
     /**
      * Which world style governs a chunk, when the world was created with several. Only ever
      * populated for a genuine mix: {@link WorldStyleField#atChunk} short-circuits before reaching
      * the cache when there is one style, so a single-style world does not allocate here at all.
      */
-    public final TimedCache<ChunkCoord, WorldStyle> worldStyle = new TimedCache<>(Config::cacheCleanupSeconds);
-    public final TimedCache<ChunkCoord, MultiChunk> multiChunk = new TimedCache<>(Config::cacheCleanupSeconds);
-    public final TimedCache<ChunkCoord, BiomeInfo> biomeInfo = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, WorldStyle> worldStyle = new TimedCache<>(Config::cacheCleanupSeconds, "worldStyle");
+    public final TimedCache<ChunkCoord, MultiChunk> multiChunk = new TimedCache<>(Config::cacheCleanupSeconds, "multiChunk");
+    public final TimedCache<ChunkCoord, BiomeInfo> biomeInfo = new TimedCache<>(Config::cacheCleanupSeconds, "biomeInfo");
     public final ConcurrentHashMap<ChunkCoord, Railway.RailChunkInfo> railInfo = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<ChunkCoord, Integer> xHighwayLevel = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<ChunkCoord, Integer> zHighwayLevel = new ConcurrentHashMap<>();
-    public final TimedCache<ChunkCoord, ChunkHeightmap> heightmap = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, ChunkHeightmap> heightmap = new TimedCache<>(Config::cacheCleanupSeconds, "heightmap");
     /** Keyed on the scatter area's anchor chunk, not a real chunk coordinate. */
-    public final TimedCache<ChunkCoord, Scattered.AreaScan> scatterAreaScan = new TimedCache<>(Config::cacheCleanupSeconds);
+    public final TimedCache<ChunkCoord, Scattered.AreaScan> scatterAreaScan = new TimedCache<>(Config::cacheCleanupSeconds, "scatterAreaScan");
 
     /**
      * The city-rarity map is per profile rather than per chunk so independently configured profiles

--- a/src/main/java/dev/krona/urbex/worldgen/LevelTaskQueue.java
+++ b/src/main/java/dev/krona/urbex/worldgen/LevelTaskQueue.java
@@ -2,6 +2,7 @@ package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.varia.GenerationMetrics;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 
@@ -99,7 +100,7 @@ public final class LevelTaskQueue {
 
     public void add(BlockPos pos, Task task) {
         pending.add(new Entry(pos, task));
-        pendingCount.incrementAndGet();
+        GenerationMetrics.queueDepth(pendingCount.incrementAndGet());
     }
 
     /**

--- a/src/test/java/dev/krona/urbex/varia/GenerationMetricsTest.java
+++ b/src/test/java/dev/krona/urbex/varia/GenerationMetricsTest.java
@@ -1,0 +1,82 @@
+package dev.krona.urbex.varia;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The measurement is off unless asked for, and says so rather than reporting zeroes.
+ * <p>
+ * These run without {@code -Durbex.metrics}, which is the state every non-measuring run is in - so
+ * what they pin is the off path. A counter that is always on is a measurement that changes what it
+ * measures, and for a per-chunk path that is not a theoretical concern (issue #132).
+ */
+class GenerationMetricsTest {
+
+    @Test
+    void metricsAreOffUnlessTheSystemPropertyIsSet() {
+        assertFalse(GenerationMetrics.enabled(),
+                "the test JVM sets no -Durbex.metrics, so this is the shipped default");
+    }
+
+    @Test
+    void anUnaskedReportSaysSoRatherThanReportingZeroes() {
+        String report = GenerationMetrics.report(625, 24000);
+
+        assertTrue(report.startsWith("PERF=off"), report);
+        assertTrue(report.contains(GenerationMetrics.ENABLED_PROPERTY),
+                "and says how to ask: " + report);
+    }
+
+    @Test
+    void recordingWhileOffCostsNothingAndChangesNothing() {
+        GenerationMetrics.chunk(5_000_000L);
+        GenerationMetrics.queueDepth(4096);
+
+        assertEquals(0, GenerationMetrics.percentileMicros(99),
+                "a chunk recorded while off must not appear in a later measured run");
+        assertEquals(0, GenerationMetrics.allocatedBytes());
+    }
+
+    /**
+     * The percentile is bucketed by powers of two, deliberately: an exact one needs every sample
+     * kept, and a million longs is itself the allocation problem being measured. What matters is
+     * that a bucket boundary is where it claims to be.
+     */
+    @Test
+    void percentilesAreEmptyWithNoSamples() {
+        GenerationMetrics.reset();
+
+        assertEquals(0, GenerationMetrics.percentileMicros(50));
+        assertEquals(0, GenerationMetrics.percentileMicros(99));
+    }
+
+    @Test
+    void aCacheWithNoLookupsReportsNoHitRateRatherThanDividingByZero() {
+        GenerationMetrics.CacheStats stats = GenerationMetrics.cache("test-empty", () -> 0);
+
+        assertEquals(0, stats.hits());
+        assertEquals(0, stats.misses());
+        assertEquals(0, stats.races());
+    }
+
+    @Test
+    void cacheCountersAccumulateIndependentlyOfWhetherReportingIsOn() {
+        // TimedCache only wires these up when metrics are on, but the counters themselves are just
+        // adders - a test that could not touch them without a system property would be a test of
+        // the property rather than of the counting.
+        GenerationMetrics.CacheStats stats = GenerationMetrics.cache("test-counting", () -> 3);
+        stats.hit();
+        stats.hit();
+        stats.miss();
+        stats.raced();
+        stats.evicted(7);
+
+        assertEquals(2, stats.hits());
+        assertEquals(1, stats.misses());
+        assertEquals(1, stats.races());
+        assertEquals(7, stats.evictions());
+    }
+}


### PR DESCRIPTION
Epic #134 forbids optimizing a deterministic generation path from inspection
alone, and three of phase 4's four issues are partly performance claims. This is
what those claims get measured against.

Throughput, allocation, cache behaviour and tail latency are all properties of
generating a known square of chunks, which the digest suites already do
repeatably - so the measurement rides on them rather than living in a harness
nobody runs. `-Durbex.metrics` switches it on and a `PERF=` line lands beside
`DRIVERDIGEST=`. Off, every entry point is a static-final false and a branch the
JIT folds; a counter that is always on is a measurement that changes what it
measures.

Allocation is sampled per thread via ThreadMXBean.getThreadAllocatedBytes rather
than from Runtime deltas, because worldgen fans out and a heap delta measures the
collector's mood. The per-chunk sample point is also the thread filter: the
threads that generate are the threads that call it.

Tail latency is bucketed by powers of two rather than exact. An exact percentile
keeps every sample, and a million longs is itself the allocation problem being
measured; a factor of two is enough to see a tail move.

The baseline it produces, at 59a381d on runDigestCheckAvoid, is in the spec.
Four things it says that inspection did not:

  - ~12 MiB allocated per generated chunk (9963 MiB over 816);
  - cityLevel hits 32% - a memo table missing two thirds of the time;
  - no cache sweep runs at all in a 24-second drive, because the TTL is 300s, so
    the O(n) sweep #132 worries about needs the soak and not this;
  - queueHighWater=598 deferred tasks against a per-tick budget of 20.

Two counters were considered and dropped rather than shipped misleading. There is
no `computes`: most of these caches populate through get-then-putIfAbsent rather
than getOrCompute, so it would read zero for them and non-zero for three, which
looks like "these never compute" rather than "this does not apply". And `size` is
sampled at report time rather than tracked, because maintaining a count on the
put path of a concurrent map is a cost the measurement would then be measuring.

Sets no cache limit and removes no allocation - that is #132b, and doing it here
would be optimizing from inspection with a measurement bolted on afterwards.

Digest goldens all unchanged:
  runDigestCheck           688914e862e938fb
  runDigestCheckFeatures   7b5348f28e0a6d23
  runDigestCheckAvoid      b37050817cd94b93
  runDigestCheckAvoidModes 53290e1a9849c43d
  runDigestCheckRail       3fff027c14eea4a9

Part of #134 phase 4.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>