### PR TITLE
fix: reading a block no longer rewrites the whole section (#52, 52a)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -326,7 +326,7 @@ public class ChunkDriver {
         BlockState state = cache.get(p);
         if (state == null) {
             state = region.getBlockState(p);
-            cache.put(p, state);
+            cache.remember(p, state);
         }
         return state;
     }
@@ -753,6 +753,25 @@ public class ChunkDriver {
                     fixHeightmapForAir(ystart, px, pz);
                 }
             }
+        }
+
+        /**
+         * Remembers what the world already holds at {@code pos}, without claiming this chunk wrote
+         * it.
+         *
+         * <p>This used to be {@link #put}, and {@code put} marks the section written - so a section
+         * Urbex only <em>read</em> from was flushed back in full at the end of the chunk, 4096 slots
+         * of terrain rewritten with the values they already had. Reading a block is not writing one
+         * (issue #52).</p>
+         *
+         * <p>The internal heightmap is deliberately not updated here. It is maintained by the write
+         * paths and read by nothing outside its own repair scan - which is its own finding, and its
+         * own change.</p>
+         */
+        private void remember(BlockPos pos, BlockState state) {
+            int sectionIdx = (pos.getY() - minY) / SECTION_HEIGHT;
+            int idx = ((pos.getX() & 0xf) << 8) + ((pos.getY() & 0xf) << 4) + (pos.getZ() & 0xf);
+            cache[sectionIdx].section[idx] = state;
         }
 
         private void put(BlockPos pos, BlockState state) {


### PR DESCRIPTION
ChunkDriver.getBlock populated the section cache on a miss through
SectionCache.put, and put marks the section written. generate() then flushes
every written section in full - so a section this chunk only *read* from was
rewritten at the end of the chunk, 4096 slots of terrain set back to the values
they already had.

Reads go through remember() now, which fills the slot and claims nothing. A
section is written only if something wrote to it.

Read-cached slots inside a section that was genuinely written are still flushed,
and that is correct rather than an oversight: the slot holds what was read from
the world, or what a later write put there, so the flush is either a no-op or
the write. Distinguishing them per slot would need a bitset per section - 12 KiB
of allocation per chunk to avoid writes that cost nothing - which is the wrong
trade in a phase that is also trying to allocate less.

The internal heightmap is deliberately not updated on a read. It is maintained
by the write paths and read by nothing outside its own repair scan, which is a
separate finding with a separate change.

Measured on runDigestCheckAvoid (625 chunks, seed 135132278163449878), two runs:

  before  ms=23779  chunksPerSec=34.3  meanUs=4378.0  allocMiB=9690
  after   ms=23456  chunksPerSec=34.8  meanUs=3953.8  allocMiB=9666
          ms=23656  chunksPerSec=34.5  meanUs=4128.0  allocMiB=9604

Mean chunk time is down about 6-10% across two runs; allocation is flat, because
the waste was CPU spent in section.setBlockState rather than bytes. Two samples
against one, so this is evidence and not a benchmark.

Digest goldens all unchanged, shuffled included - which is the assertion that
matters here, since the change is about which sections are written back:
  runDigestCheck / Shuffled  688914e862e938fb
  runDigestCheckFeatures     7b5348f28e0a6d23
  runDigestCheckAvoid        b37050817cd94b93
  runDigestCheckAvoidModes   53290e1a9849c43d
  runDigestCheckRail         3fff027c14eea4a9

Part of #134 phase 4.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>