### PR TITLE
refactor: remove the section cache's dead height bookkeeping (#132, 132b)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -653,7 +653,6 @@ public class ChunkDriver {
         private final int cx;
         private final int cz;
         private final S[] cache;
-        private final int[][] heightmap = new int[16][16];
 
         private SectionCache(ChunkDriver owner, LevelAccessor level, int cx, int cz) {
             this.owner = owner;
@@ -670,18 +669,14 @@ public class ChunkDriver {
             if (state == null || state.getBlock() instanceof StructureVoidBlock) {
                 return;
             }
-            int ystart = y1;
             int px = x & 0xf;
             int pz = z & 0xf;
-            boolean isAir = state.isAir();
-            boolean dirty = false;
             boolean record = recordingWrites;    // read the flag once, not once per block
             while (y1 <= y2) {
                 int sectionIdx = (y1 - minY) / SECTION_HEIGHT;
                 int idx = (px << 8) + ((y1 & 0xf) << 4) + pz;
 
                 if (cache[sectionIdx].section[idx] != state) {
-                    dirty = true;
                     cache[sectionIdx].section[idx] = state;
                     cache[sectionIdx].touched = true;
                 }
@@ -690,18 +685,6 @@ public class ChunkDriver {
                 }
                 y1++;
             }
-
-            // Now update the heightmap
-            if (dirty) {
-                if (!isAir) {
-                    if (heightmap[px][pz] < y2) {
-                        heightmap[px][pz] = y2;
-                    }
-                } else {
-                    // If state is air we need to recalculate the heightmap
-                    fixHeightmapForAir(ystart, px, pz);
-                }
-            }
         }
 
         // Puts a range of blockstates starting at pos and ending at y2 (inclusive)
@@ -709,11 +692,8 @@ public class ChunkDriver {
             if (state == null || state.getBlock() instanceof StructureVoidBlock) {
                 return;
             }
-            int ystart = y1;
             int px = x & 0xf;
             int pz = z & 0xf;
-            boolean isAir = state.isAir();
-            boolean dirty = false;
             boolean record = recordingWrites;    // read the flag once, not once per block
             BlockPos.MutableBlockPos worldPos = null;
             while (y1 <= y2) {
@@ -732,7 +712,6 @@ public class ChunkDriver {
                     st = owner.region.getBlockState(worldPos.set(cx + px, y1, cz + pz));
                 }
                 if (st != state && test.test(st)) {
-                    dirty = true;
                     cache[sectionIdx].section[idx] = state;
                     cache[sectionIdx].touched = true;
                     if (record) {
@@ -740,18 +719,6 @@ public class ChunkDriver {
                     }
                 }
                 y1++;
-            }
-
-            // Now update the heightmap
-            if (dirty) {
-                if (!isAir) {
-                    if (heightmap[px][pz] < y2) {
-                        heightmap[px][pz] = y2;
-                    }
-                } else {
-                    // If state is air we need to recalculate the heightmap
-                    fixHeightmapForAir(ystart, px, pz);
-                }
             }
         }
 
@@ -763,10 +730,6 @@ public class ChunkDriver {
          * Urbex only <em>read</em> from was flushed back in full at the end of the chunk, 4096 slots
          * of terrain rewritten with the values they already had. Reading a block is not writing one
          * (issue #52).</p>
-         *
-         * <p>The internal heightmap is deliberately not updated here. It is maintained by the write
-         * paths and read by nothing outside its own repair scan - which is its own finding, and its
-         * own change.</p>
          */
         private void remember(BlockPos pos, BlockState state) {
             int sectionIdx = (pos.getY() - minY) / SECTION_HEIGHT;
@@ -784,31 +747,6 @@ public class ChunkDriver {
             }
             cache[sectionIdx].section[idx] = state;
             cache[sectionIdx].touched = true;
-            if (!state.isAir()) {
-                if (heightmap[px][pz] < pos.getY()) {
-                    heightmap[px][pz] = pos.getY();
-                }
-            } else {
-                // If state is air we need to recalculate the heightmap
-                fixHeightmapForAir(pos.getY(), px, pz);
-            }
-        }
-
-        private void fixHeightmapForAir(int y1, int px, int pz) {
-            if (heightmap[px][pz] >= y1) {
-                int y = Math.max(heightmap[px][pz], y1);
-                while (y >= minY) {
-                    int si = (y - minY) / SECTION_HEIGHT;
-                    int i = (px << 8) + ((y & 0xf) << 4) + pz;
-                    BlockState st = cache[si].section[i];
-                    if (st != null && !st.isAir()) {
-                        heightmap[px][pz] = y;
-                        return;
-                    }
-                    y--;
-                }
-                heightmap[px][pz] = Integer.MIN_VALUE;
-            }
         }
 
         @Nullable
@@ -845,11 +783,6 @@ public class ChunkDriver {
         private void clear() {
             for (int si = 0 ; si < (maxY - minY) / SECTION_HEIGHT ; si++) {
                 cache[si] = new S();
-            }
-            for (int x = 0 ; x < 16 ; x++) {
-                for (int z = 0 ; z < 16 ; z++) {
-                    heightmap[x][z] = Integer.MIN_VALUE;
-                }
             }
         }
     }


### PR DESCRIPTION
SectionCache kept a 16x16 int heightmap, maintained by three write paths, with a
downward column rescan (fixHeightmapForAir) on every air write in case the
column's top had just been erased.

Nothing reads it. The only consumer is its own repair scan reading it back to
decide whether to rescan. Vanilla's heightmaps are recomputed from the finished
chunk by Heightmap.primeHeightmaps in actuallyGenerate, which is what the world
actually uses.

So this is #132's "dead internal height bookkeeping is removed or justified with
a consumer", answered by removal: an array, two branches per written block, and a
scan that could walk a whole column downward on every air write - all feeding
nothing. Air writes are not rare; clearing space above a street or a highway is
most of what the driver does.

Split from 52a rather than folded into it: that change was about which sections
are written back, this one is about bookkeeping nobody reads, and the second is
only obvious once the first has been argued.

Measured on runDigestCheckAvoid (625 chunks, seed 135132278163449878), two runs
each:

  before  ms=23456/23656  meanUs=3953.8/4128.0  allocMiB=9666/9604
  after   ms=23487/23586  meanUs=3955.2/3950.6  allocMiB=10011/9986

No measurable change either way, and the allocation column moved the wrong way by
about the same margin it moves between two identical runs - which is the honest
report. The reason to make this change is that maintaining a structure nobody
reads is a standing invitation to trust it; the numbers say it was not costing
anything worth measuring at this window size.

Digest goldens all unchanged, shuffled included:
  runDigestCheck / Shuffled  688914e862e938fb
  runDigestCheckFeatures     7b5348f28e0a6d23
  runDigestCheckAvoid        b37050817cd94b93
  runDigestCheckAvoidModes   53290e1a9849c43d
  runDigestCheckRail         3fff027c14eea4a9

Part of #134 phase 4.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>