### PR TITLE
refactor: explosion damage moves out of CityGenerator (#11)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -323,8 +323,8 @@ public class CityGenerator {
         placeOptionalLights(ctx, info);
 
         if (info.getDamageArea().hasExplosions()) {
-            breakBlocksForDamageNew(ctx, chunkX, chunkZ, info);
-            fixAfterExplosion(ctx, info);
+            Damage.breakBlocks(ctx, this, chunkX, chunkZ, info);
+            Damage.fixFloatingBlocks(ctx, this, info);
         }
         generateDebris(ctx, info);
 
@@ -479,88 +479,6 @@ public class CityGenerator {
         if (scatteredSettings != null) {
             if (!Scattered.avoidScattered(this, info)) {
                 Scattered.generateScattered(ctx, this, info, scatteredSettings);
-            }
-        }
-    }
-
-    private void breakBlocksForDamageNew(ChunkGenContext ctx, int chunkX, int chunkZ, ChunkPlan info) {
-        ChunkDriver driver = ctx.driver;
-        int cx = chunkX << 4;
-        int cz = chunkZ << 4;
-
-        DamageArea damageArea = info.getDamageArea();
-
-        float damageFactor = 1.0f;
-
-        boolean hasCollectedDamage = false;
-        float[][] collectedDamage = new float[16][16];
-
-        int minSection = provider.shape().minSection();
-        int maxSection = provider.shape().maxSection();
-        for (int yy = minSection; yy <= maxSection; yy++) {
-            java.util.List<dev.krona.urbex.worldgen.lost.Explosion> sectionExplosions = damageArea.explosionsIntersecting(yy);
-            boolean hasExplosions = !sectionExplosions.isEmpty();
-            for (int y = 0; y < 16; y++) {
-                if (hasExplosions) {
-                    int cury = yy * 16 + y;
-                    for (int x = 0; x < 16; x++) {
-                        driver.current(x, cury, 0);
-                        for (int z = 0; z < 16; z++) {
-                            BlockState d = driver.getBlock();
-                            if (d != air || cury <= info.waterLevel) {
-                                float damage = DamageArea.getDamage(sectionExplosions, cx + x, cury, cz + z) * damageFactor;
-                                if (damage >= 0.001) {
-                                    collectedDamage[x][z] += damage;
-                                    hasCollectedDamage = true;
-                                }
-                            }
-                            driver.incZ();
-                        }
-                    }
-                }
-                if (hasCollectedDamage) {
-                    int cntDamaged = 0;
-                    int cntAir = 0;
-                    int cury = yy * 16 + y;
-                    hasCollectedDamage = false;
-                    for (int x = 0; x < 16; x++) {
-                        driver.current(x, cury, 0);
-                        for (int z = 0; z < 16; z++) {
-                            BlockState d = driver.getBlock();
-                            if (d != air || cury <= info.waterLevel) {
-                                float damage = collectedDamage[x][z];
-                                if (damage >= 0.001) {
-                                    BlockState newd = damageArea.damageBlock(d, provider, ctx.tags, cx + x, cury, cz + z, damage, info.getCompiledPalette(), liquid);
-                                    if (newd != d) {
-                                        driver.block(newd);
-                                        cntDamaged++;
-                                    }
-                                }
-                            } else {
-                                cntAir++;
-                            }
-                            driver.incZ();
-//                            collectedDamage[x][z] -= .75f;
-                            collectedDamage[x][z] /= 1.4f;
-//                            collectedDamage[x][z] = 0;
-                            if (collectedDamage[x][z] <= 0) {
-                                collectedDamage[x][z] = 0;
-                            } else {
-                                hasCollectedDamage = true;
-                            }
-                        }
-                    }
-
-                    int tot = cntDamaged + cntAir;
-                    if (tot > 250) {
-                        damageFactor = 200;
-                    } else if (tot > 220) {
-                        damageFactor = damageFactor * 1.4f;
-                    } else if (tot > 180) {
-                        damageFactor = damageFactor * 1.2f;
-                    }
-
-                }
             }
         }
     }
@@ -970,62 +888,6 @@ public class CityGenerator {
                 };
 
                 generatePart(ctx, info, stairs, transform, 0, oy, 0, HardAirSetting.AIR);
-            }
-        }
-    }
-
-    private int countNotEmpty(ChunkGenContext ctx, int y, int max) {
-        ChunkDriver driver = ctx.driver;
-        int cnt = 0;
-        for (int x = 0; x < 16; x++) {
-            for (int z = 0; z < 16; z++) {
-                if (driver.getBlock(x, y, z) != air) {
-                    cnt++;
-                    if (cnt >= max) {
-                        return cnt;
-                    }
-                }
-            }
-        }
-        return cnt;
-    }
-
-    /// Fix floating blocks after an explosion
-    private void fixAfterExplosion(ChunkGenContext ctx, ChunkPlan info) {
-        ChunkDriver driver = ctx.driver;
-        if (info.profile.isCavern() && !info.hasBuilding) {
-            // In a cavern we only do this correction when there is a building
-            return;
-        }
-
-        int start = info.getDamageArea().getLowestExplosionHeight();
-        if (start == -1) {
-            // Nothing is affected
-            return;
-        }
-        int end = info.getDamageArea().getHighestExplosionHeight();
-
-        for (int y = start; y <= end; y++) {
-            int count = countNotEmpty(ctx, y, 20);
-            if (count < 16) {   // @todo configurable?
-                // (Almost) empty! That means everything above this can be deleted
-                // Except in a cavern, there we only delete the building
-                if (info.profile.isCavern()) {
-                    // We know we have a building
-                    int maxY = info.getCityGroundLevel() + info.getNumFloors() * FLOORHEIGHT;
-                    for (int x = 0; x < 16; x++) {
-                        for (int z = 0; z < 16; z++) {
-                            driver.setBlockRangeToAir(x, y + 1, z, maxY);
-                        }
-                    }
-                } else {
-                    for (int x = 0; x < 16; x++) {
-                        for (int z = 0; z < 16; z++) {
-                            driver.setBlockRangeToAir(x, y + 1, z, provider.shape().maxBuildHeight());
-                        }
-                    }
-                }
-                break;
             }
         }
     }

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Damage.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Damage.java
@@ -1,0 +1,164 @@
+package dev.krona.urbex.worldgen.gen;
+
+import dev.krona.urbex.worldgen.ChunkGenContext;
+import dev.krona.urbex.worldgen.ChunkDriver;
+import dev.krona.urbex.worldgen.CityGenerator;
+import dev.krona.urbex.worldgen.lost.DamageArea;
+import dev.krona.urbex.worldgen.lost.ChunkPlan;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * What the explosions did, and the repair afterwards.
+ *
+ * <p>Two passes over the chunk, run back to back and in this order: {@link #breakBlocks} walks every
+ * section an explosion intersects and replaces what it damaged, and {@link #fixFloatingBlocks} then
+ * deletes whatever the first pass left hanging in the air with nothing under it.</p>
+ *
+ * <p>Moved out of {@link CityGenerator} unchanged - same code, same order, same RNG - as part of
+ * splitting that class up (issue #11). It reaches back through {@code feature} for the dimension's
+ * shape and its air and liquid states, which is the convention the rest of this package already
+ * uses.</p>
+ */
+public class Damage {
+
+    private Damage() {
+    }
+
+    public static void breakBlocks(ChunkGenContext ctx, CityGenerator feature, int chunkX, int chunkZ, ChunkPlan info) {
+        ChunkDriver driver = ctx.driver;
+        int cx = chunkX << 4;
+        int cz = chunkZ << 4;
+
+        DamageArea damageArea = info.getDamageArea();
+
+        float damageFactor = 1.0f;
+
+        boolean hasCollectedDamage = false;
+        float[][] collectedDamage = new float[16][16];
+
+        int minSection = feature.provider.shape().minSection();
+        int maxSection = feature.provider.shape().maxSection();
+        for (int yy = minSection; yy <= maxSection; yy++) {
+            java.util.List<dev.krona.urbex.worldgen.lost.Explosion> sectionExplosions = damageArea.explosionsIntersecting(yy);
+            boolean hasExplosions = !sectionExplosions.isEmpty();
+            for (int y = 0; y < 16; y++) {
+                if (hasExplosions) {
+                    int cury = yy * 16 + y;
+                    for (int x = 0; x < 16; x++) {
+                        driver.current(x, cury, 0);
+                        for (int z = 0; z < 16; z++) {
+                            BlockState d = driver.getBlock();
+                            if (d != feature.air || cury <= info.waterLevel) {
+                                float damage = DamageArea.getDamage(sectionExplosions, cx + x, cury, cz + z) * damageFactor;
+                                if (damage >= 0.001) {
+                                    collectedDamage[x][z] += damage;
+                                    hasCollectedDamage = true;
+                                }
+                            }
+                            driver.incZ();
+                        }
+                    }
+                }
+                if (hasCollectedDamage) {
+                    int cntDamaged = 0;
+                    int cntAir = 0;
+                    int cury = yy * 16 + y;
+                    hasCollectedDamage = false;
+                    for (int x = 0; x < 16; x++) {
+                        driver.current(x, cury, 0);
+                        for (int z = 0; z < 16; z++) {
+                            BlockState d = driver.getBlock();
+                            if (d != feature.air || cury <= info.waterLevel) {
+                                float damage = collectedDamage[x][z];
+                                if (damage >= 0.001) {
+                                    BlockState newd = damageArea.damageBlock(d, feature.provider, ctx.tags, cx + x, cury, cz + z, damage, info.getCompiledPalette(), feature.liquid);
+                                    if (newd != d) {
+                                        driver.block(newd);
+                                        cntDamaged++;
+                                    }
+                                }
+                            } else {
+                                cntAir++;
+                            }
+                            driver.incZ();
+//                            collectedDamage[x][z] -= .75f;
+                            collectedDamage[x][z] /= 1.4f;
+//                            collectedDamage[x][z] = 0;
+                            if (collectedDamage[x][z] <= 0) {
+                                collectedDamage[x][z] = 0;
+                            } else {
+                                hasCollectedDamage = true;
+                            }
+                        }
+                    }
+
+                    int tot = cntDamaged + cntAir;
+                    if (tot > 250) {
+                        damageFactor = 200;
+                    } else if (tot > 220) {
+                        damageFactor = damageFactor * 1.4f;
+                    } else if (tot > 180) {
+                        damageFactor = damageFactor * 1.2f;
+                    }
+
+                }
+            }
+        }
+    }
+
+    private static int countNotEmpty(ChunkGenContext ctx, CityGenerator feature, int y, int max) {
+        ChunkDriver driver = ctx.driver;
+        int cnt = 0;
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                if (driver.getBlock(x, y, z) != feature.air) {
+                    cnt++;
+                    if (cnt >= max) {
+                        return cnt;
+                    }
+                }
+            }
+        }
+        return cnt;
+    }
+
+    /// Fix floating blocks after an explosion
+    public static void fixFloatingBlocks(ChunkGenContext ctx, CityGenerator feature, ChunkPlan info) {
+        ChunkDriver driver = ctx.driver;
+        if (info.profile.isCavern() && !info.hasBuilding) {
+            // In a cavern we only do this correction when there is a building
+            return;
+        }
+
+        int start = info.getDamageArea().getLowestExplosionHeight();
+        if (start == -1) {
+            // Nothing is affected
+            return;
+        }
+        int end = info.getDamageArea().getHighestExplosionHeight();
+
+        for (int y = start; y <= end; y++) {
+            int count = countNotEmpty(ctx, feature, y, 20);
+            if (count < 16) {   // @todo configurable?
+                // (Almost) empty! That means everything above this can be deleted
+                // Except in a cavern, there we only delete the building
+                if (info.profile.isCavern()) {
+                    // We know we have a building
+                    int maxY = info.getCityGroundLevel() + info.getNumFloors() * CityGenerator.FLOORHEIGHT;
+                    for (int x = 0; x < 16; x++) {
+                        for (int z = 0; z < 16; z++) {
+                            driver.setBlockRangeToAir(x, y + 1, z, maxY);
+                        }
+                    }
+                } else {
+                    for (int x = 0; x < 16; x++) {
+                        for (int z = 0; z < 16; z++) {
+                            driver.setBlockRangeToAir(x, y + 1, z, feature.provider.shape().maxBuildHeight());
+                        }
+                    }
+                }
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #134 phase 4, starting #11. The first of `CityGenerator`'s responsibilities to leave.

`gen/Damage` holds the two passes that run back to back once a chunk's content is placed:

- **`breakBlocks`** — walks every section an explosion intersects, accumulates per-column damage and replaces what it damaged
- **`fixFloatingBlocks`** — deletes whatever that pass left hanging in the air with nothing under it

It follows the convention `worldgen/gen/` already uses (`Bridges`, `Highways`, `Railways`, `Stuff`, …): static entry points taking `(ChunkGenContext ctx, CityGenerator feature, ChunkPlan info, …)`, reaching back through `feature` for shared generator state.

## Pure code motion, verified rather than asserted

Execution order and RNG consumption are load-bearing here, so "I only moved it" needs to be checked, not claimed. A token-level comparison of each moved body against its original — normalising away the added `feature` parameter — is identical:

```
OK    breakBlocks        325 tokens
OK    countNotEmpty       58 tokens
OK    fixFloatingBlocks  185 tokens
```

Same code, same order, same draws.

## Why this cluster and not the one next to it

Damage was picked as the first cut because **it needs nothing the generator keeps private**: `provider`, `air`, `liquid` and `FLOORHEIGHT` are already public, so the move widens no API.

`generateRubble` and `generateRuins` sit immediately next to it in the source and look like they belong in the same class. They are deliberately left behind: they reach for `base`, `rubbleNoise`, `leavesNoise`, `randomLeafs`, `randomDirt` and `getRandomDirt`/`getRandomLeaf`, all private, and pulling them out here would mean making six fields public to move 110 lines. They belong with the vegetation cluster that owns those tables, and should move when it does.

Two renames came along: `breakBlocksForDamageNew` → `breakBlocks`, `fixAfterExplosion` → `fixFloatingBlocks`. The "New" was left over from whatever it replaced.

## Verification

`CityGenerator` 2425 → 2287 lines. Unit tests green. All six digest suites unchanged:

| Suite | Golden | Moved? |
| --- | --- | --- |
| `runDigestCheck` | `688914e862e938fb` | no |
| `runDigestCheckShuffled` | `688914e862e938fb` | no |
| `runDigestCheckFeatures` | `7b5348f28e0a6d23` | no |
| `runDigestCheckAvoid` | `b37050817cd94b93` | no |
| `runDigestCheckAvoidModes` | `53290e1a9849c43d` | no |
| `runDigestCheckRail` | `3fff027c14eea4a9` | no |
