### PR TITLE
perf: compile each palette once per world, not once per chunk (#53, 53b)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -1871,14 +1871,16 @@ public class CityGenerator {
         return air;
     }
 
+    /**
+     * The chunk's palette with this part's local palette merged over it.
+     * <p>
+     * This carried an upstream {@code // Cache the combined palette?} comment and answered it by
+     * building a fresh {@link CompiledPalette} - deep-copying three maps over a hundred-odd entries -
+     * for every part with a local palette in every chunk. The answer is yes, and it is keyed on the
+     * two compiled assets involved rather than on the chunk (issue #53).
+     */
     public CompiledPalette computePalette(ChunkPlan info, IBuildingPart part) {
-        CompiledPalette compiledPalette = info.getCompiledPalette();
-        // Cache the combined palette?
-        Palette partPalette = part.getLocalPalette();
-        if (partPalette != null) {
-            compiledPalette = new CompiledPalette(compiledPalette, partPalette);
-        }
-        return compiledPalette;
+        return provider.caches().palettes.with(info.getCompiledPalette(), part.getLocalPalette());
     }
 
     private BlockEntityType getTypeForBlock(BlockState state) {

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
@@ -12,6 +12,7 @@ import dev.krona.urbex.worldgen.lost.ChunkCandidate;
 import dev.krona.urbex.worldgen.lost.MultiChunk;
 import dev.krona.urbex.worldgen.lost.Railway;
 import dev.krona.urbex.worldgen.lost.cityassets.CityStyle;
+import dev.krona.urbex.worldgen.lost.cityassets.PaletteCache;
 import dev.krona.urbex.worldgen.lost.cityassets.WorldStyle;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,6 +73,13 @@ public final class DimensionCaches {
     /** Identifies one city-rarity field. All four components come from the profile. */
     public record RaritySettings(long seed, double scale, double offset, double innerScale) {}
 
+    /**
+     * The palettes this world has already compiled. Keyed on compiled assets rather than on
+     * coordinates, so it is bounded by what the datapacks declare (issue #53).
+     */
+    public final PaletteCache palettes = new PaletteCache();
+
+
     public CityRarityMap getCityRarityMap(long seed, double scale, double offset, double innerScale) {
         RaritySettings key = new RaritySettings(seed, scale, offset, innerScale);
         CityRarityMap existing = cityRarity.get(key);
@@ -97,5 +105,6 @@ public final class DimensionCaches {
         heightmap.clear();
         scatterAreaScan.clear();
         cityRarity.clear();
+        palettes.clear();
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -168,12 +168,15 @@ public class ChunkPlan {
         }
         // Built into a local and published in one write: the half-built palette (without the
         // building's own entries merged in) must never be visible to another chunk's thread.
-        CompiledPalette built = new CompiledPalette(palette);
+        //
+        // Both steps go through the world's PaletteCache now. This field stays as the per-chunk
+        // memo in front of it - a field read beats two map lookups on a path every part of every
+        // building takes - but a chunk that is the first to want this combination no longer
+        // deep-copies three maps to get it (issue #53).
+        PaletteCache cache = provider.caches().palettes;
+        CompiledPalette built = cache.of(palette);
         if (hasBuilding) {
-            Palette buildingPalette = buildingType.getLocalPalette();
-            if (buildingPalette != null) {
-                built = new CompiledPalette(built, buildingPalette);
-            }
+            built = cache.with(built, buildingType.getLocalPalette());
         }
         compiledPalette = built;
         return built;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCache.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCache.java
@@ -1,0 +1,110 @@
+package dev.krona.urbex.worldgen.lost.cityassets;
+
+import dev.krona.urbex.varia.GenerationMetrics;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The compiled palettes a world has already built, so it does not build them again.
+ *
+ * <p>A {@link CompiledPalette} is a pure function of the {@link Palette}s merged into it, and those
+ * are compiled assets: one per style, per building, per part, fixed for the world. What varied was
+ * only which chunk was asking. {@code computePalette} carried an upstream {@code // Cache the
+ * combined palette?} comment and answered it by deep-copying three {@link Map}s over a hundred-odd
+ * entries for <em>every part with a local palette in every chunk</em> (issue #53).</p>
+ *
+ * <h2>Why the merge is not flattened</h2>
+ *
+ * <p>The obvious simplification - memoize {@code merge(style, building, part)} in one step - is
+ * wrong. {@link CompiledPalette#CompiledPalette(CompiledPalette, Palette...)} copies the base and
+ * then runs the character-reference resolution loop again over the new palettes only, while the
+ * varargs constructor runs it once over all of them together. A palette entry that refers to another
+ * character can therefore resolve differently, and "first definition wins" in that loop makes the
+ * order it sees load-bearing. So this memoizes each step of the existing composition rather than a
+ * shorter one that would produce a different palette.</p>
+ *
+ * <h2>Bounded by the pack, not by the world</h2>
+ *
+ * <p>Keys are compiled assets compared by identity, so the number of entries is bounded by the
+ * combinations a datapack actually declares - not by how far a player walks. That is what makes this
+ * a finite asset-derived index rather than another unbounded coordinate cache (issue #132); the
+ * {@code PERF=} line reports its size for exactly that reason.</p>
+ */
+public final class PaletteCache {
+
+    /** {@code style -> compiled}, the root of every chain. */
+    private final Map<Palette, CompiledPalette> roots = new ConcurrentHashMap<>();
+    /** {@code (base, overlay) -> compiled}, one step of the chain. */
+    private final Map<Overlay, CompiledPalette> overlays = new ConcurrentHashMap<>();
+
+    private record Overlay(CompiledPalette base, Palette extra) {}
+
+    /**
+     * Hits and misses, so "how many deep copies did this avoid" is a number rather than an argument.
+     * Null when metrics are off, like every other counter here.
+     */
+    private final GenerationMetrics.CacheStats stats =
+            GenerationMetrics.enabled() ? GenerationMetrics.cache("palettes", this::size) : null;
+
+    /** The palette compiled from {@code root} alone. */
+    public CompiledPalette of(Palette root) {
+        // get / compute-outside / putIfAbsent, like every other cache here: compiling inside a
+        // ConcurrentHashMap bin lock stalls every other worldgen thread whose key shares the bin,
+        // and racing threads compile equal palettes because the inputs are immutable.
+        CompiledPalette existing = roots.get(root);
+        if (existing != null) {
+            if (stats != null) {
+                stats.hit();
+            }
+            return existing;
+        }
+        if (stats != null) {
+            stats.miss();
+        }
+        CompiledPalette compiled = new CompiledPalette(root);
+        CompiledPalette raced = roots.putIfAbsent(root, compiled);
+        if (raced != null && stats != null) {
+            stats.raced();
+        }
+        return raced != null ? raced : compiled;
+    }
+
+    /**
+     * {@code base} with {@code extra} merged over it, or {@code base} itself when there is nothing
+     * to merge.
+     */
+    public CompiledPalette with(CompiledPalette base, @Nullable Palette extra) {
+        if (extra == null) {
+            return base;
+        }
+        Overlay key = new Overlay(base, extra);
+        CompiledPalette existing = overlays.get(key);
+        if (existing != null) {
+            if (stats != null) {
+                stats.hit();
+            }
+            return existing;
+        }
+        if (stats != null) {
+            stats.miss();
+        }
+        CompiledPalette compiled = new CompiledPalette(base, extra);
+        CompiledPalette raced = overlays.putIfAbsent(key, compiled);
+        if (raced != null && stats != null) {
+            stats.raced();
+        }
+        return raced != null ? raced : compiled;
+    }
+
+    /** How many palettes this world has compiled. Reported by {@code -Durbex.metrics}. */
+    public int size() {
+        return roots.size() + overlays.size();
+    }
+
+    public void clear() {
+        roots.clear();
+        overlays.clear();
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Style.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/Style.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import net.minecraft.util.RandomSource;
 
 public class Style {
@@ -15,6 +17,9 @@ public class Style {
     private final Identifier name;
 
     private final List<List<Pair<Float, Palette>>> randomPaletteChoices = new ArrayList<>();
+
+    /** One merged palette per set of choices; see {@link #compose}. */
+    private final Map<List<Palette>, Palette> composed = new ConcurrentHashMap<>();
 
     /**
      * Builds a fully resolved style from its {@code extends} chain, root first: a declared
@@ -92,7 +97,7 @@ public class Style {
     }
 
     public Palette getRandomPalette(RandomSource random) {
-        Palette palette = new Palette("__random__");
+        List<Palette> chosen = new ArrayList<>(randomPaletteChoices.size());
         for (List<Pair<Float, Palette>> pairs : randomPaletteChoices) {
             float totalweight = 0;
             for (Pair<Float, Palette> pair : pairs) {
@@ -105,17 +110,45 @@ public class Style {
             // same arithmetic, and r can survive the whole walk by an ulp. Falling out with null
             // and merging it is a NullPointerException on a worldgen worker; the last entry is the
             // one the walk was an ulp short of choosing.
-            Pair<Float, Palette> chosen = pairs.get(pairs.size() - 1);
+            Pair<Float, Palette> chosenPair = pairs.get(pairs.size() - 1);
             for (Pair<Float, Palette> pair : pairs) {
                 r -= pair.getKey();
                 if (r <= 0) {
-                    chosen = pair;
+                    chosenPair = pair;
                     break;
                 }
             }
-            palette.merge(chosen.getRight());
+            chosen.add(chosenPair.getRight());
         }
+        return compose(List.copyOf(chosen));
+    }
 
-        return palette;
+    /**
+     * The merged palette for one set of choices, built once per set.
+     *
+     * <p>This used to build a fresh {@code Palette("__random__")} on every call - one per chunk -
+     * which is why memoizing anything downstream of it did nothing: the compiled-palette cache keyed
+     * on this object and every chunk handed it a new one, so 1028 lookups hit 13 times. Keyed on the
+     * chosen palettes it is bounded by what the style declares (issue #53).</p>
+     *
+     * <p>Safe to share because nothing writes to the result: {@code getRandomPalette} is the only
+     * caller of {@code Palette.merge} outside asset compilation, and {@code ChunkPlan.palette} is
+     * written once and only read.</p>
+     *
+     * <p>get / compute-outside / putIfAbsent, not {@code computeIfAbsent}: merging inside a
+     * {@code ConcurrentHashMap} bin lock stalls every other worldgen thread whose key shares the
+     * bin, and racing threads merge equal palettes from immutable inputs.</p>
+     */
+    private Palette compose(List<Palette> chosen) {
+        Palette existing = composed.get(chosen);
+        if (existing != null) {
+            return existing;
+        }
+        Palette palette = new Palette("__random__");
+        for (Palette part : chosen) {
+            palette.merge(part);
+        }
+        Palette raced = composed.putIfAbsent(chosen, palette);
+        return raced != null ? raced : palette;
     }
 }


### PR DESCRIPTION
computePalette carried an upstream `// Cache the combined palette?` comment and
answered it by deep-copying three maps over a hundred-odd entries for every part
with a local palette in every chunk. This memoizes it - and finding out why the
first attempt did nothing is most of what this PR is.

**The memo is not flattened, on purpose.** merge(merge(a,b),c) is not
merge(a,b,c): the copy constructor re-runs the character-reference resolution
loop over the new palettes only, and "first definition wins" inside that loop
makes the order it sees load-bearing. So PaletteCache memoizes each step of the
existing composition rather than a shorter one that would produce a different
palette.

**What the measurement said.** With only that in place the cache hit 13 times
out of 1028 lookups - 1%. The reason is Style.getRandomPalette, which built a
fresh `Palette("__random__")` on every call, so every chunk handed the cache a
key nothing else would ever use. Memoizing that composition on the chosen
palettes takes the hit rate to 78%. Nothing downstream of a per-chunk allocation
can be cached, and a cache that misses is indistinguishable from one that works
unless someone counts.

Sharing the composed palette is safe because nothing writes to it:
getRandomPalette is the only caller of Palette.merge outside asset compilation,
and ChunkPlan.palette is written once in the constructor and only read.

Both caches are keyed on compiled assets by identity, so they are bounded by what
the datapack declares rather than by how far a player walks - the distinction
#132 asks for. The bundled pack settles at 1028 entries over a 625-chunk window,
and the PERF line reports it.

Measured on runDigestCheckAvoid (625 chunks, seed 135132278163449878):

  baseline (59a381d)   ms=24367  chunksPerSec=33.5  meanUs=4679.5  allocMiB=9963
  typed entries (53a)  ms=23764  chunksPerSec=34.3  meanUs=4385.2  allocMiB=9623
  memoized (this)      ms=23779  chunksPerSec=34.3  meanUs=4378.0  allocMiB=9690
                       palettes=803/1028(78%)

**Total allocation does not move.** Palettes are not where the ~12 MiB per chunk
lives, and the honest reading of these numbers is that this removes a real
unbounded-per-chunk allocation that was never a large fraction of the total. The
hit rate is the evidence of what it avoided; the MiB column is evidence that
something else is the reason to look at #132b.

Digest goldens all unchanged, shuffled included:
  runDigestCheck / Shuffled  688914e862e938fb
  runDigestCheckFeatures     7b5348f28e0a6d23
  runDigestCheckAvoid        b37050817cd94b93
  runDigestCheckAvoidModes   53290e1a9849c43d
  runDigestCheckRail         3fff027c14eea4a9

Part of #134 phase 4.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>