### PR TITLE
refactor: the cursor becomes its own type (#52)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/BlockCursor.java
+++ b/src/main/java/dev/krona/urbex/worldgen/BlockCursor.java
@@ -1,0 +1,116 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * A position in the chunk being generated, and the writes made at it.
+ *
+ * <p>Most of this mod's block placement is a vertical run - put a block, step up, put another - and
+ * the cursor is what that idiom is written against: {@code at(x, y, z)} then {@code add(state)} as
+ * many times as there are blocks. Roughly 150 call sites across the generator and the {@code gen}
+ * package use it, and it is a genuinely good fit for what they express.</p>
+ *
+ * <p>What it should not be is a field on {@link ChunkDriver}. The driver is a read-through view of
+ * one chunk; the cursor is a walk over it. They were the same object, so any method could move the
+ * position under any other method's feet, and "which block does this write" was a question about the
+ * driver's history rather than about the call (issue #52).</p>
+ *
+ * <p>Positions are chunk-local on the way in and absolute from there on: {@link #at} adds the chunk
+ * origin once, so nothing downstream has to remember which convention it is holding.</p>
+ *
+ * <p>Thread-confined, like everything else on the generation path: one cursor per driver, per chunk,
+ * per thread.</p>
+ */
+final class BlockCursor {
+
+    /** The chunk this cursor walks, addressed absolutely. */
+    interface Blocks {
+        void set(int x, int y, int z, BlockState state);
+
+        BlockState get(int x, int y, int z);
+    }
+
+    private final Blocks blocks;
+    private final int originX;
+    private final int originZ;
+    private final BlockPos.MutableBlockPos current = new BlockPos.MutableBlockPos();
+
+    BlockCursor(Blocks blocks, int originX, int originZ) {
+        this.blocks = blocks;
+        this.originX = originX;
+        this.originZ = originZ;
+    }
+
+    /** Moves to a chunk-local position. */
+    void at(int x, int y, int z) {
+        current.set(x + originX, y, z + originZ);
+    }
+
+    /** Moves to an absolute position. */
+    void atAbsolute(BlockPos pos) {
+        current.set(pos);
+    }
+
+    int x() {
+        return current.getX();
+    }
+
+    int y() {
+        return current.getY();
+    }
+
+    int z() {
+        return current.getZ();
+    }
+
+    /**
+     * The position itself.
+     *
+     * <p>Mutable, and shared: it is this cursor's own field, so a caller that keeps it sees the
+     * cursor move. Every caller either reads it immediately or copies it - {@link #copy} is the one
+     * to reach for otherwise.
+     */
+    BlockPos.MutableBlockPos position() {
+        return current;
+    }
+
+    BlockPos copy() {
+        return current.immutable();
+    }
+
+    void up() {
+        current.setY(current.getY() + 1);
+    }
+
+    void down() {
+        current.setY(current.getY() - 1);
+    }
+
+    void east() {
+        current.setX(current.getX() + 1);
+    }
+
+    void south() {
+        current.setZ(current.getZ() + 1);
+    }
+
+    /** Writes at the current position and stays there. */
+    void write(BlockState state) {
+        blocks.set(current.getX(), current.getY(), current.getZ(), state);
+    }
+
+    /** Writes at the current position and steps up, for building a column. */
+    void writeAndRise(BlockState state) {
+        write(state);
+        up();
+    }
+
+    BlockState read() {
+        return blocks.get(current.getX(), current.getY(), current.getZ());
+    }
+
+    BlockState readBelow() {
+        return blocks.get(current.getX(), current.getY() - 1, current.getZ());
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -203,8 +203,9 @@ public class ChunkDriver {
     private LevelAccessor region;
     private long seed;
     private ChunkAccess primer;
-    private final BlockPos.MutableBlockPos current = new BlockPos.MutableBlockPos();
     private final BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
+    /** Where the caller is walking; see {@link BlockCursor}. */
+    private BlockCursor cursor;
     /** Where writes accumulate until {@link #flushToChunk}. */
     private ChunkBuffer buffer;
     /** Resolves connections once the chunk is finished; see {@link #correctionsPass}. */
@@ -223,6 +224,7 @@ public class ChunkDriver {
             this.cx = primer.getPos().x();
             this.cz = primer.getPos().z();
             shaper = new BlockShaper(chunkView, region, seed);
+            cursor = new BlockCursor(blockAccess, primer.getPos().x() << 4, primer.getPos().z() << 4);
         }
     }
 
@@ -325,6 +327,24 @@ public class ChunkDriver {
         }
     };
 
+    /** What a {@link BlockCursor} does to this chunk: explicit positions, absolute. */
+    private final BlockCursor.Blocks blockAccess = new BlockCursor.Blocks() {
+        @Override
+        public void set(int x, int y, int z, BlockState state) {
+            setBlock(x, y, z, state);
+        }
+
+        @Override
+        public BlockState get(int x, int y, int z) {
+            return getBlock(pos.set(x, y, z));
+        }
+    };
+
+    /** Writes one block, by position rather than by where the cursor happens to be (issue #52). */
+    public void setBlock(int x, int y, int z, BlockState state) {
+        buffer.set(x, y, z, state);
+    }
+
     private void setBlock(BlockPos p, BlockState state) {
         buffer.set(p.getX(), p.getY(), p.getZ(), state);
     }
@@ -369,55 +389,59 @@ public class ChunkDriver {
         return primer;
     }
 
+    // -----------------------------------------------------------------------------------------
+    // The cursor. State and behaviour live in BlockCursor; these delegate, and keep the shape every
+    // caller already writes against (issue #52).
+    // -----------------------------------------------------------------------------------------
+
     public ChunkDriver current(int x, int y, int z) {
-        current.set(x + (primer.getPos().x() << 4), y, z + (primer.getPos().z() << 4));
+        cursor.at(x, y, z);
         return this;
     }
 
     public ChunkDriver currentAbsolute(BlockPos pos) {
-        current.set(pos);
+        cursor.atAbsolute(pos);
         return this;
     }
 
     public ChunkDriver currentRelative(BlockPos pos) {
-        current(pos.getX(), pos.getY(), pos.getZ());
-        return this;
+        return current(pos.getX(), pos.getY(), pos.getZ());
     }
 
     public BlockPos getCurrentCopy() {
-        return current.immutable();
+        return cursor.copy();
     }
 
     public BlockPos.MutableBlockPos getCurrent() {
-        return current;
+        return cursor.position();
     }
 
     public void incY() {
-        current.setY(current.getY()+1);
+        cursor.up();
     }
 
     public void decY() {
-        current.setY(current.getY()-1);
+        cursor.down();
     }
 
     public void incX() {
-        current.setX(current.getX()+1);
+        cursor.east();
     }
 
     public void incZ() {
-        current.setZ(current.getZ()+1);
+        cursor.south();
     }
 
     public int getX() {
-        return current.getX();
+        return cursor.x();
     }
 
     public int getY() {
-        return current.getY();
+        return cursor.y();
     }
 
     public int getZ() {
-        return current.getZ();
+        return cursor.z();
     }
 
     public void setBlockRange(int x, int y, int z, int y2, BlockState state) {
@@ -460,22 +484,21 @@ public class ChunkDriver {
 //    }
 
     public ChunkDriver block(BlockState c) {
-        setBlock(current, c);
+        cursor.write(c);
         return this;
     }
 
     public ChunkDriver add(BlockState state) {
-        setBlock(current, state);
-        incY();
+        cursor.writeAndRise(state);
         return this;
     }
 
     public BlockState getBlock() {
-        return getBlock(current);
+        return cursor.read();
     }
 
     public BlockState getBlockDown() {
-        return getBlock(pos.set(current.getX(), current.getY()-1, current.getZ()));
+        return cursor.readBelow();
     }
 
 

--- a/src/test/java/dev/krona/urbex/worldgen/BlockCursorTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/BlockCursorTest.java
@@ -1,0 +1,127 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+/**
+ * Where the cursor is, and what it writes there.
+ *
+ * <p>These were unobservable while the position was a field on {@link ChunkDriver}: asking what a
+ * vertical run had placed meant generating a chunk and reading the world back (issue #52).</p>
+ */
+class BlockCursorTest {
+
+    private final Map<BlockPos, BlockState> written = new HashMap<>();
+    private final List<String> order = new ArrayList<>();
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    /** A cursor over the chunk at (2, -3), so the origin offset is not zero and cannot hide. */
+    private BlockCursor cursor() {
+        return new BlockCursor(new BlockCursor.Blocks() {
+            @Override
+            public void set(int x, int y, int z, BlockState state) {
+                written.put(new BlockPos(x, y, z), state);
+                order.add(x + "," + y + "," + z);
+            }
+
+            @Override
+            public BlockState get(int x, int y, int z) {
+                return written.getOrDefault(new BlockPos(x, y, z), Blocks.AIR.defaultBlockState());
+            }
+        }, 2 << 4, -3 << 4);
+    }
+
+    @Test
+    void aChunkLocalPositionIsOffsetByTheChunkOriginExactlyOnce() {
+        BlockCursor cursor = cursor();
+
+        cursor.at(5, 64, 9);
+
+        assertEquals(2 * 16 + 5, cursor.x());
+        assertEquals(64, cursor.y());
+        assertEquals(-3 * 16 + 9, cursor.z());
+    }
+
+    @Test
+    void anAbsolutePositionIsNotOffsetAtAll() {
+        BlockCursor cursor = cursor();
+
+        cursor.atAbsolute(new BlockPos(100, 70, -200));
+
+        assertEquals(100, cursor.x());
+        assertEquals(-200, cursor.z());
+    }
+
+    /** The vertical-run idiom the whole cursor exists for. */
+    @Test
+    void writingAndRisingBuildsAColumnUpwards() {
+        BlockCursor cursor = cursor();
+
+        cursor.at(0, 64, 0);
+        cursor.writeAndRise(Blocks.STONE.defaultBlockState());
+        cursor.writeAndRise(Blocks.DIRT.defaultBlockState());
+        cursor.writeAndRise(Blocks.GRASS_BLOCK.defaultBlockState());
+
+        assertIterableEquals(List.of("32,64,-48", "32,65,-48", "32,66,-48"), order);
+        assertEquals(67, cursor.y(), "and the cursor is left above what it placed");
+    }
+
+    @Test
+    void writingWithoutRisingStaysPut() {
+        BlockCursor cursor = cursor();
+
+        cursor.at(0, 64, 0);
+        cursor.write(Blocks.STONE.defaultBlockState());
+        cursor.write(Blocks.DIRT.defaultBlockState());
+
+        assertIterableEquals(List.of("32,64,-48", "32,64,-48"), order);
+        assertEquals(Blocks.DIRT.defaultBlockState(), cursor.read(), "the last write wins");
+    }
+
+    @Test
+    void readBelowLooksOneBlockDownWithoutMoving() {
+        BlockCursor cursor = cursor();
+        cursor.at(0, 64, 0);
+        cursor.write(Blocks.STONE.defaultBlockState());
+        cursor.up();
+
+        assertEquals(Blocks.STONE.defaultBlockState(), cursor.readBelow());
+        assertEquals(65, cursor.y());
+    }
+
+    /**
+     * The position is this cursor's own mutable field, so anything that keeps it sees the cursor
+     * move. That is why {@code copy} exists, and the distinction is worth a test because the two
+     * read identically at the call site.
+     */
+    @Test
+    void aCopyIsDetachedAndThePositionIsNot() {
+        BlockCursor cursor = cursor();
+        cursor.at(0, 64, 0);
+        BlockPos copied = cursor.copy();
+        BlockPos live = cursor.position();
+
+        cursor.up();
+
+        assertEquals(64, copied.getY());
+        assertEquals(65, live.getY());
+    }
+}


### PR DESCRIPTION
Closes #52. Phase 4 of #134; last of the three remaining tickets.

The issue's title lists four conflated jobs. Three came out earlier in this milestone (#181, #184, #185); this is the fourth.

## The cursor

Its position was a `MutableBlockPos` field on `ChunkDriver`. Any method could move it under any other method's feet, and "which block does this write" was a question about the driver's history rather than about the call.

`BlockCursor` owns the position and the walk over it — `at` / `atAbsolute`, `up` / `down` / `east` / `south`, `write`, `writeAndRise`, `read`, `readBelow`. It addresses the chunk through a two-method `Blocks` interface the driver supplies, so it knows nothing about buffers, shape correction or the write log. Chunk-local coordinates are offset by the chunk origin exactly once, on the way in.

## The call sites deliberately do not move

The driver's public cursor methods delegate and keep their names, so nothing outside changes.

`driver.current(x, y, z).add(a).add(b)` is a vertical run. That is what roughly 150 sites across `CityGenerator` and `worldgen/gen/` express, and it expresses it well. Rewriting them as explicit positions would make every caller track its own `y`, for no behavioural gain and a real chance of an off-by-one — and this milestone has already caught **five** blind-replacement corruptions in mechanical rewrites of exactly this shape.

The issue asks for a driver with explicit positions, and it now has one: `setBlock(x, y, z, state)` alongside `setBlockRange`/`setBlockRangeToAir`. New code has the option without the churn.

## Tests

`BlockCursorTest` covers six behaviours that previously needed a generated chunk and a world read-back to observe:

- a chunk-local position is offset by the chunk origin **exactly once** (tested over chunk (2, −3), so a doubled or missing offset cannot hide)
- an absolute position is not offset at all
- `writeAndRise` builds a column and leaves the cursor above what it placed
- `write` stays put and the last write wins
- `readBelow` looks down without moving
- `copy()` detaches and `position()` does not — the two read identically at a call site, which is why it is worth pinning

## Where #52 ends up

| Job the issue names | Now |
| --- | --- |
| Write-behind section cache | `ChunkBuffer` (#184) |
| Blockstate post-processor | `BlockShaper` (#185) |
| Stateful cursor | `BlockCursor` (this PR) |
| Read-through world view | `ChunkDriver` itself, 512 lines from 789 |

Plus the two defects the separation surfaced along the way (#181, #183): a read marking a whole section dirty, and the digest recorder deciding both what got corrected and what a live server retained forever.

## Verification

Unit tests green. All seven digest suites unchanged:

| Suite | Golden | Moved? |
| --- | --- | --- |
| `runDigestCheck` | `688914e862e938fb` | no |
| `runDigestCheckShuffled` | `688914e862e938fb` | no |
| `runDigestCheckFeatures` | `7b5348f28e0a6d23` | no |
| `runDigestCheckAvoid` | `b37050817cd94b93` | no |
| `runDigestCheckAvoidModes` | `53290e1a9849c43d` | no |
| `runDigestCheckRail` | `3fff027c14eea4a9` | no |
| `runDigestCheckAvoidExpire` | `b37050817cd94b93` | no |
