### PR TITLE
refactor: the leaf and rubble tables move out of CityGenerator (#11)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -70,9 +70,9 @@ public class CityGenerator {
     private final NoiseGeneratorPerlin ruinNoise;
     private final NoiseGeneratorPerlin bottomLayerNoise;    // Used in floating profile for the underside of buildings
 
-    private final BlockState[] randomLeafs;
-    private final BlockState[] randomDirt;
-    private final Set<BlockState> randomDirtSet;
+
+    /** The random leaf and rubble tables, and the city-style characters that override them. */
+    public final GroundCover groundCover = new GroundCover();
 
     public final PlanningContext provider;
     public final Preset profile;
@@ -101,95 +101,9 @@ public class CityGenerator {
         addStates(Blocks.RAIL, railStates);
         addStates(Blocks.POWERED_RAIL, railStates);
 
-        randomLeafs = buildRandomLeafs();
-        randomDirt = buildRandomDirt();
-        randomDirtSet = Set.of(Blocks.MOSSY_STONE_BRICKS.defaultBlockState(),
-                Blocks.MOSSY_COBBLESTONE.defaultBlockState(),
-                Blocks.MOSS_BLOCK.defaultBlockState());
-
 //        islandTerrainGenerator.setup(provider.getWorld().getWorld(), provider);
 //        cavernTerrainGenerator.setup(provider.getWorld().getWorld(), provider);
 //        spaceTerrainGenerator.setup(provider.getWorld().getWorld(), provider);
-    }
-
-    private static BlockState[] buildRandomLeafs() {
-        BlockState leaves = Blocks.OAK_LEAVES.defaultBlockState().setValue(LeavesBlock.PERSISTENT, true);
-        BlockState leaves2 = Blocks.JUNGLE_LEAVES.defaultBlockState().setValue(LeavesBlock.PERSISTENT, true);
-        BlockState leaves3 = Blocks.SPRUCE_LEAVES.defaultBlockState().setValue(LeavesBlock.PERSISTENT, true);
-
-        BlockState[] result = new BlockState[128];
-        int i = 0;
-        while (i < 20) {
-            result[i] = leaves2;
-            i++;
-        }
-        while (i < 40) {
-            result[i] = leaves3;
-            i++;
-        }
-        while (i < result.length) {
-            result[i] = leaves;
-            i++;
-        }
-        return result;
-    }
-
-    private static BlockState[] buildRandomDirt() {
-        BlockState mBricks = Blocks.MOSSY_STONE_BRICKS.defaultBlockState();
-        BlockState mCobble = Blocks.MOSSY_COBBLESTONE.defaultBlockState();
-        BlockState moss = Blocks.MOSS_BLOCK.defaultBlockState();
-
-        BlockState[] result = new BlockState[128];
-        int i = 0;
-        while (i < 20) {
-            result[i] = mBricks;
-            i++;
-        }
-        while (i < 60) {
-            result[i] = mCobble;
-            i++;
-        }
-        while (i < result.length) {
-            result[i] = moss;
-            i++;
-        }
-        return result;
-    }
-
-    /**
-     * One leaf state for the block the driver is about to write. Addressed by that position, so
-     * how many leaves this chunk placed first cannot change which one this is.
-     */
-    private BlockState getRandomLeaf(ChunkGenContext ctx, ChunkPlan info, CompiledPalette compiledPalette) {
-        Character leavesBlock = info.getCityStyle().getLeavesBlock();
-        if (leavesBlock != null) {
-            return ctx.paletteHere(compiledPalette, leavesBlock);
-        }
-        return randomLeafs[Rng.indexAtPos(ctx.seed, ctx.driver.getX(), ctx.driver.getY(), ctx.driver.getZ(),
-                Rng.Purpose.LEAVES, randomLeafs.length)];
-    }
-
-    private Set<BlockState> getPossibleRandomDirts(ChunkGenContext ctx, ChunkPlan info, CompiledPalette compiledPalette) {
-        Character rubbleDirtBlock = info.getCityStyle().getRubbleDirtBlock();
-        if (rubbleDirtBlock != null) {
-            return compiledPalette.getAll(rubbleDirtBlock);
-        } else {
-            return randomDirtSet;
-        }
-    }
-
-    /**
-     * One rubble state for the block the driver is about to write. Addressed by that position, for
-     * the same reason as {@link #getRandomLeaf}. Nothing is regenerated here: {@code randomDirt} is
-     * a final array built once in the constructor and never empty.
-     */
-    private BlockState getRandomDirt(ChunkGenContext ctx, ChunkPlan info, CompiledPalette compiledPalette) {
-        Character rubbleDirtBlock = info.getCityStyle().getRubbleDirtBlock();
-        if (rubbleDirtBlock != null) {
-            return ctx.paletteHere(compiledPalette, rubbleDirtBlock);
-        }
-        return randomDirt[Rng.indexAtPos(ctx.seed, ctx.driver.getX(), ctx.driver.getY(), ctx.driver.getZ(),
-                Rng.Purpose.RUBBLE, randomDirt.length)];
     }
 
     public Set<BlockState> getRailStates() {
@@ -899,7 +813,7 @@ public class CityGenerator {
         double[] rubbleBuffer = ctx.buffers.rubble = this.rubbleNoise.getRegion(ctx.buffers.rubble, (chunkX << 4), (chunkZ << 4), 16, 16, 1.0 / 16.0, 1.0 / 16.0, 1.0D);
         double[] leavesBuffer = ctx.buffers.leaves = this.leavesNoise.getRegion(ctx.buffers.leaves, (chunkX << 6), (chunkZ << 6), 16, 16, 1.0 / 64.0, 1.0 / 64.0, 4.0D);
 
-        Set<BlockState> possibleRandomDirts = getPossibleRandomDirts(ctx, info, info.getCompiledPalette());
+        Set<BlockState> possibleRandomDirts = groundCover.possibleRubble(info, info.getCompiledPalette());
         for (int x = 0; x < 16; ++x) {
             for (int z = 0; z < 16; ++z) {
                 double vr = info.profile.rubbleDirtScale() < 0.01f ? 0 : rubbleBuffer[x + z * 16] / info.profile.rubbleDirtScale();
@@ -911,7 +825,7 @@ public class CityGenerator {
                     if (c != air && c != liquid) {
                         for (int i = 0; i < vr; i++) {
                             if (isEmpty(driver.getBlock())) {
-                                driver.add(getRandomDirt(ctx, info, info.getCompiledPalette()));
+                                driver.add(groundCover.rubbleAt(ctx, info, info.getCompiledPalette()));
                             } else {
                                 driver.incY();
                             }
@@ -922,7 +836,7 @@ public class CityGenerator {
                     if (leafBaseState == base || possibleRandomDirts.contains(leafBaseState)) {
                         for (int i = 0; i < vl; i++) {
                             if (isEmpty(driver.getBlock())) {
-                                driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
+                                driver.add(groundCover.leafAt(ctx, info, info.getCompiledPalette()));
                             } else {
                                 driver.incY();
                             }
@@ -1043,7 +957,7 @@ public class CityGenerator {
                                 height++;   // Make sure we keep on filling with air a bit longer because we are lowering here
                                 c = driver.getBlockDown();
                             }
-                            driver.add(getRandomLeaf(ctx, info, palette));
+                            driver.add(groundCover.leafAt(ctx, info, palette));
                             vl--;
                         } else {
                             driver.add(air);
@@ -1290,7 +1204,7 @@ public class CityGenerator {
                     float v = Math.min(.8f, info.profile.randomLeafBlockChance() * (info.profile.randomLeafBlockThickness() + 1 - x));
                     int cnt = 0;
                     while (rollHere(ctx, driver, Rng.Purpose.VEGETATION) < v && cnt < 30) {
-                        driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
+                        driver.add(groundCover.leafAt(ctx, info, info.getCompiledPalette()));
                         cnt++;
                     }
                 }
@@ -1308,7 +1222,7 @@ public class CityGenerator {
                     float v = Math.min(.8f, info.profile.randomLeafBlockChance() * (x - 14 + info.profile.randomLeafBlockThickness()));
                     int cnt = 0;
                     while (rollHere(ctx, driver, Rng.Purpose.VEGETATION_XMAX) < v && cnt < 30) {
-                        driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
+                        driver.add(groundCover.leafAt(ctx, info, info.getCompiledPalette()));
                         cnt++;
                     }
                 }
@@ -1326,7 +1240,7 @@ public class CityGenerator {
                     float v = Math.min(.8f, info.profile.randomLeafBlockChance() * (info.profile.randomLeafBlockThickness() + 1 - z));
                     int cnt = 0;
                     while (rollHere(ctx, driver, Rng.Purpose.VEGETATION_ZMIN) < v && cnt < 30) {
-                        driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
+                        driver.add(groundCover.leafAt(ctx, info, info.getCompiledPalette()));
                         cnt++;
                     }
                 }
@@ -1344,7 +1258,7 @@ public class CityGenerator {
                     float v = info.profile.randomLeafBlockChance() * (z - 14 + info.profile.randomLeafBlockThickness());
                     int cnt = 0;
                     while (rollHere(ctx, driver, Rng.Purpose.VEGETATION_ZMAX) < v && cnt < 30) {
-                        driver.add(getRandomLeaf(ctx, info, info.getCompiledPalette()));
+                        driver.add(groundCover.leafAt(ctx, info, info.getCompiledPalette()));
                         cnt++;
                     }
                 }

--- a/src/main/java/dev/krona/urbex/worldgen/gen/GroundCover.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/GroundCover.java
@@ -1,0 +1,115 @@
+package dev.krona.urbex.worldgen.gen;
+
+import dev.krona.urbex.varia.Rng;
+import dev.krona.urbex.worldgen.ChunkGenContext;
+import dev.krona.urbex.worldgen.lost.ChunkPlan;
+import dev.krona.urbex.worldgen.lost.cityassets.CompiledPalette;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.Set;
+
+/**
+ * What grows on, and falls onto, the ground: leaves and rubble.
+ *
+ * <p>Two weighted tables and the rule for using them. A city style may name a single character for
+ * either, in which case that palette entry wins and the table is not consulted at all; otherwise the
+ * block is drawn from the table, <em>addressed by the position being written</em> - so how many
+ * leaves this chunk has already placed cannot change which one comes next.</p>
+ *
+ * <p>The tables are constants in every sense that matters - three leaf states and three mossy
+ * states, in fixed proportions, depending on nothing outside this file. They are still built per
+ * instance rather than statically because {@code Blocks} is only legal to touch after the game has
+ * bootstrapped, and an instance built by {@link dev.krona.urbex.worldgen.CityGenerator}'s
+ * constructor is built at a moment where that is guaranteed (issue #11).</p>
+ */
+public final class GroundCover {
+
+    private final BlockState[] leaves = buildLeaves();
+    private final BlockState[] rubble = buildRubble();
+    private final Set<BlockState> defaultRubble = Set.of(
+            Blocks.MOSSY_STONE_BRICKS.defaultBlockState(),
+            Blocks.MOSSY_COBBLESTONE.defaultBlockState(),
+            Blocks.MOSS_BLOCK.defaultBlockState());
+
+    /**
+     * One leaf state for the block the driver is about to write. Addressed by that position, so
+     * how many leaves this chunk placed first cannot change which one this is.
+     */
+    public BlockState leafAt(ChunkGenContext ctx, ChunkPlan info, CompiledPalette compiledPalette) {
+        Character leavesBlock = info.getCityStyle().getLeavesBlock();
+        if (leavesBlock != null) {
+            return ctx.paletteHere(compiledPalette, leavesBlock);
+        }
+        return leaves[Rng.indexAtPos(ctx.seed, ctx.driver.getX(), ctx.driver.getY(), ctx.driver.getZ(),
+                Rng.Purpose.LEAVES, leaves.length)];
+    }
+
+    public Set<BlockState> possibleRubble(ChunkPlan info, CompiledPalette compiledPalette) {
+        Character rubbleDirtBlock = info.getCityStyle().getRubbleDirtBlock();
+        if (rubbleDirtBlock != null) {
+            return compiledPalette.getAll(rubbleDirtBlock);
+        } else {
+            return defaultRubble;
+        }
+    }
+
+    /**
+     * One rubble state for the block the driver is about to write. Addressed by that position, for
+     * the same reason as {@link #leafAt}. Nothing is regenerated here: {@code rubble} is
+     * a final array built once in the constructor and never empty.
+     */
+    public BlockState rubbleAt(ChunkGenContext ctx, ChunkPlan info, CompiledPalette compiledPalette) {
+        Character rubbleDirtBlock = info.getCityStyle().getRubbleDirtBlock();
+        if (rubbleDirtBlock != null) {
+            return ctx.paletteHere(compiledPalette, rubbleDirtBlock);
+        }
+        return rubble[Rng.indexAtPos(ctx.seed, ctx.driver.getX(), ctx.driver.getY(), ctx.driver.getZ(),
+                Rng.Purpose.RUBBLE, rubble.length)];
+    }
+
+    private static BlockState[] buildLeaves() {
+        BlockState leaves = Blocks.OAK_LEAVES.defaultBlockState().setValue(LeavesBlock.PERSISTENT, true);
+        BlockState leaves2 = Blocks.JUNGLE_LEAVES.defaultBlockState().setValue(LeavesBlock.PERSISTENT, true);
+        BlockState leaves3 = Blocks.SPRUCE_LEAVES.defaultBlockState().setValue(LeavesBlock.PERSISTENT, true);
+
+        BlockState[] result = new BlockState[128];
+        int i = 0;
+        while (i < 20) {
+            result[i] = leaves2;
+            i++;
+        }
+        while (i < 40) {
+            result[i] = leaves3;
+            i++;
+        }
+        while (i < result.length) {
+            result[i] = leaves;
+            i++;
+        }
+        return result;
+    }
+
+    private static BlockState[] buildRubble() {
+        BlockState mBricks = Blocks.MOSSY_STONE_BRICKS.defaultBlockState();
+        BlockState mCobble = Blocks.MOSSY_COBBLESTONE.defaultBlockState();
+        BlockState moss = Blocks.MOSS_BLOCK.defaultBlockState();
+
+        BlockState[] result = new BlockState[128];
+        int i = 0;
+        while (i < 20) {
+            result[i] = mBricks;
+            i++;
+        }
+        while (i < 60) {
+            result[i] = mCobble;
+            i++;
+        }
+        while (i < result.length) {
+            result[i] = moss;
+            i++;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Part of #134 phase 4, continuing #11.

`gen/GroundCover` holds the two weighted tables and the rule for using them:

> A city style may name a single palette character for leaves or for rubble, in which case that entry wins and the table is not consulted at all. Otherwise the block is drawn from the table, **addressed by the position being written** — so how many leaves a chunk has already placed cannot change which one comes next.

This is precisely the state that kept `generateRubble` behind when explosion damage moved out in #186: three private fields (`randomLeafs`, `randomDirt`, `randomDirtSet`) and three private methods that only these passes used. `CityGenerator` now holds one public collaborator instead of six private members.

## Why per-instance and not static constants

The tables are constants in every sense that matters — three leaf states and three mossy states in fixed proportions, depending on nothing outside the file. They are still built per instance, for two reasons:

1. `Blocks.*` is only legal to touch once the game has bootstrapped. Construction from `CityGenerator`'s constructor is a moment where that is guaranteed; a static initialiser fires whenever the class is first touched, which is a worse contract to depend on.
2. Phase 3 spent a PR removing latched static maps from `City`. Adding new static state here would walk that back.

## Pure code motion

Verified token-for-token against the originals, modulo the renames: **117 tokens** of table building, **161 tokens** of lookup, identical.

One real signature change: `possibleRubble` drops the `ChunkGenContext` parameter, which the method never read.

Renames: `getRandomLeaf` → `leafAt`, `getRandomDirt` → `rubbleAt`, `getPossibleRandomDirts` → `possibleRubble`, `buildRandomLeafs`/`buildRandomDirt` → `buildLeaves`/`buildRubble`.

## Verification

`CityGenerator` 2287 → 2201 lines (2425 at the start of this stack). Unit tests green. All six digest suites unchanged:

| Suite | Golden | Moved? |
| --- | --- | --- |
| `runDigestCheck` | `688914e862e938fb` | no |
| `runDigestCheckShuffled` | `688914e862e938fb` | no |
| `runDigestCheckFeatures` | `7b5348f28e0a6d23` | no |
| `runDigestCheckAvoid` | `b37050817cd94b93` | no |
| `runDigestCheckAvoidModes` | `53290e1a9849c43d` | no |
| `runDigestCheckRail` | `3fff027c14eea4a9` | no |

## What this unblocks

`generateRubble`, `generateRandomVegetation` and `generateParkSection` can now move without widening anything — they were the only remaining users of these tables. `generateRuins` still needs `ruinNoise` and `base`.
