### PR TITLE
fix: the digest recorder no longer decides what gets generated (#52)

### DIFF
--- a/docs/superpowers/specs/2026-08-13-phase4-decompose-and-measure.md
+++ b/docs/superpowers/specs/2026-08-13-phase4-decompose-and-measure.md
@@ -94,6 +94,22 @@ Four things this says that inspection did not, and that #132b now has to answer:
 `generated` exceeds `chunks` because the pipeline pulls in neighbours to satisfy the requested
 square; it is the honest denominator for a per-chunk figure.
 
+## A blind spot the baseline found
+
+`ChunkDriver` used one field as both the end-of-chunk corrections worklist and the `/urbex digest`
+write log, and `putRange` only filled it when the recorder was on. So which positions received
+connection properties and neighbour shape updates depended on whether a digest was running.
+
+The interesting part is what happened when it was fixed: **nothing**. All six suites hash the same
+chunks whether corrections run over every written position or only over cursor-written ones — about
+26M recorded block writes, five worlds, no difference. The measurement is what made the change
+decidable at all: correcting bulk fills costs ~6.5% of mean chunk time (3864µs against 4117–4206µs
+on `runDigestCheckAvoid`) and no measurable wall clock, since the extra work parallelizes.
+
+So the digests do not cover this class of defect, and a green six-suite run is not evidence about
+it. Anything that changes *which* positions the corrections pass visits needs a unit test;
+`ChunkDriverCorrectionsTest` is that test.
+
 ## What this PR does not do
 
 It sets no cache limits and removes no allocation. Those are #132b, and doing them here would be

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -122,52 +122,79 @@ public class ChunkDriver {
         RECORDED_WRITES.clear();
     }
 
-    /** Thread-confined: only ever touched by the single thread driving this chunk. */
-    private Long2ObjectOpenHashMap<BlockState> recorded;
+    /**
+     * Every position this driver wrote and the state it last put there. Thread-confined: only ever
+     * touched by the single thread driving this chunk.
+     *
+     * <p>Filled on every write, whether or not anything is recording, and that is the fix rather
+     * than an implementation detail. {@code putRange} used to consult {@link #recordingWrites}
+     * before noting a position at all - and {@link #correctionsPass} walks this same log - so a
+     * bulk-filled wall got its connection properties during {@code /urbex digest} and did not
+     * during normal play. The corrections pass is generation; the recorder is a harness, and a
+     * harness must not be load-bearing (issue #52).</p>
+     *
+     * <p>No golden moved when this was fixed, and none moves if it is broken again: every suite
+     * hashes the same chunks under either rule. The guard is
+     * {@code ChunkDriverCorrectionsTest}, not the digests - which is worth knowing before trusting
+     * a green digest run to cover a change to <em>which</em> positions get corrected.</p>
+     */
+    private Long2ObjectOpenHashMap<BlockState> written;
+
     private boolean published;
     private boolean loggedLateWrite;
 
-    private void recordWrite(int x, int y, int z, BlockState state) {
+    /** This driver put {@code state} at the given position. */
+    private void wrote(int x, int y, int z, BlockState state) {
         if (published) {
-            if (!recordingWrites) {
-                return;
-            }
-            // publishRecordedWrites() has already run for this driver, so the accumulator is gone
-            // and this position would simply vanish. Nothing reaches here today - updateAdjacent is
-            // the only writer that could outlive the placement pass, and it is only ever called
-            // from correct(). But Task 6 verifies itself with this harness, and a harness that
-            // silently discards writes is the worst possible thing to debug. So: say so, loudly,
-            // and record it anyway rather than quietly reporting a wrong digest.
-            if (!loggedLateWrite) {
-                loggedLateWrite = true;
-                Urbex.getLogger().error(
-                        "ChunkDriver write recorder: block written at {},{},{} after this driver "
-                                + "published its writes. The /urbex digest harness would have "
-                                + "dropped it; recording it separately. This is a bug - some pass "
-                                + "now runs after actuallyGenerate().", x, y, z);
-            }
-            Long2ObjectOpenHashMap<BlockState> late = new Long2ObjectOpenHashMap<>();
-            late.put(BlockPos.asLong(x, y, z), state);
-            mergeIntoRecordedWrites(late);
+            recordLateWrite(x, y, z, state);
             return;
         }
-        if (recorded == null) {
-            recorded = new Long2ObjectOpenHashMap<>();
+        if (written == null) {
+            written = new Long2ObjectOpenHashMap<>();
         }
         // put, not putIfAbsent: within one driver, the last write to a position wins - the same
         // property the old read-the-final-world approach had for driver-internal overwrites
-        recorded.put(BlockPos.asLong(x, y, z), state);
+        written.put(BlockPos.asLong(x, y, z), state);
+    }
+
+    private void recordLateWrite(int x, int y, int z, BlockState state) {
+        if (!recordingWrites) {
+            return;
+        }
+        // publishRecordedWrites() has already run for this driver, so the accumulator is gone
+        // and this position would simply vanish. Nothing reaches here today - updateAdjacent is
+        // the only writer that could outlive the placement pass, and it is only ever called
+        // from correct(). But Task 6 verifies itself with this harness, and a harness that
+        // silently discards writes is the worst possible thing to debug. So: say so, loudly,
+        // and record it anyway rather than quietly reporting a wrong digest.
+        if (!loggedLateWrite) {
+            loggedLateWrite = true;
+            Urbex.getLogger().error(
+                    "ChunkDriver write recorder: block written at {},{},{} after this driver "
+                            + "published its writes. The /urbex digest harness would have "
+                            + "dropped it; recording it separately. This is a bug - some pass "
+                            + "now runs after actuallyGenerate().", x, y, z);
+        }
+        Long2ObjectOpenHashMap<BlockState> late = new Long2ObjectOpenHashMap<>();
+        late.put(BlockPos.asLong(x, y, z), state);
+        mergeIntoRecordedWrites(late);
     }
 
     /**
-     * Hand this chunk's recorded positions over to the shared map. Called once, at the end of
-     * generation, from the thread that did the driving.
+     * Hand this chunk's write log over to the shared map, if anyone asked for it. Called once, at
+     * the end of generation, from the thread that did the driving.
+     *
+     * <p>The {@code recordingWrites} check is the whole point of the method. {@link #RECORDED_WRITES}
+     * is a static that only {@code /urbex digest} ever clears, and this published into it
+     * unconditionally - so a server that never ran the command still kept every position and
+     * {@code BlockState} of every chunk it had ever generated, for the life of the process, and
+     * paid a full copy of the accumulated map per chunk to put them there (issue #52).</p>
      */
     private void publishRecordedWrites() {
-        Long2ObjectOpenHashMap<BlockState> local = recorded;
-        recorded = null;
+        Long2ObjectOpenHashMap<BlockState> local = written;
+        written = null;
         published = true;
-        if (local == null || local.isEmpty()) {
+        if (!recordingWrites || local == null || local.isEmpty()) {
             return;
         }
         mergeIntoRecordedWrites(local);
@@ -271,10 +298,10 @@ public class ChunkDriver {
      * result cannot depend on write order.
      */
     private void correctionsPass() {
-        if (recorded == null || recorded.isEmpty()) {
+        if (written == null || written.isEmpty()) {
             return;
         }
-        long[] positions = recorded.keySet().toLongArray();
+        long[] positions = written.keySet().toLongArray();
         Arrays.sort(positions);
         for (long packed : positions) {
             current.set(BlockPos.getX(packed), BlockPos.getY(packed), BlockPos.getZ(packed));
@@ -295,7 +322,7 @@ public class ChunkDriver {
                 return;
             }
             cache.put(p, state);
-            recordWrite(p.getX(), p.getY(), p.getZ(), state);
+            wrote(p.getX(), p.getY(), p.getZ(), state);
         }
     }
 
@@ -671,7 +698,6 @@ public class ChunkDriver {
             }
             int px = x & 0xf;
             int pz = z & 0xf;
-            boolean record = recordingWrites;    // read the flag once, not once per block
             while (y1 <= y2) {
                 int sectionIdx = (y1 - minY) / SECTION_HEIGHT;
                 int idx = (px << 8) + ((y1 & 0xf) << 4) + pz;
@@ -680,9 +706,7 @@ public class ChunkDriver {
                     cache[sectionIdx].section[idx] = state;
                     cache[sectionIdx].touched = true;
                 }
-                if (record) {
-                    owner.recordWrite(x, y1, z, state);
-                }
+                owner.wrote(x, y1, z, state);
                 y1++;
             }
         }
@@ -694,7 +718,6 @@ public class ChunkDriver {
             }
             int px = x & 0xf;
             int pz = z & 0xf;
-            boolean record = recordingWrites;    // read the flag once, not once per block
             BlockPos.MutableBlockPos worldPos = null;
             while (y1 <= y2) {
                 int sectionIdx = (y1 - minY) / SECTION_HEIGHT;
@@ -714,9 +737,7 @@ public class ChunkDriver {
                 if (st != state && test.test(st)) {
                     cache[sectionIdx].section[idx] = state;
                     cache[sectionIdx].touched = true;
-                    if (record) {
-                        owner.recordWrite(x, y1, z, state);
-                    }
+                    owner.wrote(x, y1, z, state);
                 }
                 y1++;
             }

--- a/src/test/java/dev/krona/urbex/worldgen/ChunkDriverCorrectionsTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/ChunkDriverCorrectionsTest.java
@@ -1,0 +1,92 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.WallBlock;
+import net.minecraft.world.level.block.state.properties.WallSide;
+import net.minecraft.world.level.chunk.ProtoChunk;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which positions the end-of-chunk corrections pass visits, and what decides it.
+ *
+ * <p>The pass reads connection properties off finished neighbours and shape-updates them back, so
+ * the set of positions it visits is part of what the mod generates - not a diagnostic. It must
+ * therefore be the same set whether or not {@code /urbex digest} happens to be recording, which is
+ * the property these pin (issue #52).</p>
+ */
+class ChunkDriverCorrectionsTest {
+
+    private static final BlockPos NEIGHBOUR = new BlockPos(5, 64, 5);
+    private static final BlockPos WALL = new BlockPos(6, 64, 5);
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void aCursorWrittenWallConnectsToItsNeighbour() {
+        assertEquals(WallSide.LOW, wallSideWest(false, driver ->
+                        driver.current(WALL.getX(), WALL.getY(), WALL.getZ())
+                                .block(Blocks.COBBLESTONE_WALL.defaultBlockState())),
+                "the corrections pass exists to do exactly this");
+    }
+
+    /**
+     * The bulk-fill path. This wrote the wall without ever putting it on the corrections worklist
+     * unless the digest recorder was on, because {@code putRange} used the recorder's flag to decide
+     * whether to note the position at all - and the worklist and the recorder were one field.
+     */
+    @Test
+    void aBulkFilledWallConnectsTheSameWayTheCursorWrittenOneDoes() {
+        assertEquals(WallSide.LOW, wallSideWest(false, driver ->
+                driver.setBlockRange(WALL.getX(), WALL.getY(), WALL.getZ(), WALL.getY() + 1,
+                        Blocks.COBBLESTONE_WALL.defaultBlockState())));
+    }
+
+    @Test
+    void recordingTheDigestDoesNotChangeWhatIsGenerated() {
+        assertEquals(
+                wallSideWest(false, bulkFillTheWall()),
+                wallSideWest(true, bulkFillTheWall()),
+                "a digest that only agrees with itself measures the harness, not the mod");
+    }
+
+    private static java.util.function.Consumer<ChunkDriver> bulkFillTheWall() {
+        return driver -> driver.setBlockRange(WALL.getX(), WALL.getY(), WALL.getZ(), WALL.getY() + 1,
+                Blocks.COBBLESTONE_WALL.defaultBlockState());
+    }
+
+    /**
+     * Places the wall the given way against a stone neighbour and reports the connection it ends up
+     * with. The neighbour is written straight into the chunk rather than through the driver, so the
+     * only position on the worklist is the wall's: a driver-written neighbour would be corrected too
+     * and would shape-update the wall from the other side, which is a different path than the one
+     * under test.
+     */
+    private static WallSide wallSideWest(boolean recording, java.util.function.Consumer<ChunkDriver> placeWall) {
+        ProtoChunk chunk = TestChunk.emptyChunk();
+        chunk.setBlockState(NEIGHBOUR, Blocks.STONE.defaultBlockState(), 0);
+
+        ChunkDriver driver = new ChunkDriver();
+        driver.setPrimer(TestChunk.levelFor(chunk), chunk);
+        if (recording) {
+            ChunkDriver.startRecordingWrites();
+        }
+        try {
+            placeWall.accept(driver);
+            driver.actuallyGenerate(chunk);
+        } finally {
+            ChunkDriver.stopRecordingWrites();
+            ChunkDriver.clearRecordedWrites();
+        }
+        return chunk.getBlockState(WALL).getValue(WallBlock.WEST);
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/ChunkDriverSectionCacheTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/ChunkDriverSectionCacheTest.java
@@ -2,33 +2,15 @@ package dev.krona.urbex.worldgen;
 
 import net.minecraft.SharedConstants;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.IdMapper;
 import net.minecraft.server.Bootstrap;
-import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.LevelHeightAccessor;
-import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeGenerationSettings;
-import net.minecraft.world.level.biome.BiomeSpecialEffects;
-import net.minecraft.world.level.biome.MobSpawnSettings;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.chunk.PalettedContainerFactory;
 import net.minecraft.world.level.chunk.ProtoChunk;
-import net.minecraft.world.level.chunk.Strategy;
-import net.minecraft.world.level.chunk.UpgradeData;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Proxy;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ChunkDriverSectionCacheTest {
-
-    private static final LevelHeightAccessor HEIGHT = LevelHeightAccessor.create(-64, 384);
 
     @BeforeAll
     static void bootstrap() {
@@ -38,90 +20,16 @@ class ChunkDriverSectionCacheTest {
 
     @Test
     void airOnlySectionWritesAreFlushedOverExistingTerrain() {
-        ProtoChunk chunk = new ProtoChunk(
-                new ChunkPos(0, 0),
-                UpgradeData.EMPTY,
-                HEIGHT,
-                palettedContainerFactory(),
-                null);
+        ProtoChunk chunk = TestChunk.emptyChunk();
         BlockPos cleared = new BlockPos(0, 64, 0);
         chunk.setBlockState(cleared, Blocks.STONE.defaultBlockState(), 0);
 
         ChunkDriver driver = new ChunkDriver();
-        driver.setPrimer(levelFor(chunk), chunk);
+        driver.setPrimer(TestChunk.levelFor(chunk), chunk);
         driver.current(0, cleared.getY(), 0).block(Blocks.AIR.defaultBlockState());
         driver.flushToChunk(chunk);
 
         assertTrue(chunk.getBlockState(cleared).isAir(),
                 "an air-only cache section must still replace existing terrain");
-    }
-
-    private static PalettedContainerFactory palettedContainerFactory() {
-        Holder<Biome> biome = dummyBiome();
-        IdMapper<Holder<Biome>> biomeIds = new IdMapper<>();
-        biomeIds.add(biome);
-        return new PalettedContainerFactory(
-                Strategy.createForBlockStates(Block.BLOCK_STATE_REGISTRY),
-                Blocks.AIR.defaultBlockState(),
-                null,
-                Strategy.createForBiomes(biomeIds),
-                biome,
-                null);
-    }
-
-    private static Holder<Biome> dummyBiome() {
-        BiomeSpecialEffects effects = new BiomeSpecialEffects(
-                0,
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                BiomeSpecialEffects.GrassColorModifier.NONE);
-        Biome biome = new Biome.BiomeBuilder()
-                .temperature(0.5f)
-                .downfall(0.5f)
-                .specialEffects(effects)
-                .mobSpawnSettings(MobSpawnSettings.EMPTY)
-                .generationSettings(BiomeGenerationSettings.EMPTY)
-                .build();
-        return Holder.direct(biome);
-    }
-
-    private static LevelAccessor levelFor(ProtoChunk chunk) {
-        return (LevelAccessor) Proxy.newProxyInstance(
-                LevelAccessor.class.getClassLoader(),
-                new Class<?>[]{LevelAccessor.class},
-                (proxy, method, args) -> switch (method.getName()) {
-                    case "getMinY" -> HEIGHT.getMinY();
-                    case "getMaxY" -> HEIGHT.getMaxY();
-                    case "getHeight" -> HEIGHT.getHeight();
-                    case "getSectionsCount" -> HEIGHT.getSectionsCount();
-                    case "getSectionIndex" -> HEIGHT.getSectionIndex((int) args[0]);
-                    case "getChunk" -> chunk;
-                    case "getBlockState" -> chunk.getBlockState((BlockPos) args[0]);
-                    case "hasChunk" -> true;
-                    case "toString" -> "chunk-level";
-                    case "hashCode" -> System.identityHashCode(proxy);
-                    case "equals" -> proxy == args[0];
-                    default -> defaultValue(method.getReturnType());
-                });
-    }
-
-    private static Object defaultValue(Class<?> type) {
-        if (type == boolean.class) {
-            return false;
-        }
-        if (type == int.class) {
-            return 0;
-        }
-        if (type == long.class) {
-            return 0L;
-        }
-        if (type == float.class) {
-            return 0.0f;
-        }
-        if (type == double.class) {
-            return 0.0d;
-        }
-        return null;
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/ChunkDriverWriteRecorderTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/ChunkDriverWriteRecorderTest.java
@@ -1,0 +1,73 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.chunk.ProtoChunk;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What the write recorder keeps, and when.
+ *
+ * <p>It publishes into a static map that only {@code /urbex digest} ever clears, so "when" is the
+ * interesting half: a server that never runs the command must come out of a generation run with
+ * nothing retained (issue #52).</p>
+ */
+class ChunkDriverWriteRecorderTest {
+
+    private static final BlockPos PLACED = new BlockPos(3, 64, 3);
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @BeforeEach
+    void forgetEarlierRuns() {
+        ChunkDriver.stopRecordingWrites();
+        ChunkDriver.clearRecordedWrites();
+    }
+
+    @Test
+    void aRunNobodyAskedToRecordRetainsNothing() {
+        driveOneBlock();
+
+        assertEquals(0, ChunkDriver.recordedChunkCount(),
+                "an unasked-for recording is a leak: nothing ever clears this map in normal play");
+    }
+
+    @Test
+    void aRecordedRunPublishesTheBlockItWrote() {
+        ChunkDriver.startRecordingWrites();
+        try {
+            driveOneBlock();
+        } finally {
+            ChunkDriver.stopRecordingWrites();
+        }
+
+        assertEquals(1, ChunkDriver.recordedChunkCount());
+        assertArrayEquals(
+                new long[]{BlockPos.asLong(PLACED.getX(), PLACED.getY(), PLACED.getZ())},
+                ChunkDriver.recordedWrites(new ChunkPos(0, 0)));
+        assertEquals(Blocks.STONE.defaultBlockState(),
+                ChunkDriver.recordedState(new ChunkPos(0, 0),
+                        BlockPos.asLong(PLACED.getX(), PLACED.getY(), PLACED.getZ())));
+    }
+
+    private static void driveOneBlock() {
+        ProtoChunk chunk = TestChunk.emptyChunk();
+        ChunkDriver driver = new ChunkDriver();
+        driver.setPrimer(TestChunk.levelFor(chunk), chunk);
+        driver.current(PLACED.getX(), PLACED.getY(), PLACED.getZ())
+                .block(Blocks.STONE.defaultBlockState());
+        driver.actuallyGenerate(chunk);
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/TestChunk.java
+++ b/src/test/java/dev/krona/urbex/worldgen/TestChunk.java
@@ -1,0 +1,110 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.IdMapper;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelHeightAccessor;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.chunk.PalettedContainerFactory;
+import net.minecraft.world.level.chunk.ProtoChunk;
+import net.minecraft.world.level.chunk.Strategy;
+import net.minecraft.world.level.chunk.UpgradeData;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+/**
+ * One empty chunk and a level that contains only it, for driving a {@link ChunkDriver} in a unit
+ * test.
+ *
+ * <p>The level is a proxy rather than a real {@code ServerLevel}: what the driver asks of it is a
+ * height range, one chunk, and block reads, and standing a real level up to answer three questions
+ * would put a chunk generator, a registry access and a save directory in the way of them.</p>
+ */
+final class TestChunk {
+
+    static final LevelHeightAccessor HEIGHT = LevelHeightAccessor.create(-64, 384);
+
+    private TestChunk() {
+    }
+
+    static ProtoChunk emptyChunk() {
+        return new ProtoChunk(new ChunkPos(0, 0), UpgradeData.EMPTY, HEIGHT, containerFactory(), null);
+    }
+
+    static LevelAccessor levelFor(ProtoChunk chunk) {
+        return (LevelAccessor) Proxy.newProxyInstance(
+                LevelAccessor.class.getClassLoader(),
+                new Class<?>[]{LevelAccessor.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getMinY" -> HEIGHT.getMinY();
+                    case "getMaxY" -> HEIGHT.getMaxY();
+                    case "getHeight" -> HEIGHT.getHeight();
+                    case "getSectionsCount" -> HEIGHT.getSectionsCount();
+                    case "getSectionIndex" -> HEIGHT.getSectionIndex((int) args[0]);
+                    case "getChunk" -> chunk;
+                    case "getBlockState" -> chunk.getBlockState((BlockPos) args[0]);
+                    case "hasChunk" -> true;
+                    case "toString" -> "chunk-level";
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static PalettedContainerFactory containerFactory() {
+        Holder<Biome> biome = dummyBiome();
+        IdMapper<Holder<Biome>> biomeIds = new IdMapper<>();
+        biomeIds.add(biome);
+        return new PalettedContainerFactory(
+                Strategy.createForBlockStates(Block.BLOCK_STATE_REGISTRY),
+                Blocks.AIR.defaultBlockState(),
+                null,
+                Strategy.createForBiomes(biomeIds),
+                biome,
+                null);
+    }
+
+    private static Holder<Biome> dummyBiome() {
+        BiomeSpecialEffects effects = new BiomeSpecialEffects(
+                0,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                BiomeSpecialEffects.GrassColorModifier.NONE);
+        Biome biome = new Biome.BiomeBuilder()
+                .temperature(0.5f)
+                .downfall(0.5f)
+                .specialEffects(effects)
+                .mobSpawnSettings(MobSpawnSettings.EMPTY)
+                .generationSettings(BiomeGenerationSettings.EMPTY)
+                .build();
+        return Holder.direct(biome);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0.0f;
+        }
+        if (type == double.class) {
+            return 0.0d;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Part of #134 phase 4. Addresses the "conflates" half of #52 at its sharpest point: `ChunkDriver` kept **one field** for two jobs — the corrections worklist generation walks at the end of a chunk, and the write log `/urbex digest` publishes. Two defects fell out of that.

## The live one: a leak

`publishRecordedWrites` merged into the static `RECORDED_WRITES` unconditionally, and only `/urbex digest` ever clears that map. A server that never ran the command still retained **every position and `BlockState` of every chunk it had ever generated**, for the life of the process — and `mergeIntoRecordedWrites` is copy-on-merge, so it paid a full copy of the accumulated map per chunk to put them there.

Now the publish is gated on `recordingWrites`, which is what the method was always for.

## The latent one: the harness was load-bearing

`putRange` consulted `recordingWrites` before noting a position *at all*, and the corrections pass walks that same log. So which positions received connection properties and neighbour shape updates depended on whether a digest happened to be running.

`ChunkDriverCorrectionsTest` pins a concrete case — a wall placed through `setBlockRange` connects to its neighbour while being measured and does not otherwise:

```
aCursorWrittenWallConnectsToItsNeighbour              PASSED (before and after)
aBulkFilledWallConnectsTheSameWayTheCursorWrittenOne  FAILED before, PASSED after
recordingTheDigestDoesNotChangeWhatIsGenerated        FAILED before, PASSED after
```

## What the measurement said, which was not what I expected

**No world was ever wrong.** All six suites produce their existing goldens under *either* rule — correcting every written position, or only cursor-written ones. That is ~26M recorded block writes across five worlds with no difference.

Which means **the digests do not cover this class of defect**. A green six-suite run is not evidence about which positions the corrections pass visits; the unit tests above are. Recorded in the phase-4 spec and in the field's javadoc, because the next person to touch `correctionsPass` will otherwise reasonably assume the goldens have them covered.

The measurement also made the direction decidable. Correcting bulk fills costs **~6.5% of mean chunk time** and **no measurable wall clock** — the extra work parallelizes:

| | mean µs | ms | allocMiB |
| --- | --- | --- | --- |
| cursor-only corrections (scratch) | 3864.0 | 23981 | 9521 |
| this PR (every written position) | 4206.0 / 4117.4 | 23892 / 24074 | 9681 / 9960 |
| parent (#182), same machine state | 4173.4 / 4102.4 | 24230 / 24036 | 9864 / 9884 |

p99 (32768µs) and max unchanged throughout. Parent and this PR are noise-identical because the parent already did all of this work *whenever it was being measured* — the whole point of the defect.

I paid the 6.5% rather than taking the cheaper cursor-only rule, because the alternative is a driver where `setBlockRange(…, fence)` quietly produces an unconnected fence and nothing in the code says so. That is the trap this phase exists to remove, and it is a per-chunk latency cost with no throughput cost.

## Verification

Unit tests green. All six digest suites unchanged:

| Suite | Golden | Moved? |
| --- | --- | --- |
| `runDigestCheck` | `688914e862e938fb` | no |
| `runDigestCheckShuffled` | `688914e862e938fb` | no |
| `runDigestCheckFeatures` | `7b5348f28e0a6d23` | no |
| `runDigestCheckAvoid` | `b37050817cd94b93` | no |
| `runDigestCheckAvoidModes` | `53290e1a9849c43d` | no |
| `runDigestCheckRail` | `3fff027c14eea4a9` | no |

`unsafeReads=0` on every run.

## Not in this PR

The structural half of #52 — the driver still conflates the write buffer, the read-through world view, the cursor and the shape post-processor. Those are the next PRs in the stack.
