### PR TITLE
refactor: split ChunkPlan into six collaborators (#11)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/ErrorLogger.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ErrorLogger.java
@@ -3,6 +3,7 @@ package dev.krona.urbex.worldgen;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.lost.ChunkPlan;
+import dev.krona.urbex.worldgen.lost.CityField;
 import dev.krona.urbex.worldgen.lost.ChunkCandidate;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -51,7 +52,7 @@ public class ErrorLogger {
         Logger logger = Urbex.getLogger();
         try {
             ChunkCoord coord = new ChunkCoord(provider.dimension(), chunkX, chunkZ);
-            logger.info("IsCity: " + ChunkPlan.isCityRaw(coord, provider, provider.preset()));
+            logger.info("IsCity: " + CityField.isCityRaw(coord, provider, provider.preset()));
             ChunkCandidate candidate = ChunkPlan.getChunkCandidate(coord, provider);
             logger.info("    Level: " + candidate.cityLevel());
             if (candidate.multiBuilding() != null) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/BridgeDecisions.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/BridgeDecisions.java
@@ -1,0 +1,244 @@
+package dev.krona.urbex.worldgen.lost;
+
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.gen.Terrain;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.tags.BiomeTags;
+import dev.krona.urbex.worldgen.PlanningContext;
+import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
+
+/**
+ * Whether a bridge crosses this chunk, and which deck part it uses.
+ *
+ * <p>Two kinds of answer, and the order between them matters: a span the primary bridge planner laid
+ * down settles the chunk for both orientations, and only when there is none does the opportunistic
+ * scan run - letting an ordinary bridge claim the chunk first would cancel the planned one.</p>
+ *
+ * <h2>The memoisation, and why there is no lock</h2>
+ *
+ * <p>A {@link ChunkPlan} lives in the dimension's cache and is read by every chunk that neighbours
+ * it, so these fields are filled in from whichever thread got here first while other threads are
+ * reading. They are all volatile, and every {@code …Calculated} flag is written <em>after</em> the
+ * value it guards, so a reader that sees the flag set is guaranteed to see the value. Two threads
+ * racing on the same field both compute and both write; the result is the same either way, because
+ * it is derived from the already-fixed plan graph.</p>
+ *
+ * <p>That is the racy-single-check idiom, not double-checked locking, and the absence of a lock is
+ * deliberate: the scan below walks into its neighbours and reads their decisions, so any
+ * per-instance lock would be a lock-ordering deadlock waiting to happen. Splitting this out of
+ * {@link ChunkPlan} (issue #11) moved the state and the walk together for exactly that reason -
+ * they are one thing, and separating them would leave the rationale attached to neither.</p>
+ */
+final class BridgeDecisions {
+
+    private final ChunkPlan plan;
+
+    private volatile boolean xCalculated = false;
+    private volatile boolean zCalculated = false;
+    private volatile BuildingPart xType = null;
+    private volatile BuildingPart zType = null;
+
+    private volatile boolean plannedCalculated = false;
+    private volatile PrimaryBridgePlanner.BridgeSpan plannedSpan;
+
+    private volatile Boolean ocean = null;
+
+    BridgeDecisions(ChunkPlan plan) {
+        this.plan = plan;
+    }
+
+    PrimaryBridgePlanner.BridgeSpan planned() {
+        if (plannedCalculated) {
+            return plannedSpan;
+        }
+        PrimaryBridgePlanner.BridgeSpan result = PrimaryBridgePlanner.spanAt(plan.coord, plan.provider).orElse(null);
+        // Value first, then the flag.
+        plannedSpan = result;
+        plannedCalculated = true;
+        return result;
+    }
+
+    BuildingPart at(PlanningContext provider, Orientation orientation) {
+        return switch (orientation) {
+            case X -> x(plan.provider);
+            case Z -> z(plan.provider);
+        };
+    }
+
+    boolean any(PlanningContext provider) {
+        if (x(plan.provider) != null) {
+            return true;
+        }
+        if (z(plan.provider) != null) {
+            return true;
+        }
+        return false;
+    }
+
+    // To prevent adjacent bridges of the same direction we give the bridges at even chunk Z coordinates higher priority
+    BuildingPart x(PlanningContext provider) {
+        if (xCalculated) {
+            return xType;
+        }
+        BuildingPart result = computeX(plan.provider);
+        // Value first, then the flag. The old code set the flag up front and filled the value in
+        // afterwards, which is fine under a lock and a lie without one.
+        xType = result;
+        xCalculated = true;
+        return result;
+    }
+
+    private BuildingPart computeX(PlanningContext provider) {
+        PrimaryBridgePlanner.BridgeSpan planned = planned();
+        if (planned != null) {
+            // A planned span settles this chunk for both orientations. Falling through to the
+            // opportunistic scan below when the span runs the other way would let an ordinary bridge
+            // claim the chunk first and cancel the planned one.
+            return planned.orientation() == Orientation.X
+                    ? PrimaryBridgePlanner.deckPart(planned, plan.coord, plan.provider) : null;
+        }
+        if (!plan.xBridge) {
+            return null;
+        }
+        if (!isSuitableForBridge(plan.provider, plan)) {
+            return null;
+        }
+        if (plan.coord.chunkZ() % 2 != 0 && (plan.getZmin().hasXBridge(plan.provider) != null || plan.getZmax().hasXBridge(plan.provider) != null)) {
+            return null;
+        }
+        BuildingPart bt = plan.bridgeType;
+        ChunkPlan i = plan.getXmin();
+        while ((!i.isCity) && i.xBridge && isSuitableForBridge(plan.provider, i)) {
+            if (plan.coord.chunkZ() % 2 != 0 && (i.getZmin().hasXBridge(plan.provider) != null || i.getZmax().hasXBridge(plan.provider) != null)) {
+                return null;
+            }
+            bt = i.bridgeType;
+            i = i.getXmin();
+        }
+        if ((!i.isCity) || i.hasBuilding || i.cityLevel > 0) {  // @todo support bridges at higher levels?
+            return null;
+        }
+
+        ChunkPlan minimum = i;
+
+        i = plan.getXmax();
+        while ((!i.isCity) && i.xBridge && isSuitableForBridge(plan.provider, i)) {
+            if (plan.coord.chunkZ() % 2 != 0 && (i.getZmin().hasXBridge(plan.provider) != null || i.getZmax().hasXBridge(plan.provider) != null)) {
+                return null;
+            }
+            i = i.getXmax();
+        }
+        if ((!i.isCity) || i.hasBuilding || i.cityLevel > 0) {
+            return null;
+        }
+        // Here we can automatically mark the rest of the bridge as ok. Saves on calculation
+        i = i.getXmin();
+        ChunkCoord minCoord = minimum.coord;
+        while (!i.coord.equals(minCoord)) {
+            i.bridges.xType = bt;
+            i.bridges.xCalculated = true;
+            i.bridges.zType = null;
+            i.bridges.zCalculated = true;
+            i = i.getXmin();
+        }
+
+        return bt;
+    }
+
+    // To prevent adjacent bridges of the same direction we give the bridges at even chunk X coordinates higher priority
+    BuildingPart z(PlanningContext provider) {
+        if (zCalculated) {
+            return zType;
+        }
+        BuildingPart result = computeZ(plan.provider);
+        zType = result;
+        zCalculated = true;
+        return result;
+    }
+
+    private BuildingPart computeZ(PlanningContext provider) {
+        PrimaryBridgePlanner.BridgeSpan planned = planned();
+        if (planned != null) {
+            return planned.orientation() == Orientation.Z
+                    ? PrimaryBridgePlanner.deckPart(planned, plan.coord, plan.provider) : null;
+        }
+        if (!plan.zBridge) {
+            return null;
+        }
+        if (!isSuitableForBridge(plan.provider, plan)) {
+            return null;
+        }
+        if (x(plan.provider) != null) {
+            return null;
+        }
+
+        if (plan.coord.chunkX() % 2 != 0 && (plan.getXmin().hasZBridge(plan.provider) != null || plan.getXmax().hasZBridge(plan.provider) != null)) {
+            return null;
+        }
+
+        BuildingPart bt = plan.bridgeType;
+        ChunkPlan i = plan.getZmin();
+        while ((!i.isCity) && i.zBridge && isSuitableForBridge(plan.provider, i)) {
+            if (i.hasXBridge(plan.provider) != null) {
+                return null;
+            }
+            if (plan.coord.chunkX() % 2 != 0 && (i.getXmin().hasZBridge(plan.provider) != null || i.getXmax().hasZBridge(plan.provider) != null)) {
+                return null;
+            }
+
+            bt = i.bridgeType;
+            i = i.getZmin();
+        }
+
+        ChunkPlan minimum = i;
+
+        if ((!i.isCity) || i.hasBuilding || i.cityLevel > 0) {
+            return null;
+        }
+        i = plan.getZmax();
+        while ((!i.isCity) && i.zBridge && isSuitableForBridge(plan.provider, i)) {
+            if (i.hasXBridge(plan.provider) != null) {
+                return null;
+            }
+            if (plan.coord.chunkX() % 2 != 0 && (i.getXmin().hasZBridge(plan.provider) != null || i.getXmax().hasZBridge(plan.provider) != null)) {
+                return null;
+            }
+            i = i.getZmax();
+        }
+        if ((!i.isCity) || i.hasBuilding || i.cityLevel > 0) {
+            return null;
+        }
+        // Here we can automatically mark the rest of the bridge as ok. Saves on calculation
+        i = i.getZmin();
+        ChunkCoord minCoord = minimum.coord;
+        while (!i.coord.equals(minCoord)) {
+            i.bridges.zType = bt;
+            i.bridges.zCalculated = true;
+            i.bridges.xType = null;
+            i.bridges.xCalculated = true;
+            i = i.getZmin();
+        }
+
+        return bt;
+    }
+
+    boolean isOcean() {
+        if (ocean != null) {
+            return ocean;
+        }
+        Holder<Biome> mainBiome = BiomeInfo.getBiomeInfo(plan.provider, plan.coord).getMainBiome();
+        ocean = mainBiome.is(BiomeTags.IS_OCEAN) || mainBiome.is(BiomeTags.IS_DEEP_OCEAN);
+        return ocean;
+    }
+
+
+    private boolean isSuitableForBridge(PlanningContext provider, ChunkPlan i) {
+        if (i.getPlannedBridge() != null) {
+            // A planned span owns this chunk. An opportunistic bridge must not run through it -
+            // it would stamp its own part over the planned deck on its way past.
+            return false;
+        }
+        return i.cityLevel < plan.cityLevel || Terrain.isWaterBiome(plan.provider, i.coord);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkCandidates.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkCandidates.java
@@ -1,0 +1,311 @@
+package dev.krona.urbex.worldgen.lost;
+
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.plan.EffectiveRoad;
+import dev.krona.urbex.plan.RoadCell;
+import dev.krona.urbex.plan.RoadDirection;
+import dev.krona.urbex.plan.RoadType;
+import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.varia.*;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.varia.Rng;
+import dev.krona.urbex.worldgen.ChunkHeightmap;
+import dev.krona.urbex.worldgen.CityGenerator;
+import dev.krona.urbex.worldgen.PlanningContext;
+import dev.krona.urbex.worldgen.gen.Terrain;
+import dev.krona.urbex.worldgen.lost.cityassets.*;
+import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
+import dev.krona.urbex.worldgen.lost.regassets.data.WorldSettings;
+import java.util.*;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import static dev.krona.urbex.worldgen.CityGenerator.FLOORHEIGHT;
+
+/**
+ * What content a chunk is a candidate for, before anything is built.
+ *
+ * <p>The first pass of planning: is this chunk city, does a road or a highway or a railway run
+ * through it, is it one section of a multi-chunk building, and which building would go here. The
+ * answer is a {@link ChunkCandidate}, cached per coordinate, and it is deliberately upstream of
+ * everything a {@link ChunkPlan} decides - a candidate may not read a building decision, its own or
+ * a neighbour's, or the decision graph stops being acyclic.</p>
+ *
+ * <p>Split out of {@link ChunkPlan} (issue #11), where the resolution of a chunk's candidate sat
+ * alongside everything that consumes it.</p>
+ */
+public final class ChunkCandidates {
+
+    private ChunkCandidates() {
+    }
+
+    public static boolean hasBuildingGui(int chunkX, int chunkZ, PlanningContext provider, ChunkCandidate candidate) {
+//        Random rand = ChunkPlan.getBuildingRandom(chunkX, chunkZ, provider.seed());
+//        rand.nextFloat();       // Compatibility?
+
+        return candidate.couldHaveBuilding();
+    }
+
+    public static ChunkCandidate candidateUncached(ChunkCoord key, PlanningContext provider) {
+//        ChunkCandidate cached = CITY_INFO_MAP.get(key);
+//        if (cached != null) {
+//            return cached;
+//        }
+        int chunkX = key.chunkX();
+        int chunkZ = key.chunkZ();
+        Preset profile = provider.preset();
+
+        boolean isCity = CityField.isCityRaw(key, provider, profile);
+        int cityLevel = CityField.cityLevelUncached(key, provider);
+        RandomSource rand = ChunkPlan.getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
+        boolean couldHaveBuilding = isCity && rand.nextFloat() < profile.buildingChance();
+        // The preview resolves neither a multi-building section nor a style, exactly as before -
+        // those three stay null here rather than being computed for a screen that does not use them.
+        return new ChunkCandidate(isCity, couldHaveBuilding, null, cityLevel, null, null, null);
+    }
+
+    /**
+     * Not synchronized: the candidate of a chunk are a pure function of the seed and the
+     * coordinate, so two threads racing on the same coordinate compute the same answer and one of
+     * them simply loses the putIfAbsent below. Locking here would be a deadlock waiting to happen -
+     * this method reaches its neighbours' city styles, which reach back here.
+     */
+    public static ChunkCandidate candidate(ChunkCoord coord, PlanningContext provider) {
+        ChunkCandidate cached = provider.caches().candidate.get(coord);
+        if (cached != null) {
+            return cached;
+        }
+        int chunkX = coord.chunkX();
+        int chunkZ = coord.chunkZ();
+        Preset profile = provider.preset();
+
+        // Computed into locals and constructed once at the end. This used to assemble a mutable
+        // object field by field and hand the half-built thing to its own helpers; the record cannot
+        // be published half-built, which is the point (issue #126).
+        boolean isCity = CityField.isCityRaw(coord, provider, profile);
+
+        MultiSection section = isCity ? multiBuildingSection(coord, provider, profile) : MultiSection.NONE;
+        MultiPos multiPos = section.pos();
+        MultiBuilding multiBuilding = section.building();
+
+        int cityLevel;
+        if (multiPos.isSingle()) {
+            cityLevel = CityField.getCityLevel(coord, provider);
+        } else {
+            cityLevel = profile.multiUseCorner() ? getTopLeftCityLevel(multiPos, coord, provider)
+                    : getAverageCityLevel(multiPos, coord, provider);
+        }
+        RandomSource rand = ChunkPlan.getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
+        boolean couldHaveBuilding = ChunkContentResolver.couldHaveBuilding(profile,
+                isCity, multiPos, cityLevel, rand,
+                chunkFacts(coord, provider, profile));
+
+        CityStyle cityStyle;
+        // If this is a street we find other chunks connected to this and pick the cityStyle
+        // that represents the majority. This is to prevent streets from switching style randomly if two
+        // different styled cities mix
+        if (isCity && !couldHaveBuilding) {
+            // Counted by Identifier, not by the id's String form. A tie is the ordinary case at a
+            // style boundary (ten votes: 3x3 neighbours plus the centre twice), and
+            // Counter.getMostOccuring() breaks ties on a stated rule rather than HashMap bucket
+            // order. That rule is Identifier's own order - path, then namespace - which is what
+            // MultiChunk's city-style sort already uses; tie-breaking on toString() instead would
+            // order the same asset kind namespace-first here and path-first there, and the two
+            // disagree as soon as a second namespace ships a city style.
+            Counter<Identifier> counter = new Counter<>();
+            for (int cx = -1; cx <= 1; cx++) {
+                for (int cz = -1; cz <= 1; cz++) {
+                    ChunkCoord key = coord.offset(cx, cz);
+                    cityStyle = City.getCityStyle(key, provider, profile);
+                    counter.add(cityStyle.getId());
+                    if (cx == 0 && cz == 0) {
+                        counter.add(cityStyle.getId());   // Add this chunk again for a bias
+                    }
+                }
+            }
+            cityStyle = provider.assets().cityStyles().get(counter.getMostOccuring(Comparator.naturalOrder()));
+        } else {
+            cityStyle = City.getCityStyle(coord, provider, profile);
+        }
+        Building buildingType;
+        if (multiPos.isMulti() && !multiPos.isTopLeft()) {
+            if (multiBuilding != null) {
+                String b = multiBuilding.getBuilding(multiPos.x(), multiPos.z());
+                buildingType = provider.assets().buildings().getOrThrow(b);
+            } else {
+                // @todo is this even possible?
+                buildingType = getTopLeftCityInfo(multiPos, coord, provider).buildingType();
+                if (buildingType == null) {
+                    throw new RuntimeException("Topleft building type is not set!");
+                }
+            }
+        } else {
+            PredefinedBuilding predefinedBuilding = City.getPredefinedBuildingAtTopLeft(provider, coord);
+            if (multiPos.isTopLeft()) {
+                String b = multiBuilding.getBuilding(0, 0);
+                buildingType = provider.assets().buildings().getOrThrow(b);
+            } else {
+                String name = cityStyle.getRandomBuilding(rand, coord);
+                if (predefinedBuilding != null) {
+                    name = predefinedBuilding.building();
+                }
+                if (name == null) {
+                    throw new RuntimeException("Invalid building for multibuilding!");
+                }
+                buildingType = provider.assets().buildings().getOrThrow(name);
+            }
+        }
+
+        ChunkCandidate candidate = new ChunkCandidate(isCity, couldHaveBuilding,
+                multiPos, cityLevel, cityStyle, multiBuilding, buildingType);
+        ChunkCandidate raced = provider.caches().candidate.putIfAbsent(coord, candidate);
+        return raced != null ? raced : candidate;
+    }
+
+    public static boolean isCity(ChunkCoord coord, PlanningContext provider) {
+        return candidate(coord, provider).isCity();
+    }
+
+    /**
+     * The road a chunk actually renders: the raw {@link dev.krona.urbex.plan.RoadField} clipped to
+     * the city mask. A road needs its own chunk to be raw city and at least one chunk it connects to
+     * to be raw city as well, which is what removes the isolated one-chunk stubs a city mask's
+     * protrusions would otherwise leave behind.
+     *
+     * <p>Static and raw-city-only on purpose. This is consulted while the chunk candidate are
+     * still being computed, so it may not read anything that depends on a building decision - its
+     * own or a neighbour's - or the decision graph stops being acyclic.
+     */
+    public static RoadType effectiveRoadType(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        // The city test comes first, and it is not a matter of taste. Every chunk in the world builds
+        // a ChunkPlan, and the great majority of them are wilderness; asking the road field first
+        // would build the block layout five times over - once for this chunk and once per neighbour
+        // probe, each one sorting a candidate list with a comparator that hashes twice per comparison
+        // - only for the clip below to throw the answer away. EffectiveRoad.resolve returns NONE for
+        // a non-city chunk whatever the field said, so hoisting the test cannot change the answer.
+        if (!CityField.isCityRaw(coord, provider, profile)) {
+            return RoadType.NONE;
+        }
+        RoadCell cell = provider.roadField().at(coord.chunkX(), coord.chunkZ());
+        boolean connectedCityNeighbour = false;
+        for (RoadDirection direction : RoadDirection.values()) {
+            if (cell.connects(direction)) {
+                ChunkCoord adjacent = coord.offset(direction.stepX(), direction.stepZ());
+                if (CityField.isCityRaw(adjacent, provider, profile)) {
+                    connectedCityNeighbour = true;
+                    break;
+                }
+            }
+        }
+        // isCity is true: the early return above is the only way past this point.
+        return EffectiveRoad.resolve(cell.type(), true, connectedCityNeighbour, false);
+    }
+
+    /**
+     * The world lookups {@link ChunkContentResolver#couldHaveBuilding} may need, each still behind a
+     * supplier so the decision keeps its short-circuiting: consulting {@link Highway} or
+     * {@link Railway} for a chunk whose building roll already failed would be new work, and
+     * {@code Railway}'s chunk types are mutable state.
+     */
+    private static ChunkContentResolver.ChunkFacts chunkFacts(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        return new ChunkContentResolver.ChunkFacts(
+                () -> City.getPredefinedBuildingAtTopLeft(provider, coord) != null,
+                () -> City.getPredefinedStreetAt(provider, coord) != null,
+                () -> City.getCityStyle(coord, provider, profile),
+                () -> effectiveRoadType(coord, provider, profile),
+                () -> hasHighway(coord, provider, profile),
+                () -> Math.max(Highway.getXHighwayLevel(coord, provider, profile), Highway.getZHighwayLevel(coord, provider, profile)),
+                () -> hasRailway(coord, provider, profile),
+                () -> Railway.getRailChunkType(coord, provider, profile));
+    }
+
+    /**
+     * Which multi-building section a chunk belongs to, if any. Returned rather than written into a
+     * half-built {@link ChunkCandidate} - see that type for why (issue #126).
+     *
+     * @param pos      {@link MultiPos#SINGLE} when this chunk is not part of a multi-building
+     * @param building null whenever {@code pos} is {@code SINGLE}
+     */
+    private record MultiSection(MultiPos pos, MultiBuilding building) {
+        static final MultiSection NONE = new MultiSection(MultiPos.SINGLE, null);
+    }
+
+    private static MultiSection multiBuildingSection(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        // If a chunk is occupied according to City then there is a predefined building or street here.
+        // Try to look for it
+        if (City.isChunkOccupied(provider, coord)) {
+            PredefinedIndex.BuildingAt predefinedBuilding = City.getPredefinedBuilding(provider, coord);
+            if (predefinedBuilding != null) {
+                if (predefinedBuilding.building().multi()) {
+                    MultiBuilding building = provider.assets().multiBuildings().getOrThrow(predefinedBuilding.building().building());
+                    return new MultiSection(new MultiPos(predefinedBuilding.offsetX(), predefinedBuilding.offsetZ(),
+                            building.getDimX(), building.getDimZ()), building);
+                }
+            }
+            return MultiSection.NONE;
+        }
+
+        MultiChunk multiChunk = MultiChunk.getOrCreate(provider, coord);
+        MultiChunk.MB multiBuilding = multiChunk.getMultiBuilding(coord);
+        if (multiBuilding == null) {
+            return MultiSection.NONE;
+        }
+
+        MultiBuilding building = provider.assets().multiBuildings().getOrThrow(multiBuilding.name());
+        return new MultiSection(new MultiPos(multiBuilding.offsetX(), multiBuilding.offsetZ(),
+                building.getDimX(), building.getDimZ()), building);
+    }
+
+
+    private static int getAverageCityLevel(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
+        int level = 0;
+        int topX = coord.chunkX() - mp.x();
+        int topZ = coord.chunkZ() - mp.z();
+        for (int x = 0; x < mp.w(); x++) {
+            for (int z = 0; z < mp.h(); z++) {
+                ChunkCoord key = new ChunkCoord(provider.dimension(), topX + x, topZ + z);
+                level += CityField.getCityLevel(key, provider);
+            }
+        }
+        return level / (mp.w() * mp.h());
+    }
+
+    private static int getTopLeftCityLevel(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
+        int topX = coord.chunkX() - mp.x();
+        int topZ = coord.chunkZ() - mp.z();
+        ChunkCoord key = new ChunkCoord(provider.dimension(), topX, topZ);
+        return CityField.getCityLevel(key, provider);
+    }
+
+    /**
+     * The candidate of this multi-building's top-left chunk. Only reached from the one branch
+     * that needs the top-left's building type, and only when {@code mp} is not itself the top left -
+     * the caller has no half-built object to hand back for that case any more, and does not need one.
+     */
+    private static ChunkCandidate getTopLeftCityInfo(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
+        ChunkCoord key = coord.offset(-mp.x(), -mp.z());
+        return candidate(key, provider);
+    }
+
+    public static boolean hasHighway(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        return Highway.getXHighwayLevel(coord, provider, profile) >= 0 || Highway.getZHighwayLevel(coord, provider, profile) >= 0;
+    }
+
+    public static boolean hasRailway(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        return Railway.getRailChunkType(coord, provider, profile).getType() != RailChunkType.NONE;
+    }
+
+    public static boolean hasRailwayAtSurface(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        RailChunkType type = Railway.getRailChunkType(coord, provider, profile).getType();
+        return type.isSurface() || type.isStation();
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -108,6 +108,8 @@ public class ChunkPlan {
 
     /** How high this chunk's city sits and what terrain correction it asks for; see {@link HeightDecisions}. */
     final HeightDecisions heights = new HeightDecisions(this);
+    /** What this chunk joins on to; see {@link ConnectionGraph}. */
+    final ConnectionGraph graph = new ConnectionGraph(this);
 
     // No per-generation runtime state here, and specifically no post-generation callbacks: those
     // belong to the ChunkGenContext that queued them (see PostTodoQueue). A ChunkPlan is a
@@ -1034,113 +1036,33 @@ public class ChunkPlan {
     }
 
     public boolean hasXCorridor() {
-        if (!xRailCorridor) {
-            return false;
-        }
-        ChunkPlan i = getXmin();
-        while (i.canRailGoThrough() && i.xRailCorridor) {
-            i = i.getXmin();
-        }
-        if ((!i.hasBuilding) || i.cellars == 0) {
-            return false;
-        }
-        i = getXmax();
-        while (i.canRailGoThrough() && i.xRailCorridor) {
-            i = i.getXmax();
-        }
-        return !((!i.hasBuilding) || i.cellars == 0);
+        return graph.xCorridor();
     }
 
     public boolean hasZCorridor() {
-        if (!zRailCorridor) {
-            return false;
-        }
-        ChunkPlan i = getZmin();
-        while (i.canRailGoThrough() && i.zRailCorridor) {
-            i = i.getZmin();
-        }
-        if ((!i.hasBuilding) || i.cellars == 0) {
-            return false;
-        }
-        i = getZmax();
-        while (i.canRailGoThrough() && i.zRailCorridor) {
-            i = i.getZmax();
-        }
-        return !((!i.hasBuilding) || i.cellars == 0);
+        return graph.zCorridor();
     }
 
-    // Return true if it is possible for a rail section to go through here
     public boolean canRailGoThrough() {
-        if (!isCity) {
-            // There is no city here so no passing possible
-            return false;
-        }
-        if (!hasBuilding) {
-            // There is no building here but we have a city so we can pass
-            return true;
-        }
-        // Otherwise we can only pass if this building has no floors below ground
-        return cellars == 0;
+        return graph.canRailGoThrough();
     }
 
-    // Return true if it is possible for a water corridor to go through here
     public boolean canWaterCorridorGoThrough() {
-        if (!isCity) {
-            // There is no city here so no passing possible
-            return false;
-        }
-        if (!hasBuilding) {
-            // There is no building here but we have a city so we can pass
-            return true;
-        }
-        // Otherwise we can only pass if this building has at most one floor below ground
-        return cellars <= 1;
+        return graph.canWaterCorridorGoThrough();
     }
 
-    // Return true if the road from a neighbouring chunk can extend into this chunk
     public boolean doesRoadExtendTo() {
-        boolean b = isCity && !hasBuilding;
-        if (b) {
-            return !isElevatedParkSection();
-        }
-        return false;
+        return graph.roadExtendsOut();
     }
 
-    // Return true if there can be a road connection between the two given chunks
     public static boolean hasRoadConnection(ChunkPlan i1, ChunkPlan i2) {
-        if (!i1.doesRoadExtendTo()) {
-            return false;
-        }
-        if (!i2.doesRoadExtendTo()) {
-            return false;
-        }
-        if (i1.cityLevel == i2.cityLevel) {
-            return true;
-        }
-        // A one-level difference only connects where a slope actually bridges it. Reading the slope
-        // rather than merely allowing a difference of one is what keeps the upper road drawing
-        // through to its edge exactly over the ramp, and ending in a kerb everywhere else.
-        Direction slope1 = i1.getStreetSlopeDirection();
-        if (slope1 != null && slope1.get(i1).coord.equals(i2.coord)) {
-            return true;
-        }
-        Direction slope2 = i2.getStreetSlopeDirection();
-        return slope2 != null && slope2.get(i2).coord.equals(i1.coord);
+        return ConnectionGraph.hasRoadConnection(i1, i2);
     }
 
-    /**
-     * A stream for one of the per-chunk building decisions.
-     * <p>
-     * The purpose is the caller's because three independent decisions are made at this one
-     * coordinate - whether a building is here at all, which parts its floors use, and whether a
-     * lonely neighbour suppresses it - and each of them reads draw 1. Sharing a purpose made the
-     * building chance and the loneliness roll literally the same number.
-     */
     public static RandomSource getBuildingRandom(int chunkX, int chunkZ, long seed, Rng.Purpose purpose) {
         return Rng.at(seed, chunkX, chunkZ, purpose);
     }
 
-    // Convert a local building level to a global one (where cityLevel == 0)
     public int localToGlobal(int l) {
         return l + cityLevel;
     }
@@ -1150,116 +1072,27 @@ public class ChunkPlan {
     }
 
     public boolean hasConnectionAt(int level, Orientation orientation) {
-        return switch (orientation) {
-            case X -> hasConnectionAtX(level);
-            case Z -> hasConnectionAtZ(level);
-        };
+        return graph.at(level, orientation);
     }
 
-    // Call this from the street reference with the (potential building) as 'adj'
-    // 'streetLevel' is the cityLevel at the position of the street
     public boolean hasFrontPartFrom(ChunkPlan adj) {
-        ChunkPlan.StreetType st = streetType;
-        boolean elevated = isElevatedParkSection();
-        if (elevated) {
-            st = ChunkPlan.StreetType.PARK;
-        }
-
-        if (adj.hasBuilding && adj.frontType != null && st == ChunkPlan.StreetType.NORMAL && cityLevel < adj.cityLevel + adj.getNumFloors()) {
-            RailChunkType type = getRailInfo().getType();
-            if (type == RailChunkType.STATION_UNDERGROUND) {
-                return false;
-            }
-            if (type == RailChunkType.GOING_DOWN_ONE_FROM_SURFACE) {
-                return false;
-            }
-            if (getMaxHighwayLevel() >= 0) {
-                return false;
-            }
-
-            int local = adj.globalToLocal(cityLevel);
-            if (adj.isValidFloor(local) && adj.getFloor(local).getMetaBoolean(BuildingPart.META_DONTCONNECT)) {
-                return false;
-            }
-        } else {
-            return false;
-        }
-        return true;
+        return graph.frontPartFrom(adj);
     }
 
-
-    // This checks if there can be a connection at minX
     public boolean hasConnectionAtX(int level) {
-        if (!isCity) {
-            return false;
-        }
-        if (multiBuildingPos.isRightSide()) {
-            return false;
-        }
-        if (level < 0 || level >= connectionAtX.length) {
-            return false;
-        }
-        if (level < floorTypes.length && floorTypes[level].getMetaBoolean(BuildingPart.META_DONTCONNECT)) {
-            return false;       // No connection supported
-        }
-        if (getXmin().hasFrontPartFrom(this)) {
-            return true;
-        }
-        return connectionAtX[level];
+        return graph.atX(level);
     }
 
-    // This checks if there can be a connection at minX
     public boolean hasConnectionAtXFromStreet(int level) {
-        if (!isCity) {
-            return false;
-        }
-        if (multiBuildingPos.isRightSide()) {
-            return false;
-        }
-        if (level < 0 || level >= connectionAtX.length) {
-            return false;
-        }
-        if (hasFrontPartFrom(getXmin())) {
-            return true;
-        }
-        return connectionAtX[level];
+        return graph.atXFromStreet(level);
     }
 
-    // This checks if there can be a connection at minZ
     public boolean hasConnectionAtZ(int level) {
-        if (!isCity) {
-            return false;
-        }
-        if (multiBuildingPos.isBottomSide()) {
-            return false;
-        }
-        if (level < 0 || level >= connectionAtZ.length) {
-            return false;
-        }
-        if (level < floorTypes.length && floorTypes[level].getMetaBoolean(BuildingPart.META_DONTCONNECT)) {
-            return false;       // No connection supported
-        }
-        if (getZmin().hasFrontPartFrom(this)) {
-            return true;
-        }
-        return connectionAtZ[level];
+        return graph.atZ(level);
     }
 
-    // This checks if there can be a connection at minZ
     public boolean hasConnectionAtZFromStreet(int level) {
-        if (!isCity) {
-            return false;
-        }
-        if (multiBuildingPos.isBottomSide()) {
-            return false;
-        }
-        if (level < 0 || level >= connectionAtZ.length) {
-            return false;
-        }
-        if (hasFrontPartFrom(getZmin())) {
-            return true;
-        }
-        return connectionAtZ[level];
+        return graph.atZFromStreet(level);
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -318,8 +318,8 @@ public class ChunkPlan {
         int chunkZ = key.chunkZ();
         Preset profile = provider.preset();
 
-        boolean isCity = isCityRaw(key, provider, profile);
-        int cityLevel = getCityLevelGui(key, provider);
+        boolean isCity = CityField.isCityRaw(key, provider, profile);
+        int cityLevel = CityField.cityLevelUncached(key, provider);
         RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
         boolean couldHaveBuilding = isCity && rand.nextFloat() < profile.buildingChance();
         // The preview resolves neither a multi-building section nor a style, exactly as before -
@@ -345,7 +345,7 @@ public class ChunkPlan {
         // Computed into locals and constructed once at the end. This used to assemble a mutable
         // object field by field and hand the half-built thing to its own helpers; the record cannot
         // be published half-built, which is the point (issue #126).
-        boolean isCity = isCityRaw(coord, provider, profile);
+        boolean isCity = CityField.isCityRaw(coord, provider, profile);
 
         MultiSection section = isCity ? multiBuildingSection(coord, provider, profile) : MultiSection.NONE;
         MultiPos multiPos = section.pos();
@@ -353,7 +353,7 @@ public class ChunkPlan {
 
         int cityLevel;
         if (multiPos.isSingle()) {
-            cityLevel = getCityLevel(coord, provider);
+            cityLevel = CityField.getCityLevel(coord, provider);
         } else {
             cityLevel = profile.multiUseCorner() ? getTopLeftCityLevel(multiPos, coord, provider)
                     : getAverageCityLevel(multiPos, coord, provider);
@@ -425,19 +425,6 @@ public class ChunkPlan {
         return raced != null ? raced : candidate;
     }
 
-    /**
-     * Don't use the cache as we're busy building the cache.
-     */
-    public static boolean isCityRaw(ChunkCoord coord, PlanningContext provider, Preset profile) {
-        if (isVoidChunk(coord, provider)) {
-            // If we have a void chunk then no city here
-            return false;
-        }
-
-        float cityFactor = City.getCityFactor(coord, provider, profile);
-        return cityFactor > profile.cityThreshold();
-    }
-
     public static boolean isCity(ChunkCoord coord, PlanningContext provider) {
         return getChunkCandidate(coord, provider).isCity();
     }
@@ -459,7 +446,7 @@ public class ChunkPlan {
         // probe, each one sorting a candidate list with a comparator that hashes twice per comparison
         // - only for the clip below to throw the answer away. EffectiveRoad.resolve returns NONE for
         // a non-city chunk whatever the field said, so hoisting the test cannot change the answer.
-        if (!isCityRaw(coord, provider, profile)) {
+        if (!CityField.isCityRaw(coord, provider, profile)) {
             return RoadType.NONE;
         }
         RoadCell cell = provider.roadField().at(coord.chunkX(), coord.chunkZ());
@@ -467,7 +454,7 @@ public class ChunkPlan {
         for (RoadDirection direction : RoadDirection.values()) {
             if (cell.connects(direction)) {
                 ChunkCoord adjacent = coord.offset(direction.stepX(), direction.stepZ());
-                if (isCityRaw(adjacent, provider, profile)) {
+                if (CityField.isCityRaw(adjacent, provider, profile)) {
                     connectedCityNeighbour = true;
                     break;
                 }
@@ -547,7 +534,7 @@ public class ChunkPlan {
         for (int x = 0; x < mp.w(); x++) {
             for (int z = 0; z < mp.h(); z++) {
                 ChunkCoord key = new ChunkCoord(provider.dimension(), topX + x, topZ + z);
-                level += getCityLevel(key, provider);
+                level += CityField.getCityLevel(key, provider);
             }
         }
         return level / (mp.w() * mp.h());
@@ -557,7 +544,7 @@ public class ChunkPlan {
         int topX = coord.chunkX() - mp.x();
         int topZ = coord.chunkZ() - mp.z();
         ChunkCoord key = new ChunkCoord(provider.dimension(), topX, topZ);
-        return getCityLevel(key, provider);
+        return CityField.getCityLevel(key, provider);
     }
 
     /**
@@ -951,130 +938,6 @@ public class ChunkPlan {
      * Return true if this is a void chunk (only for floating island worldtype). This does
      * not use the cache so it is safe to use when the cache is building
      */
-    public static boolean isVoidChunk(ChunkCoord coord, PlanningContext provider) {
-        if (provider.preset().isFloating()) {
-            return provider.heightmap(coord).getHeight() <= 0;
-        } else {
-            return false;
-        }
-    }
-
-
-    /**
-     * This function does not use the cache. So safe to use when the cache is building
-     * This function uses its own cache.
-     */
-    public static int getCityLevel(ChunkCoord key, PlanningContext provider) {
-        // Unconditional. This used to be gated on provider.getWorld() != null, "In LC preview we
-        // don't want to use the cache as the config isn't loaded yet" - a guard from when the
-        // preview shared the dimension's caches. It has held its own DimensionCaches, built from
-        // its own seed and dropped with it, since #125; and the value cached here is a pure function
-        // of the seed and the preset, both of which are fixed for one preview.
-        Integer cached = provider.caches().cityLevel.get(key);
-        if (cached != null) {
-            return cached;
-        }
-        int result;
-        if (provider.preset().isFloating()) {
-            result = getCityLevelFloating(key, provider);
-        } else if (provider.preset().isCavern()) {
-            result =  getCityLevelCavern(key, provider);
-        } else {
-            result = getCityLevelNormal(key, provider, provider.preset());
-        }
-        Integer raced = provider.caches().cityLevel.putIfAbsent(key, result);
-        if (raced != null) {
-            return raced;
-        }
-        return result;
-    }
-
-    public static int getCityLevelGui(ChunkCoord key, PlanningContext provider) {
-        int result;
-        if (provider.preset().isFloating()) {
-            result = getCityLevelFloating(key, provider);
-        } else if (provider.preset().isCavern()) {
-            result =  getCityLevelCavern(key, provider);
-        } else {
-            result = getCityLevelNormal(key, provider, provider.preset());
-        }
-        return result;
-    }
-
-    private static int getCityLevelCavern(ChunkCoord coord, PlanningContext provider) {
-        // @todo for now
-        return getCityLevelFloating(coord, provider);
-    }
-
-
-    private static int getCityLevelNormal(ChunkCoord coord, PlanningContext provider, Preset profile) {
-        ChunkHeightmap heightmap = provider.heightmap(coord);
-        int height = heightmap.getHeight();
-        if (profile.useAvgHeightmap() && Config.heightSampleSize() > 2) {
-            int sampleSize = Config.heightSampleSize();
-            int constX = coord.chunkX() < 0 ? -1 : 1;
-            int constZ = coord.chunkZ() < 0 ? -1 : 1;
-            int chunkBaseX =  (coord.chunkX() / sampleSize) * sampleSize + (sampleSize / 2 * constX);
-            int chunkBaseZ =  (coord.chunkZ() / sampleSize) * sampleSize + (sampleSize / 2 * constZ);
-            int chunkLeft = ((coord.chunkX() / sampleSize) - 1) * sampleSize + (sampleSize / 2 * constX);
-            int chunkRight = ((coord.chunkX() / sampleSize) + 1) * sampleSize + (sampleSize / 2 * constX);
-            int chunkUp = ((coord.chunkZ() / sampleSize) - 1) * sampleSize + (sampleSize / 2 * constZ);
-            int chunkDown = ((coord.chunkZ() / sampleSize) + 1) * sampleSize + (sampleSize / 2 * constZ);
-            ChunkCoord left = new ChunkCoord(provider.dimension(), chunkLeft, chunkBaseZ);
-            ChunkCoord right = new ChunkCoord(provider.dimension(), chunkRight, chunkBaseZ);
-            ChunkCoord up = new ChunkCoord(provider.dimension(), chunkBaseX, chunkUp);
-            ChunkCoord down = new ChunkCoord(provider.dimension(), chunkBaseX, chunkDown);
-            int avgHeightmap = height;
-            int counter = 1;
-            if (isCityRaw(left, provider, profile)) {
-                avgHeightmap += provider.heightmap(left).getHeight();
-                counter++;
-            }
-            if (isCityRaw(right, provider, profile)) {
-                avgHeightmap += provider.heightmap(right).getHeight();
-                counter++;
-            }
-            if (isCityRaw(up, provider, profile)) {
-                avgHeightmap += provider.heightmap(up).getHeight();
-                counter++;
-            }
-            if (isCityRaw(down, provider, profile)) {
-                avgHeightmap += provider.heightmap(down).getHeight();
-                counter++;
-            }
-            avgHeightmap /= counter;
-            return getLevelBasedOnHeight(avgHeightmap, profile);
-        }
-        return getLevelBasedOnHeight(height, profile);
-    }
-
-    private static int getCityLevelFloating(ChunkCoord coord, PlanningContext provider) {
-        int h = provider.heightmap(coord).getHeight();
-        return getLevelBasedOnHeight(h, provider.preset());
-    }
-
-    private static int getLevelBasedOnHeight(int height, Preset profile) {
-        if (height < profile.cityLevel0Height()) {
-            return 0;
-        } else if (height < profile.cityLevel1Height()) {
-            return 1;
-        } else if (height < profile.cityLevel2Height()) {
-            return 2;
-        } else if (height < profile.cityLevel3Height()) {
-            return 3;
-        } else if (height < profile.cityLevel4Height()) {
-            return 4;
-        } else if (height < profile.cityLevel5Height()) {
-            return 5;
-        } else if (height < profile.cityLevel6Height()) {
-            return 6;
-        } else if (height < profile.cityLevel7Height()) {
-            return 7;
-        } else {
-            return 8;
-        }
-    }
-
     private Block getRandomDoor(RandomSource rand) {
         return switch (rand.nextInt(7)) {
             case 0 -> Blocks.BIRCH_DOOR;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -98,16 +98,10 @@ public class ChunkPlan {
     private volatile DamageArea damageArea = null;
     private Palette palette = null;             // written once, in the constructor
     private volatile CompiledPalette compiledPalette = null;
-    private volatile Boolean isOcean = null;
     private volatile WorldStyle chunkWorldStyle = null;
 
-    private volatile boolean xBridgeTypeCalculated = false;
-    private volatile boolean zBridgeTypeCalculated = false;
-    private volatile BuildingPart xBridgeType = null;
-    private volatile BuildingPart zBridgeType = null;
-
-    private volatile boolean plannedBridgeCalculated = false;
-    private volatile PrimaryBridgePlanner.BridgeSpan plannedBridge;
+    /** This chunk's bridge decisions and the state memoising them; see {@link BridgeDecisions}. */
+    final BridgeDecisions bridges = new BridgeDecisions(this);
 
     private volatile boolean streetSlopeCalculated = false;
     private volatile Direction streetSlopeDirection;
@@ -1120,199 +1114,28 @@ public class ChunkPlan {
      */
     @Nullable
     public PrimaryBridgePlanner.BridgeSpan getPlannedBridge() {
-        if (plannedBridgeCalculated) {
-            return plannedBridge;
-        }
-        PrimaryBridgePlanner.BridgeSpan result = PrimaryBridgePlanner.spanAt(coord, provider).orElse(null);
-        // Value first, then the flag.
-        plannedBridge = result;
-        plannedBridgeCalculated = true;
-        return result;
+        return bridges.planned();
     }
 
     public BuildingPart hasBridge(PlanningContext provider, Orientation orientation) {
-        return switch (orientation) {
-            case X -> hasXBridge(provider);
-            case Z -> hasZBridge(provider);
-        };
+        return bridges.at(provider, orientation);
     }
 
     public boolean hasBridge(PlanningContext provider) {
-        if (hasXBridge(provider) != null) {
-            return true;
-        }
-        if (hasZBridge(provider) != null) {
-            return true;
-        }
-        return false;
+        return bridges.any(provider);
     }
 
-    // To prevent adjacent bridges of the same direction we give the bridges at even chunk Z coordinates higher priority
     public BuildingPart hasXBridge(PlanningContext provider) {
-        if (xBridgeTypeCalculated) {
-            return xBridgeType;
-        }
-        BuildingPart result = computeXBridge(provider);
-        // Value first, then the flag. The old code set the flag up front and filled the value in
-        // afterwards, which is fine under a lock and a lie without one.
-        xBridgeType = result;
-        xBridgeTypeCalculated = true;
-        return result;
+        return bridges.x(provider);
     }
 
-    private BuildingPart computeXBridge(PlanningContext provider) {
-        PrimaryBridgePlanner.BridgeSpan planned = getPlannedBridge();
-        if (planned != null) {
-            // A planned span settles this chunk for both orientations. Falling through to the
-            // opportunistic scan below when the span runs the other way would let an ordinary bridge
-            // claim the chunk first and cancel the planned one.
-            return planned.orientation() == Orientation.X
-                    ? PrimaryBridgePlanner.deckPart(planned, coord, provider) : null;
-        }
-        if (!xBridge) {
-            return null;
-        }
-        if (!isSuitableForBridge(provider, this)) {
-            return null;
-        }
-        if (coord.chunkZ() % 2 != 0 && (getZmin().hasXBridge(provider) != null || getZmax().hasXBridge(provider) != null)) {
-            return null;
-        }
-        BuildingPart bt = bridgeType;
-        ChunkPlan i = getXmin();
-        while ((!i.isCity) && i.xBridge && isSuitableForBridge(provider, i)) {
-            if (coord.chunkZ() % 2 != 0 && (i.getZmin().hasXBridge(provider) != null || i.getZmax().hasXBridge(provider) != null)) {
-                return null;
-            }
-            bt = i.bridgeType;
-            i = i.getXmin();
-        }
-        if ((!i.isCity) || i.hasBuilding || i.cityLevel > 0) {  // @todo support bridges at higher levels?
-            return null;
-        }
-
-        ChunkPlan minimum = i;
-
-        i = getXmax();
-        while ((!i.isCity) && i.xBridge && isSuitableForBridge(provider, i)) {
-            if (coord.chunkZ() % 2 != 0 && (i.getZmin().hasXBridge(provider) != null || i.getZmax().hasXBridge(provider) != null)) {
-                return null;
-            }
-            i = i.getXmax();
-        }
-        if ((!i.isCity) || i.hasBuilding || i.cityLevel > 0) {
-            return null;
-        }
-        // Here we can automatically mark the rest of the bridge as ok. Saves on calculation
-        i = i.getXmin();
-        ChunkCoord minCoord = minimum.coord;
-        while (!i.coord.equals(minCoord)) {
-            i.xBridgeType = bt;
-            i.xBridgeTypeCalculated = true;
-            i.zBridgeType = null;
-            i.zBridgeTypeCalculated = true;
-            i = i.getXmin();
-        }
-
-        return bt;
-    }
-
-    // To prevent adjacent bridges of the same direction we give the bridges at even chunk X coordinates higher priority
     public BuildingPart hasZBridge(PlanningContext provider) {
-        if (zBridgeTypeCalculated) {
-            return zBridgeType;
-        }
-        BuildingPart result = computeZBridge(provider);
-        zBridgeType = result;
-        zBridgeTypeCalculated = true;
-        return result;
-    }
-
-    private BuildingPart computeZBridge(PlanningContext provider) {
-        PrimaryBridgePlanner.BridgeSpan planned = getPlannedBridge();
-        if (planned != null) {
-            return planned.orientation() == Orientation.Z
-                    ? PrimaryBridgePlanner.deckPart(planned, coord, provider) : null;
-        }
-        if (!zBridge) {
-            return null;
-        }
-        if (!isSuitableForBridge(provider, this)) {
-            return null;
-        }
-        if (hasXBridge(provider) != null) {
-            return null;
-        }
-
-        if (coord.chunkX() % 2 != 0 && (getXmin().hasZBridge(provider) != null || getXmax().hasZBridge(provider) != null)) {
-            return null;
-        }
-
-        BuildingPart bt = bridgeType;
-        ChunkPlan i = getZmin();
-        while ((!i.isCity) && i.zBridge && isSuitableForBridge(provider, i)) {
-            if (i.hasXBridge(provider) != null) {
-                return null;
-            }
-            if (coord.chunkX() % 2 != 0 && (i.getXmin().hasZBridge(provider) != null || i.getXmax().hasZBridge(provider) != null)) {
-                return null;
-            }
-
-            bt = i.bridgeType;
-            i = i.getZmin();
-        }
-
-        ChunkPlan minimum = i;
-
-        if ((!i.isCity) || i.hasBuilding || i.cityLevel > 0) {
-            return null;
-        }
-        i = getZmax();
-        while ((!i.isCity) && i.zBridge && isSuitableForBridge(provider, i)) {
-            if (i.hasXBridge(provider) != null) {
-                return null;
-            }
-            if (coord.chunkX() % 2 != 0 && (i.getXmin().hasZBridge(provider) != null || i.getXmax().hasZBridge(provider) != null)) {
-                return null;
-            }
-            i = i.getZmax();
-        }
-        if ((!i.isCity) || i.hasBuilding || i.cityLevel > 0) {
-            return null;
-        }
-        // Here we can automatically mark the rest of the bridge as ok. Saves on calculation
-        i = i.getZmin();
-        ChunkCoord minCoord = minimum.coord;
-        while (!i.coord.equals(minCoord)) {
-            i.zBridgeType = bt;
-            i.zBridgeTypeCalculated = true;
-            i.xBridgeType = null;
-            i.xBridgeTypeCalculated = true;
-            i = i.getZmin();
-        }
-
-        return bt;
+        return bridges.z(provider);
     }
 
     public boolean isOcean() {
-        if (isOcean != null) {
-            return isOcean;
-        }
-        Holder<Biome> mainBiome = BiomeInfo.getBiomeInfo(provider, coord).getMainBiome();
-        isOcean = mainBiome.is(BiomeTags.IS_OCEAN) || mainBiome.is(BiomeTags.IS_DEEP_OCEAN);
-        return isOcean;
+        return bridges.isOcean();
     }
-
-
-    private boolean isSuitableForBridge(PlanningContext provider, ChunkPlan i) {
-        if (i.getPlannedBridge() != null) {
-            // A planned span owns this chunk. An opportunistic bridge must not run through it -
-            // it would stamp its own part over the planned deck on its way past.
-            return false;
-        }
-        return i.cityLevel < cityLevel || Terrain.isWaterBiome(provider, i.coord);
-    }
-
 
     public boolean hasXCorridor() {
         if (!xRailCorridor) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -60,7 +60,7 @@ public class ChunkPlan {
     public final StreetType streetType;
     private final RoadType effectiveRoad;   // The planned road this chunk renders, NONE for most chunks
 
-    private final int floors;
+    final int floors;
     public final int cellars;
     public final BuildingPart[] floorTypes;
     public final BuildingPart[] floorTypes2;
@@ -106,8 +106,8 @@ public class ChunkPlan {
     /** Which way this chunk's street slopes and where its stairs face; see {@link SlopeDecisions}. */
     final SlopeDecisions slopes = new SlopeDecisions(this);
 
-    private volatile MinMax desiredTerrainCorrectionHeights = null;
-    private volatile MinMax desiredMaxHeight1 = null;
+    /** How high this chunk's city sits and what terrain correction it asks for; see {@link HeightDecisions}. */
+    final HeightDecisions heights = new HeightDecisions(this);
 
     // No per-generation runtime state here, and specifically no post-generation callbacks: those
     // belong to the ChunkGenContext that queued them (see PostTodoQueue). A ChunkPlan is a
@@ -1267,131 +1267,39 @@ public class ChunkPlan {
      * Return Integer.MIN_VALUE if the building is degenerate (no floors, no cellars).
      */
     public int getBuildingBottomHeight() {
-        int min = provider.shape().minY() + 2;
-        int max = provider.shape().maxY() - 1 - FLOORHEIGHT;
-
-        // Locals. This used to decrement the published cellars and floors as it walked, so the answer
-        // depended on how many times it had been asked: the first call shrank the building and every
-        // later one measured the shrunken version, and a TimedCache eviction reset the count by
-        // rebuilding the object. It is the "building queries such as bottom-height calculation mutate
-        // floors/cellars during consumption" defect in issue #126, and the only reason the fields it
-        // touched could not be final.
-        int remainingCellars = cellars;
-        int lowestLevel = getCityGroundLevel() - remainingCellars * FLOORHEIGHT;
-
-        // Fix lowest level so it goes above minimum build height
-        while (lowestLevel <= min) {
-            lowestLevel += FLOORHEIGHT;
-            remainingCellars--;
-            if (remainingCellars < 0) {
-                return Integer.MIN_VALUE;     // Bail out, this is a degenerate case
-            }
-        }
-
-        // Contributes nothing but the degenerate bail-out: the height returned is the cellar walk's.
-        int remainingFloors = floors;
-        while (getCityGroundLevel() + remainingFloors * FLOORHEIGHT >= max) {
-            remainingFloors--;
-            if (remainingFloors < 0) {
-                return Integer.MIN_VALUE;     // Bail out, this is a degenerate case
-            }
-        }
-        return lowestLevel;
+        return heights.buildingBottom();
     }
 
-    /**
-     * Return the building part at a given y value. Return null if there is no building part at that level
-     */
     public BuildingPart getFloorAtY(int lowestLevel, int y) {
-        if (y < lowestLevel || y >= lowestLevel + (floors + cellars + 1) * FLOORHEIGHT) {
-            return null;    // No building part at this level
-        }
-        int localY = (y - lowestLevel) / FLOORHEIGHT;
-        if (localY < 0 || localY >= floorTypes.length) {
-            return null;    // No building part at this level
-        }
-        return floorTypes[localY];
+        return heights.floorAtY(lowestLevel, y);
     }
 
-    /**
-     * Get the lowest height of a corner of four chunks (if it is a city chunk).
-     * info: reference to the bottom-right chunk. The 0,0 position of this chunk is the reference.
-     * Returns 100000 if the corner is not adjacent to any city chunk
-     * Also returns 100000 if all corners are city or landscape chunks (as
-     * this kind of corner should also have no effect on the landscape beyond those chunks)
-     * This is the level 0 version which looks at current chunk corner only
-     */
     public int getLowestCityHeightAtChunkCorner() {
-        ChunkPlan info00 = getXmin().getZmin();
-        ChunkPlan info01 = getXmin();
-        ChunkPlan info10 = getZmin();
-        if (isCity && info10.isCity && info00.isCity && info01.isCity) {
-            return 100000;
-        }
-        if (!isCity && !info10.isCity && !info00.isCity && !info01.isCity) {
-            return 100000;
-        }
-        // If we come here we have a mix of city and normal chunks
-        int h = getCityHeightForChunk();
-        h = Math.min(h, info01.getCityHeightForChunk());
-        h = Math.min(h, info10.getCityHeightForChunk());
-        h = Math.min(h, info00.getCityHeightForChunk());
-        return h;
+        return heights.lowestCityHeightAtCorner();
     }
 
-    /*
-     * This is used for correcting the terrain and indicates the desired
-     * level to which adjacent terrains should interpolate
-     */
     public int getCityHeightForChunk() {
-        if (isCity) {
-            return getCityGroundLevel();
-        } else {
-            if (isOcean()) {
-                return groundLevel - profile.oceanCorrectionBorder();
-            } else {
-                return 100000;
-            }
-        }
+        return heights.cityHeightForChunk();
     }
+
+    public MinMax getDesiredMaxHeightL2() {
+        return heights.desiredMaxHeightL2();
+    }
+
+    public void updateMinMaxL2(MinMax minMax, int offs) {
+        heights.updateMinMaxL2(minMax, offs);
+    }
+
 
     /**
-     * Given adjacent (city) chunks, calculate the desired height to interpolate the
-     * landscape to (minimum/maximum). This is calculated for the reference position of this chunk (0,0 point)
-     * This is the level 1 version which looks at adjacent heights only
+     * How a chunk with no building renders: a planned road is {@link #NORMAL} paving, an open lot is
+     * the {@link #PARK} grass surface. Nothing else decides between them - in particular the open-lot
+     * park chance does not, it only furnishes a lot that is already grass. There is no third surface:
+     * the old {@code FULL} type was reachable only from a coin flip the road field replaced.
      */
-    private MinMax getDesiredMaxHeightL1() {
-        if (desiredMaxHeight1 == null) {
-            int h = getLowestCityHeightAtChunkCorner();
-
-            int cx = coord.chunkX();
-            int cz = coord.chunkZ();
-
-            // @todo build limit
-            if (h < provider.shape().maxBuildHeight()) {
-                // The L0 height at this corner is fixed so we return that
-                desiredMaxHeight1 = new MinMax(
-                        h + Terrain.getRandomizedOffset(provider.seed(), cx, cz, profile.terrainFixLowerMinOffset(), profile.terrainFixLowerMaxOffset(), Rng.Purpose.TERRAIN_FIX_LOWER),
-                        h + Terrain.getRandomizedOffset(provider.seed(), cx, cz, profile.terrainFixUpperMinOffset(), profile.terrainFixUpperMaxOffset(), Rng.Purpose.TERRAIN_FIX_UPPER));
-                return desiredMaxHeight1;
-            }
-
-            MinMax minMax = new MinMax();
-
-            getXmin().getZmin().updateMinMaxL1(minMax, 25 + Terrain.getHeightOffsetL1(provider.seed(), cx - 1, cz - 1));
-            getXmin().updateMinMaxL1(minMax, 20 + Terrain.getHeightOffsetL1(provider.seed(), cx - 1, cz));
-            getXmin().getZmax().updateMinMaxL1(minMax, 25 + Terrain.getHeightOffsetL1(provider.seed(), cx - 1, cz + 1));
-
-            getZmin().updateMinMaxL1(minMax, 20 + Terrain.getHeightOffsetL1(provider.seed(), cx, cz - 1));
-            getZmax().updateMinMaxL1(minMax, 20 + Terrain.getHeightOffsetL1(provider.seed(), cx, cz + 1));
-
-            getXmax().getZmin().updateMinMaxL1(minMax, 25 + Terrain.getHeightOffsetL1(provider.seed(), cx + 1, cz - 1));
-            getXmax().updateMinMaxL1(minMax, 20 + Terrain.getHeightOffsetL1(provider.seed(), cx + 1, cz));
-            getXmax().getZmax().updateMinMaxL1(minMax, 25 + Terrain.getHeightOffsetL1(provider.seed(), cx + 1, cz + 1));
-
-            desiredMaxHeight1 = minMax;
-        }
-        return desiredMaxHeight1;
+    public enum StreetType {
+        NORMAL,
+        PARK
     }
 
     public static class MinMax {
@@ -1412,75 +1320,6 @@ public class ChunkPlan {
             min = max = 100000;
         }
     }
-
-    /**
-     * Given adjacent (city) chunks, calculate the desired height to interpolate the
-     * landscape too. This is calculated for the reference position of this chunk (0,0 point)
-     * This is the level 2 version which looks at L1 heights of adjacent chunks
-     */
-    public MinMax getDesiredMaxHeightL2() {
-        if (desiredTerrainCorrectionHeights == null) {
-            MinMax mm = getDesiredMaxHeightL1();
-            // @todo build limit
-            if (mm.min < provider.shape().maxBuildHeight()) {
-                // The L1 height at this corner is fixed so we return that
-                desiredTerrainCorrectionHeights = new MinMax(mm);
-                return desiredTerrainCorrectionHeights;
-            }
-
-            int cx = coord.chunkX();
-            int cz = coord.chunkZ();
-
-            MinMax minMax = new MinMax();
-
-            getXmin().getZmin().updateMinMaxL2(minMax, 25 + Terrain.getHeightOffsetL2(provider.seed(), cx - 1, cz - 1));
-            getXmin().updateMinMaxL2(minMax, 20 + Terrain.getHeightOffsetL2(provider.seed(), cx - 1, cz));
-            getXmin().getZmax().updateMinMaxL2(minMax, 25 + Terrain.getHeightOffsetL2(provider.seed(), cx - 1, cz + 1));
-
-            getZmin().updateMinMaxL2(minMax, 20 + Terrain.getHeightOffsetL2(provider.seed(), cx, cz - 1));
-            getZmax().updateMinMaxL2(minMax, 20 + Terrain.getHeightOffsetL2(provider.seed(), cx, cz + 1));
-
-            getXmax().getZmin().updateMinMaxL2(minMax, 25 + Terrain.getHeightOffsetL2(provider.seed(), cx + 1, cz - 1));
-            getXmax().updateMinMaxL2(minMax, 20 + Terrain.getHeightOffsetL2(provider.seed(), cx + 1, cz));
-            getXmax().getZmax().updateMinMaxL2(minMax, 25 + Terrain.getHeightOffsetL2(provider.seed(), cx + 1, cz + 1));
-            desiredTerrainCorrectionHeights = minMax;
-        }
-        return desiredTerrainCorrectionHeights;
-    }
-
-    public void updateMinMaxL2(MinMax minMax, int offs) {
-        MinMax h = getDesiredMaxHeightL1();
-        if ((h.min - offs) < minMax.min) {
-            minMax.min = h.min - offs;
-        }
-        if ((h.max + offs) < minMax.max) {
-            minMax.max = h.max + offs;
-        }
-    }
-
-
-    private void updateMinMaxL1(MinMax minMax, int offs) {
-        int h = getLowestCityHeightAtChunkCorner();
-        if ((h - offs) < minMax.min) {
-            minMax.min = h - offs;
-        }
-        if ((h + offs) < minMax.max) {
-            minMax.max = h + offs;
-        }
-    }
-
-
-    /**
-     * How a chunk with no building renders: a planned road is {@link #NORMAL} paving, an open lot is
-     * the {@link #PARK} grass surface. Nothing else decides between them - in particular the open-lot
-     * park chance does not, it only furnishes a lot that is already grass. There is no third surface:
-     * the old {@code FULL} type was reachable only from a coin flip the road field replaced.
-     */
-    public enum StreetType {
-        NORMAL,
-        PARK
-    }
-
 
     public boolean isCity() {
         return this.isCity;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -294,220 +294,35 @@ public class ChunkPlan {
 
     // Version for usage inside the gui
     public static boolean hasBuildingGui(int chunkX, int chunkZ, PlanningContext provider, ChunkCandidate candidate) {
-//        Random rand = getBuildingRandom(chunkX, chunkZ, provider.seed());
-//        rand.nextFloat();       // Compatibility?
-
-        return candidate.couldHaveBuilding();
+        return ChunkCandidates.hasBuildingGui(chunkX, chunkZ, provider, candidate);
     }
 
     public static ChunkCandidate getChunkCandidateGui(ChunkCoord key, PlanningContext provider) {
-//        ChunkCandidate cached = CITY_INFO_MAP.get(key);
-//        if (cached != null) {
-//            return cached;
-//        }
-        int chunkX = key.chunkX();
-        int chunkZ = key.chunkZ();
-        Preset profile = provider.preset();
-
-        boolean isCity = CityField.isCityRaw(key, provider, profile);
-        int cityLevel = CityField.cityLevelUncached(key, provider);
-        RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
-        boolean couldHaveBuilding = isCity && rand.nextFloat() < profile.buildingChance();
-        // The preview resolves neither a multi-building section nor a style, exactly as before -
-        // those three stay null here rather than being computed for a screen that does not use them.
-        return new ChunkCandidate(isCity, couldHaveBuilding, null, cityLevel, null, null, null);
+        return ChunkCandidates.candidateUncached(key, provider);
     }
 
-    /**
-     * Not synchronized: the candidate of a chunk are a pure function of the seed and the
-     * coordinate, so two threads racing on the same coordinate compute the same answer and one of
-     * them simply loses the putIfAbsent below. Locking here would be a deadlock waiting to happen -
-     * this method reaches its neighbours' city styles, which reach back here.
-     */
     public static ChunkCandidate getChunkCandidate(ChunkCoord coord, PlanningContext provider) {
-        ChunkCandidate cached = provider.caches().candidate.get(coord);
-        if (cached != null) {
-            return cached;
-        }
-        int chunkX = coord.chunkX();
-        int chunkZ = coord.chunkZ();
-        Preset profile = provider.preset();
-
-        // Computed into locals and constructed once at the end. This used to assemble a mutable
-        // object field by field and hand the half-built thing to its own helpers; the record cannot
-        // be published half-built, which is the point (issue #126).
-        boolean isCity = CityField.isCityRaw(coord, provider, profile);
-
-        MultiSection section = isCity ? multiBuildingSection(coord, provider, profile) : MultiSection.NONE;
-        MultiPos multiPos = section.pos();
-        MultiBuilding multiBuilding = section.building();
-
-        int cityLevel;
-        if (multiPos.isSingle()) {
-            cityLevel = CityField.getCityLevel(coord, provider);
-        } else {
-            cityLevel = profile.multiUseCorner() ? getTopLeftCityLevel(multiPos, coord, provider)
-                    : getAverageCityLevel(multiPos, coord, provider);
-        }
-        RandomSource rand = getBuildingRandom(chunkX, chunkZ, provider.seed(), Rng.Purpose.BUILDING);
-        boolean couldHaveBuilding = ChunkContentResolver.couldHaveBuilding(profile,
-                isCity, multiPos, cityLevel, rand,
-                chunkFacts(coord, provider, profile));
-
-        CityStyle cityStyle;
-        // If this is a street we find other chunks connected to this and pick the cityStyle
-        // that represents the majority. This is to prevent streets from switching style randomly if two
-        // different styled cities mix
-        if (isCity && !couldHaveBuilding) {
-            // Counted by Identifier, not by the id's String form. A tie is the ordinary case at a
-            // style boundary (ten votes: 3x3 neighbours plus the centre twice), and
-            // Counter.getMostOccuring() breaks ties on a stated rule rather than HashMap bucket
-            // order. That rule is Identifier's own order - path, then namespace - which is what
-            // MultiChunk's city-style sort already uses; tie-breaking on toString() instead would
-            // order the same asset kind namespace-first here and path-first there, and the two
-            // disagree as soon as a second namespace ships a city style.
-            Counter<Identifier> counter = new Counter<>();
-            for (int cx = -1; cx <= 1; cx++) {
-                for (int cz = -1; cz <= 1; cz++) {
-                    ChunkCoord key = coord.offset(cx, cz);
-                    cityStyle = City.getCityStyle(key, provider, profile);
-                    counter.add(cityStyle.getId());
-                    if (cx == 0 && cz == 0) {
-                        counter.add(cityStyle.getId());   // Add this chunk again for a bias
-                    }
-                }
-            }
-            cityStyle = provider.assets().cityStyles().get(counter.getMostOccuring(Comparator.naturalOrder()));
-        } else {
-            cityStyle = City.getCityStyle(coord, provider, profile);
-        }
-        Building buildingType;
-        if (multiPos.isMulti() && !multiPos.isTopLeft()) {
-            if (multiBuilding != null) {
-                String b = multiBuilding.getBuilding(multiPos.x(), multiPos.z());
-                buildingType = provider.assets().buildings().getOrThrow(b);
-            } else {
-                // @todo is this even possible?
-                buildingType = getTopLeftCityInfo(multiPos, coord, provider).buildingType();
-                if (buildingType == null) {
-                    throw new RuntimeException("Topleft building type is not set!");
-                }
-            }
-        } else {
-            PredefinedBuilding predefinedBuilding = City.getPredefinedBuildingAtTopLeft(provider, coord);
-            if (multiPos.isTopLeft()) {
-                String b = multiBuilding.getBuilding(0, 0);
-                buildingType = provider.assets().buildings().getOrThrow(b);
-            } else {
-                String name = cityStyle.getRandomBuilding(rand, coord);
-                if (predefinedBuilding != null) {
-                    name = predefinedBuilding.building();
-                }
-                if (name == null) {
-                    throw new RuntimeException("Invalid building for multibuilding!");
-                }
-                buildingType = provider.assets().buildings().getOrThrow(name);
-            }
-        }
-
-        ChunkCandidate candidate = new ChunkCandidate(isCity, couldHaveBuilding,
-                multiPos, cityLevel, cityStyle, multiBuilding, buildingType);
-        ChunkCandidate raced = provider.caches().candidate.putIfAbsent(coord, candidate);
-        return raced != null ? raced : candidate;
+        return ChunkCandidates.candidate(coord, provider);
     }
 
     public static boolean isCity(ChunkCoord coord, PlanningContext provider) {
-        return getChunkCandidate(coord, provider).isCity();
+        return ChunkCandidates.candidate(coord, provider).isCity();
     }
 
-    /**
-     * The road a chunk actually renders: the raw {@link dev.krona.urbex.plan.RoadField} clipped to
-     * the city mask. A road needs its own chunk to be raw city and at least one chunk it connects to
-     * to be raw city as well, which is what removes the isolated one-chunk stubs a city mask's
-     * protrusions would otherwise leave behind.
-     *
-     * <p>Static and raw-city-only on purpose. This is consulted while the chunk candidate are
-     * still being computed, so it may not read anything that depends on a building decision - its
-     * own or a neighbour's - or the decision graph stops being acyclic.
-     */
     public static RoadType effectiveRoadType(ChunkCoord coord, PlanningContext provider, Preset profile) {
-        // The city test comes first, and it is not a matter of taste. Every chunk in the world builds
-        // a ChunkPlan, and the great majority of them are wilderness; asking the road field first
-        // would build the block layout five times over - once for this chunk and once per neighbour
-        // probe, each one sorting a candidate list with a comparator that hashes twice per comparison
-        // - only for the clip below to throw the answer away. EffectiveRoad.resolve returns NONE for
-        // a non-city chunk whatever the field said, so hoisting the test cannot change the answer.
-        if (!CityField.isCityRaw(coord, provider, profile)) {
-            return RoadType.NONE;
-        }
-        RoadCell cell = provider.roadField().at(coord.chunkX(), coord.chunkZ());
-        boolean connectedCityNeighbour = false;
-        for (RoadDirection direction : RoadDirection.values()) {
-            if (cell.connects(direction)) {
-                ChunkCoord adjacent = coord.offset(direction.stepX(), direction.stepZ());
-                if (CityField.isCityRaw(adjacent, provider, profile)) {
-                    connectedCityNeighbour = true;
-                    break;
-                }
-            }
-        }
-        // isCity is true: the early return above is the only way past this point.
-        return EffectiveRoad.resolve(cell.type(), true, connectedCityNeighbour, false);
+        return ChunkCandidates.effectiveRoadType(coord, provider, profile);
     }
 
-    /**
-     * The world lookups {@link ChunkContentResolver#couldHaveBuilding} may need, each still behind a
-     * supplier so the decision keeps its short-circuiting: consulting {@link Highway} or
-     * {@link Railway} for a chunk whose building roll already failed would be new work, and
-     * {@code Railway}'s chunk types are mutable state.
-     */
-    private static ChunkContentResolver.ChunkFacts chunkFacts(ChunkCoord coord, PlanningContext provider, Preset profile) {
-        return new ChunkContentResolver.ChunkFacts(
-                () -> City.getPredefinedBuildingAtTopLeft(provider, coord) != null,
-                () -> City.getPredefinedStreetAt(provider, coord) != null,
-                () -> City.getCityStyle(coord, provider, profile),
-                () -> effectiveRoadType(coord, provider, profile),
-                () -> hasHighway(coord, provider, profile),
-                () -> Math.max(Highway.getXHighwayLevel(coord, provider, profile), Highway.getZHighwayLevel(coord, provider, profile)),
-                () -> hasRailway(coord, provider, profile),
-                () -> Railway.getRailChunkType(coord, provider, profile));
+    public static boolean hasHighway(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        return ChunkCandidates.hasHighway(coord, provider, profile);
     }
 
-    /**
-     * Which multi-building section a chunk belongs to, if any. Returned rather than written into a
-     * half-built {@link ChunkCandidate} - see that type for why (issue #126).
-     *
-     * @param pos      {@link MultiPos#SINGLE} when this chunk is not part of a multi-building
-     * @param building null whenever {@code pos} is {@code SINGLE}
-     */
-    private record MultiSection(MultiPos pos, MultiBuilding building) {
-        static final MultiSection NONE = new MultiSection(MultiPos.SINGLE, null);
+    public static boolean hasRailway(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        return ChunkCandidates.hasRailway(coord, provider, profile);
     }
 
-    private static MultiSection multiBuildingSection(ChunkCoord coord, PlanningContext provider, Preset profile) {
-        // If a chunk is occupied according to City then there is a predefined building or street here.
-        // Try to look for it
-        if (City.isChunkOccupied(provider, coord)) {
-            PredefinedIndex.BuildingAt predefinedBuilding = City.getPredefinedBuilding(provider, coord);
-            if (predefinedBuilding != null) {
-                if (predefinedBuilding.building().multi()) {
-                    MultiBuilding building = provider.assets().multiBuildings().getOrThrow(predefinedBuilding.building().building());
-                    return new MultiSection(new MultiPos(predefinedBuilding.offsetX(), predefinedBuilding.offsetZ(),
-                            building.getDimX(), building.getDimZ()), building);
-                }
-            }
-            return MultiSection.NONE;
-        }
-
-        MultiChunk multiChunk = MultiChunk.getOrCreate(provider, coord);
-        MultiChunk.MB multiBuilding = multiChunk.getMultiBuilding(coord);
-        if (multiBuilding == null) {
-            return MultiSection.NONE;
-        }
-
-        MultiBuilding building = provider.assets().multiBuildings().getOrThrow(multiBuilding.name());
-        return new MultiSection(new MultiPos(multiBuilding.offsetX(), multiBuilding.offsetZ(),
-                building.getDimX(), building.getDimZ()), building);
+    public static boolean hasRailwayAtSurface(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        return ChunkCandidates.hasRailwayAtSurface(coord, provider, profile);
     }
 
     private ChunkPlan calculateTopLeft() {
@@ -516,49 +331,6 @@ public class ChunkPlan {
         }
         ChunkCoord key = coord.offset(-multiBuildingPos.x(), -multiBuildingPos.z());
         return getChunkPlan(key, provider);
-    }
-
-    private static int getAverageCityLevel(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
-        int level = 0;
-        int topX = coord.chunkX() - mp.x();
-        int topZ = coord.chunkZ() - mp.z();
-        for (int x = 0; x < mp.w(); x++) {
-            for (int z = 0; z < mp.h(); z++) {
-                ChunkCoord key = new ChunkCoord(provider.dimension(), topX + x, topZ + z);
-                level += CityField.getCityLevel(key, provider);
-            }
-        }
-        return level / (mp.w() * mp.h());
-    }
-
-    private static int getTopLeftCityLevel(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
-        int topX = coord.chunkX() - mp.x();
-        int topZ = coord.chunkZ() - mp.z();
-        ChunkCoord key = new ChunkCoord(provider.dimension(), topX, topZ);
-        return CityField.getCityLevel(key, provider);
-    }
-
-    /**
-     * The candidate of this multi-building's top-left chunk. Only reached from the one branch
-     * that needs the top-left's building type, and only when {@code mp} is not itself the top left -
-     * the caller has no half-built object to hand back for that case any more, and does not need one.
-     */
-    private static ChunkCandidate getTopLeftCityInfo(MultiPos mp, ChunkCoord coord, PlanningContext provider) {
-        ChunkCoord key = coord.offset(-mp.x(), -mp.z());
-        return getChunkCandidate(key, provider);
-    }
-
-    public static boolean hasHighway(ChunkCoord coord, PlanningContext provider, Preset profile) {
-        return Highway.getXHighwayLevel(coord, provider, profile) >= 0 || Highway.getZHighwayLevel(coord, provider, profile) >= 0;
-    }
-
-    public static boolean hasRailway(ChunkCoord coord, PlanningContext provider, Preset profile) {
-        return Railway.getRailChunkType(coord, provider, profile).getType() != RailChunkType.NONE;
-    }
-
-    public static boolean hasRailwayAtSurface(ChunkCoord coord, PlanningContext provider, Preset profile) {
-        RailChunkType type = Railway.getRailChunkType(coord, provider, profile).getType();
-        return type.isSurface() || type.isStation();
     }
 
     public Railway.RailChunkInfo getRailInfo() {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -55,7 +55,7 @@ public class ChunkPlan {
     public final BuildingPart bridgeType;
     public final BuildingPart stairType;
     public final BuildingPart frontType;
-    private final float stairPriority;      // A random number that indicates if this chunk should get a stair if there are competing stairs around it. The highest wins
+    final float stairPriority;      // A random number that indicates if this chunk should get a stair if there are competing stairs around it. The highest wins
     public final BuildingPart railDungeon;    // Dungeon next to rails. Will only generate if there are actually rails next to it
     public final StreetType streetType;
     private final RoadType effectiveRoad;   // The planned road this chunk renders, NONE for most chunks
@@ -103,13 +103,8 @@ public class ChunkPlan {
     /** This chunk's bridge decisions and the state memoising them; see {@link BridgeDecisions}. */
     final BridgeDecisions bridges = new BridgeDecisions(this);
 
-    private volatile boolean streetSlopeCalculated = false;
-    private volatile Direction streetSlopeDirection;
-
-    private volatile boolean stairsCalculated = false;
-    private volatile Direction stairDirection;
-    private volatile boolean actualStairsCalculated = false;
-    private volatile Direction actualStairDirection;
+    /** Which way this chunk's street slopes and where its stairs face; see {@link SlopeDecisions}. */
+    final SlopeDecisions slopes = new SlopeDecisions(this);
 
     private volatile MinMax desiredTerrainCorrectionHeights = null;
     private volatile MinMax desiredMaxHeight1 = null;
@@ -958,12 +953,12 @@ public class ChunkPlan {
     }
 
     /** A chunk that renders a planned road of some class, rather than a lot, a park or a building. */
-    private boolean isPlannedRoadSection() {
+    boolean isPlannedRoadSection() {
         return isCity && !hasBuilding && effectiveRoad != RoadType.NONE;
     }
 
     /** A planned road below primary: the only roads allowed to slope. */
-    private boolean isMinorRoadSection() {
+    boolean isMinorRoadSection() {
         return isPlannedRoadSection() && effectiveRoad != RoadType.PRIMARY;
     }
 
@@ -984,59 +979,11 @@ public class ChunkPlan {
      */
     @Nullable
     public Direction getStreetSlopeDirection() {
-        if (streetSlopeCalculated) {
-            return streetSlopeDirection;
-        }
-        Direction direction = computeStreetSlopeDirection();
-        // Value first, then the flag: a reader that sees the flag set must see the value.
-        streetSlopeDirection = direction;
-        streetSlopeCalculated = true;
-        return direction;
+        return slopes.streetSlope();
     }
 
-    @Nullable
-    private Direction computeStreetSlopeDirection() {
-        if (!isMinorRoadSection()) {
-            return null;
-        }
-        Direction slopeDirection = null;
-        for (Direction direction : Direction.VALUES) {
-            ChunkPlan adjacent = direction.get(this);
-            if (adjacent.isMinorRoadSection() && adjacent.cityLevel == cityLevel + 1) {
-                if (slopeDirection != null) {
-                    // Two ways up out of one chunk: which one the ramp should face is not decided.
-                    return null;
-                }
-                slopeDirection = direction;
-            }
-        }
-        if (slopeDirection == null) {
-            return null;
-        }
-
-        ChunkPlan upper = slopeDirection.get(this);
-        ChunkPlan approach = slopeDirection.getOpposite().get(this);
-        if (!approach.isMinorRoadSection() || approach.cityLevel != cityLevel) {
-            return null;
-        }
-        ChunkPlan departure = slopeDirection.get(upper);
-        if (!departure.isMinorRoadSection() || departure.cityLevel != upper.cityLevel) {
-            return null;
-        }
-
-        for (Direction direction : Direction.VALUES) {
-            if (direction != slopeDirection && direction != slopeDirection.getOpposite()) {
-                ChunkPlan side = direction.get(this);
-                if (side.isPlannedRoadSection() && side.cityLevel == cityLevel) {
-                    return null;
-                }
-                ChunkPlan upperSide = direction.get(upper);
-                if (upperSide.isPlannedRoadSection() && upperSide.cityLevel == upper.cityLevel) {
-                    return null;
-                }
-            }
-        }
-        return slopeDirection;
+    public Direction getActualStairDirection() {
+        return slopes.actualStair();
     }
 
     public boolean isElevatedParkSection() {
@@ -1055,57 +1002,6 @@ public class ChunkPlan {
         counter += getXmax().getZmax().isStreetOrParkSection() ? 1 : 0;
         return counter >= threshold;
     }
-
-    private Direction getStairDirection() {
-        if (stairsCalculated) {
-            return stairDirection;
-        }
-        Direction direction = null;
-        // A sloped chunk already carries the whole level change across its full width. The narrow
-        // stair decoration on top of it would be a second, contradictory way up.
-        if (getStreetSlopeDirection() == null && streetType != StreetType.PARK && !hasBuilding && isCity) {
-            if (cityLevel == getXmin().cityLevel - 1 && !getXmin().hasBuilding && getXmin().isCity) {
-                direction = Direction.XMIN;
-            } else if (cityLevel == getXmax().cityLevel - 1 && !getXmax().hasBuilding && getXmax().isCity) {
-                direction = Direction.XMAX;
-            } else if (cityLevel == getZmin().cityLevel - 1 && !getZmin().hasBuilding && getZmin().isCity) {
-                direction = Direction.ZMIN;
-            } else if (cityLevel == getZmax().cityLevel - 1 && !getZmax().hasBuilding && getZmax().isCity) {
-                direction = Direction.ZMAX;
-            }
-        }
-        // Value first, then the flag: a reader that sees the flag set must see the value.
-        stairDirection = direction;
-        stairsCalculated = true;
-        return direction;
-    }
-
-    // This returns the actual stair direction. It keeps track if there are stair chunks around
-    // it those have higher stair priority
-    public Direction getActualStairDirection() {
-        if (actualStairsCalculated) {
-            return actualStairDirection;
-        }
-        Direction direction = getStairDirection();
-        if (direction != null) {
-            for (int cx = -1; cx <= 1; cx++) {
-                for (int cz = -1; cz <= 1; cz++) {
-                    if (cx != 0 || cz != 0) {
-                        ChunkCoord key = coord.offset(cx, cz);
-                        ChunkPlan adjacent = getChunkPlan(key, provider);
-                        if (adjacent.getStairDirection() != null && adjacent.stairPriority > stairPriority) {
-                            direction = null;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        actualStairDirection = direction;
-        actualStairsCalculated = true;
-        return direction;
-    }
-
 
     /**
      * The planned primary bridge claiming this chunk, or {@code null}. Memoized because the border

--- a/src/main/java/dev/krona/urbex/worldgen/lost/CityField.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/CityField.java
@@ -1,0 +1,167 @@
+package dev.krona.urbex.worldgen.lost;
+
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.setup.Config;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.ChunkHeightmap;
+import dev.krona.urbex.worldgen.PlanningContext;
+
+/**
+ * Where a city is, and how high it sits.
+ *
+ * <p>Two questions answered at one coordinate: whether the city mask covers it at all, and which of
+ * the preset's nine level bands the terrain there falls into. They are one class because they are
+ * mutually recursive - averaging the heightmap over a neighbourhood only counts the neighbours that
+ * are themselves city - and because they are the same kind of thing: a pure function of the world
+ * seed and a chunk coordinate, with no dependency on any building decision.</p>
+ *
+ * <p><strong>Raw, and that is load-bearing.</strong> These are consulted while the chunk candidate
+ * graph is still being computed, so they must not read anything that depends on a building decision,
+ * its own or a neighbour's, or the graph stops being acyclic. {@code ChunkPlan.isCity} is the
+ * decided form and belongs to the layer above; this is the one underneath it.</p>
+ *
+ * <p>Split out of {@link ChunkPlan} (issue #11), which is where all of this lived along with
+ * everything else about a planned chunk.</p>
+ */
+public final class CityField {
+
+    private CityField() {
+    }
+
+    /**
+     * Don't use the cache as we're busy building the cache.
+     */
+    public static boolean isCityRaw(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        if (isVoidChunk(coord, provider)) {
+            // If we have a void chunk then no city here
+            return false;
+        }
+
+        float cityFactor = City.getCityFactor(coord, provider, profile);
+        return cityFactor > profile.cityThreshold();
+    }
+
+    public static boolean isVoidChunk(ChunkCoord coord, PlanningContext provider) {
+        if (provider.preset().isFloating()) {
+            return provider.heightmap(coord).getHeight() <= 0;
+        } else {
+            return false;
+        }
+    }
+
+
+    /**
+     * This function does not use the cache. So safe to use when the cache is building
+     * This function uses its own cache.
+     */
+    public static int getCityLevel(ChunkCoord key, PlanningContext provider) {
+        // Unconditional. This used to be gated on provider.getWorld() != null, "In LC preview we
+        // don't want to use the cache as the config isn't loaded yet" - a guard from when the
+        // preview shared the dimension's caches. It has held its own DimensionCaches, built from
+        // its own seed and dropped with it, since #125; and the value cached here is a pure function
+        // of the seed and the preset, both of which are fixed for one preview.
+        Integer cached = provider.caches().cityLevel.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        int result;
+        if (provider.preset().isFloating()) {
+            result = getCityLevelFloating(key, provider);
+        } else if (provider.preset().isCavern()) {
+            result =  getCityLevelCavern(key, provider);
+        } else {
+            result = getCityLevelNormal(key, provider, provider.preset());
+        }
+        Integer raced = provider.caches().cityLevel.putIfAbsent(key, result);
+        if (raced != null) {
+            return raced;
+        }
+        return result;
+    }
+
+    public static int cityLevelUncached(ChunkCoord key, PlanningContext provider) {
+        int result;
+        if (provider.preset().isFloating()) {
+            result = getCityLevelFloating(key, provider);
+        } else if (provider.preset().isCavern()) {
+            result =  getCityLevelCavern(key, provider);
+        } else {
+            result = getCityLevelNormal(key, provider, provider.preset());
+        }
+        return result;
+    }
+
+    private static int getCityLevelCavern(ChunkCoord coord, PlanningContext provider) {
+        // @todo for now
+        return getCityLevelFloating(coord, provider);
+    }
+
+
+    private static int getCityLevelNormal(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        ChunkHeightmap heightmap = provider.heightmap(coord);
+        int height = heightmap.getHeight();
+        if (profile.useAvgHeightmap() && Config.heightSampleSize() > 2) {
+            int sampleSize = Config.heightSampleSize();
+            int constX = coord.chunkX() < 0 ? -1 : 1;
+            int constZ = coord.chunkZ() < 0 ? -1 : 1;
+            int chunkBaseX =  (coord.chunkX() / sampleSize) * sampleSize + (sampleSize / 2 * constX);
+            int chunkBaseZ =  (coord.chunkZ() / sampleSize) * sampleSize + (sampleSize / 2 * constZ);
+            int chunkLeft = ((coord.chunkX() / sampleSize) - 1) * sampleSize + (sampleSize / 2 * constX);
+            int chunkRight = ((coord.chunkX() / sampleSize) + 1) * sampleSize + (sampleSize / 2 * constX);
+            int chunkUp = ((coord.chunkZ() / sampleSize) - 1) * sampleSize + (sampleSize / 2 * constZ);
+            int chunkDown = ((coord.chunkZ() / sampleSize) + 1) * sampleSize + (sampleSize / 2 * constZ);
+            ChunkCoord left = new ChunkCoord(provider.dimension(), chunkLeft, chunkBaseZ);
+            ChunkCoord right = new ChunkCoord(provider.dimension(), chunkRight, chunkBaseZ);
+            ChunkCoord up = new ChunkCoord(provider.dimension(), chunkBaseX, chunkUp);
+            ChunkCoord down = new ChunkCoord(provider.dimension(), chunkBaseX, chunkDown);
+            int avgHeightmap = height;
+            int counter = 1;
+            if (isCityRaw(left, provider, profile)) {
+                avgHeightmap += provider.heightmap(left).getHeight();
+                counter++;
+            }
+            if (isCityRaw(right, provider, profile)) {
+                avgHeightmap += provider.heightmap(right).getHeight();
+                counter++;
+            }
+            if (isCityRaw(up, provider, profile)) {
+                avgHeightmap += provider.heightmap(up).getHeight();
+                counter++;
+            }
+            if (isCityRaw(down, provider, profile)) {
+                avgHeightmap += provider.heightmap(down).getHeight();
+                counter++;
+            }
+            avgHeightmap /= counter;
+            return getLevelBasedOnHeight(avgHeightmap, profile);
+        }
+        return getLevelBasedOnHeight(height, profile);
+    }
+
+    private static int getCityLevelFloating(ChunkCoord coord, PlanningContext provider) {
+        int h = provider.heightmap(coord).getHeight();
+        return getLevelBasedOnHeight(h, provider.preset());
+    }
+
+    private static int getLevelBasedOnHeight(int height, Preset profile) {
+        if (height < profile.cityLevel0Height()) {
+            return 0;
+        } else if (height < profile.cityLevel1Height()) {
+            return 1;
+        } else if (height < profile.cityLevel2Height()) {
+            return 2;
+        } else if (height < profile.cityLevel3Height()) {
+            return 3;
+        } else if (height < profile.cityLevel4Height()) {
+            return 4;
+        } else if (height < profile.cityLevel5Height()) {
+            return 5;
+        } else if (height < profile.cityLevel6Height()) {
+            return 6;
+        } else if (height < profile.cityLevel7Height()) {
+            return 7;
+        } else {
+            return 8;
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ConnectionGraph.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ConnectionGraph.java
@@ -1,0 +1,240 @@
+package dev.krona.urbex.worldgen.lost;
+
+import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
+
+/**
+ * What this chunk joins on to.
+ *
+ * <p>Corridors and rails passing through, roads extending outwards, and - the bulk of it - which
+ * floors of a building line up with the floors of the building next door, so a doorway cut in one
+ * opens onto something rather than onto air.</p>
+ *
+ * <p>Every answer is about a pair of chunks, which is why it is worth its own type: these read the
+ * neighbour's plan and its floor list, and reading them off {@link ChunkPlan} made the class both
+ * the thing being asked about and the thing doing the asking. Nothing here is memoised - the
+ * answers are cheap and the inputs are already fixed (issue #11).</p>
+ */
+final class ConnectionGraph {
+
+    private final ChunkPlan plan;
+
+    ConnectionGraph(ChunkPlan plan) {
+        this.plan = plan;
+    }
+
+    boolean xCorridor() {
+        if (!plan.xRailCorridor) {
+            return false;
+        }
+        ChunkPlan i = plan.getXmin();
+        while (i.canRailGoThrough() && i.xRailCorridor) {
+            i = i.getXmin();
+        }
+        if ((!i.hasBuilding) || i.cellars == 0) {
+            return false;
+        }
+        i = plan.getXmax();
+        while (i.canRailGoThrough() && i.xRailCorridor) {
+            i = i.getXmax();
+        }
+        return !((!i.hasBuilding) || i.cellars == 0);
+    }
+
+    boolean zCorridor() {
+        if (!plan.zRailCorridor) {
+            return false;
+        }
+        ChunkPlan i = plan.getZmin();
+        while (i.canRailGoThrough() && i.zRailCorridor) {
+            i = i.getZmin();
+        }
+        if ((!i.hasBuilding) || i.cellars == 0) {
+            return false;
+        }
+        i = plan.getZmax();
+        while (i.canRailGoThrough() && i.zRailCorridor) {
+            i = i.getZmax();
+        }
+        return !((!i.hasBuilding) || i.cellars == 0);
+    }
+
+    // Return true if it is possible for a rail section to go through here
+    boolean canRailGoThrough() {
+        if (!plan.isCity) {
+            // There is no city here so no passing possible
+            return false;
+        }
+        if (!plan.hasBuilding) {
+            // There is no building here but we have a city so we can pass
+            return true;
+        }
+        // Otherwise we can only pass if this building has no floors below ground
+        return plan.cellars == 0;
+    }
+
+    // Return true if it is possible for a water corridor to go through here
+    boolean canWaterCorridorGoThrough() {
+        if (!plan.isCity) {
+            // There is no city here so no passing possible
+            return false;
+        }
+        if (!plan.hasBuilding) {
+            // There is no building here but we have a city so we can pass
+            return true;
+        }
+        // Otherwise we can only pass if this building has at most one floor below ground
+        return plan.cellars <= 1;
+    }
+
+    // Return true if the road from a neighbouring chunk can extend into this chunk
+    boolean roadExtendsOut() {
+        boolean b = plan.isCity && !plan.hasBuilding;
+        if (b) {
+            return !plan.isElevatedParkSection();
+        }
+        return false;
+    }
+
+    // Return true if there can be a road connection between the two given chunks
+    static boolean hasRoadConnection(ChunkPlan i1, ChunkPlan i2) {
+        if (!i1.doesRoadExtendTo()) {
+            return false;
+        }
+        if (!i2.doesRoadExtendTo()) {
+            return false;
+        }
+        if (i1.cityLevel == i2.cityLevel) {
+            return true;
+        }
+        // A one-level difference only connects where a slope actually bridges it. Reading the slope
+        // rather than merely allowing a difference of one is what keeps the upper road drawing
+        // through to its edge exactly over the ramp, and ending in a kerb everywhere else.
+        Direction slope1 = i1.getStreetSlopeDirection();
+        if (slope1 != null && slope1.get(i1).coord.equals(i2.coord)) {
+            return true;
+        }
+        Direction slope2 = i2.getStreetSlopeDirection();
+        return slope2 != null && slope2.get(i2).coord.equals(i1.coord);
+    }
+
+    /**
+     * A stream for one of the per-chunk building decisions.
+     * <p>
+     * The purpose is the caller's because three independent decisions are made at this one
+     * coordinate - whether a building is here at all, which parts its floors use, and whether a
+     * lonely neighbour suppresses it - and each of them reads draw 1. Sharing a purpose made the
+     * building chance and the loneliness roll literally the same number.
+     */
+    boolean at(int level, Orientation orientation) {
+        return switch (orientation) {
+            case X -> atX(level);
+            case Z -> atZ(level);
+        };
+    }
+
+    // Call this from the street reference with the (potential building) as 'adj'
+    // 'streetLevel' is the plan.cityLevel at the position of the street
+    boolean frontPartFrom(ChunkPlan adj) {
+        ChunkPlan.StreetType st = plan.streetType;
+        boolean elevated = plan.isElevatedParkSection();
+        if (elevated) {
+            st = ChunkPlan.StreetType.PARK;
+        }
+
+        if (adj.hasBuilding && adj.frontType != null && st == ChunkPlan.StreetType.NORMAL && plan.cityLevel < adj.cityLevel + adj.getNumFloors()) {
+            RailChunkType type = plan.getRailInfo().getType();
+            if (type == RailChunkType.STATION_UNDERGROUND) {
+                return false;
+            }
+            if (type == RailChunkType.GOING_DOWN_ONE_FROM_SURFACE) {
+                return false;
+            }
+            if (plan.getMaxHighwayLevel() >= 0) {
+                return false;
+            }
+
+            int local = adj.globalToLocal(plan.cityLevel);
+            if (adj.isValidFloor(local) && adj.getFloor(local).getMetaBoolean(BuildingPart.META_DONTCONNECT)) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+
+    // This checks if there can be a connection at minX
+    boolean atX(int level) {
+        if (!plan.isCity) {
+            return false;
+        }
+        if (plan.multiBuildingPos.isRightSide()) {
+            return false;
+        }
+        if (level < 0 || level >= plan.connectionAtX.length) {
+            return false;
+        }
+        if (level < plan.floorTypes.length && plan.floorTypes[level].getMetaBoolean(BuildingPart.META_DONTCONNECT)) {
+            return false;       // No connection supported
+        }
+        if (plan.getXmin().hasFrontPartFrom(plan)) {
+            return true;
+        }
+        return plan.connectionAtX[level];
+    }
+
+    // This checks if there can be a connection at minX
+    boolean atXFromStreet(int level) {
+        if (!plan.isCity) {
+            return false;
+        }
+        if (plan.multiBuildingPos.isRightSide()) {
+            return false;
+        }
+        if (level < 0 || level >= plan.connectionAtX.length) {
+            return false;
+        }
+        if (frontPartFrom(plan.getXmin())) {
+            return true;
+        }
+        return plan.connectionAtX[level];
+    }
+
+    // This checks if there can be a connection at minZ
+    boolean atZ(int level) {
+        if (!plan.isCity) {
+            return false;
+        }
+        if (plan.multiBuildingPos.isBottomSide()) {
+            return false;
+        }
+        if (level < 0 || level >= plan.connectionAtZ.length) {
+            return false;
+        }
+        if (level < plan.floorTypes.length && plan.floorTypes[level].getMetaBoolean(BuildingPart.META_DONTCONNECT)) {
+            return false;       // No connection supported
+        }
+        if (plan.getZmin().hasFrontPartFrom(plan)) {
+            return true;
+        }
+        return plan.connectionAtZ[level];
+    }
+
+    // This checks if there can be a connection at minZ
+    boolean atZFromStreet(int level) {
+        if (!plan.isCity) {
+            return false;
+        }
+        if (plan.multiBuildingPos.isBottomSide()) {
+            return false;
+        }
+        if (level < 0 || level >= plan.connectionAtZ.length) {
+            return false;
+        }
+        if (frontPartFrom(plan.getZmin())) {
+            return true;
+        }
+        return plan.connectionAtZ[level];
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/HeightDecisions.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/HeightDecisions.java
@@ -1,0 +1,217 @@
+package dev.krona.urbex.worldgen.lost;
+
+
+import dev.krona.urbex.varia.Rng;
+import dev.krona.urbex.worldgen.CityGenerator;
+import dev.krona.urbex.worldgen.gen.Terrain;
+import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
+
+/**
+ * How high this chunk's city sits, and how far the terrain around it has to move to meet it.
+ *
+ * <p>Two memoised answers. {@code desiredMaxHeightL1} is what this chunk alone wants; the L2 form
+ * widens it by consulting the neighbours, which is what stops a building and the street beside it
+ * asking the terrain for two different things. Both are held per plan because the terrain-correction
+ * pass asks for them once per column.</p>
+ *
+ * <p>Split out of {@link ChunkPlan} with the state it memoises (issue #11), for the same reason as
+ * {@link BridgeDecisions} and {@link SlopeDecisions}: resolving one chunk's answer reads its
+ * neighbours', so the fields and the walk over them are one thing.</p>
+ */
+final class HeightDecisions {
+
+    private final ChunkPlan plan;
+
+    private volatile ChunkPlan.MinMax correctionHeights = null;
+    private volatile ChunkPlan.MinMax maxHeightL1 = null;
+
+    HeightDecisions(ChunkPlan plan) {
+        this.plan = plan;
+    }
+
+    int buildingBottom() {
+        int min = plan.provider.shape().minY() + 2;
+        int max = plan.provider.shape().maxY() - 1 - CityGenerator.FLOORHEIGHT;
+
+        // Locals. This used to decrement the published plan.cellars and plan.floors as it walked, so the answer
+        // depended on how many times it had been asked: the first call shrank the building and every
+        // later one measured the shrunken version, and a TimedCache eviction reset the count by
+        // rebuilding the object. It is the "building queries such as bottom-height calculation mutate
+        // plan.floors/plan.cellars during consumption" defect in issue #126, and the only reason the fields it
+        // touched could not be final.
+        int remainingCellars = plan.cellars;
+        int lowestLevel = plan.getCityGroundLevel() - remainingCellars * CityGenerator.FLOORHEIGHT;
+
+        // Fix lowest level so it goes above minimum build height
+        while (lowestLevel <= min) {
+            lowestLevel += CityGenerator.FLOORHEIGHT;
+            remainingCellars--;
+            if (remainingCellars < 0) {
+                return Integer.MIN_VALUE;     // Bail out, this is a degenerate case
+            }
+        }
+
+        // Contributes nothing but the degenerate bail-out: the height returned is the cellar walk's.
+        int remainingFloors = plan.floors;
+        while (plan.getCityGroundLevel() + remainingFloors * CityGenerator.FLOORHEIGHT >= max) {
+            remainingFloors--;
+            if (remainingFloors < 0) {
+                return Integer.MIN_VALUE;     // Bail out, this is a degenerate case
+            }
+        }
+        return lowestLevel;
+    }
+
+    /**
+     * Return the building part at a given y value. Return null if there is no building part at that level
+     */
+    BuildingPart floorAtY(int lowestLevel, int y) {
+        if (y < lowestLevel || y >= lowestLevel + (plan.floors + plan.cellars + 1) * CityGenerator.FLOORHEIGHT) {
+            return null;    // No building part at this level
+        }
+        int localY = (y - lowestLevel) / CityGenerator.FLOORHEIGHT;
+        if (localY < 0 || localY >= plan.floorTypes.length) {
+            return null;    // No building part at this level
+        }
+        return plan.floorTypes[localY];
+    }
+
+    /**
+     * Get the lowest height of a corner of four chunks (if it is a city chunk).
+     * info: reference to the bottom-right chunk. The 0,0 position of this chunk is the reference.
+     * Returns 100000 if the corner is not adjacent to any city chunk
+     * Also returns 100000 if all corners are city or landscape chunks (as
+     * this kind of corner should also have no effect on the landscape beyond those chunks)
+     * This is the level 0 version which looks at current chunk corner only
+     */
+    int lowestCityHeightAtCorner() {
+        ChunkPlan info00 = plan.getXmin().getZmin();
+        ChunkPlan info01 = plan.getXmin();
+        ChunkPlan info10 = plan.getZmin();
+        if (plan.isCity && info10.isCity && info00.isCity && info01.isCity) {
+            return 100000;
+        }
+        if (!plan.isCity && !info10.isCity && !info00.isCity && !info01.isCity) {
+            return 100000;
+        }
+        // If we come here we have a mix of city and normal chunks
+        int h = cityHeightForChunk();
+        h = Math.min(h, info01.getCityHeightForChunk());
+        h = Math.min(h, info10.getCityHeightForChunk());
+        h = Math.min(h, info00.getCityHeightForChunk());
+        return h;
+    }
+
+    /*
+     * This is used for correcting the terrain and indicates the desired
+     * level to which adjacent terrains should interpolate
+     */
+    int cityHeightForChunk() {
+        if (plan.isCity) {
+            return plan.getCityGroundLevel();
+        } else {
+            if (plan.isOcean()) {
+                return plan.groundLevel - plan.profile.oceanCorrectionBorder();
+            } else {
+                return 100000;
+            }
+        }
+    }
+
+    /**
+     * Given adjacent (city) chunks, calculate the desired height to interpolate the
+     * landscape to (minimum/maximum). This is calculated for the reference position of this chunk (0,0 point)
+     * This is the level 1 version which looks at adjacent heights only
+     */
+    private ChunkPlan.MinMax desiredMaxHeightL1() {
+        if (maxHeightL1 == null) {
+            int h = lowestCityHeightAtCorner();
+
+            int cx = plan.coord.chunkX();
+            int cz = plan.coord.chunkZ();
+
+            // @todo build limit
+            if (h < plan.provider.shape().maxBuildHeight()) {
+                // The L0 height at this corner is fixed so we return that
+                maxHeightL1 = new ChunkPlan.MinMax(
+                        h + Terrain.getRandomizedOffset(plan.provider.seed(), cx, cz, plan.profile.terrainFixLowerMinOffset(), plan.profile.terrainFixLowerMaxOffset(), Rng.Purpose.TERRAIN_FIX_LOWER),
+                        h + Terrain.getRandomizedOffset(plan.provider.seed(), cx, cz, plan.profile.terrainFixUpperMinOffset(), plan.profile.terrainFixUpperMaxOffset(), Rng.Purpose.TERRAIN_FIX_UPPER));
+                return maxHeightL1;
+            }
+
+            ChunkPlan.MinMax minMax = new ChunkPlan.MinMax();
+
+            plan.getXmin().getZmin().heights.updateMinMaxL1(minMax, 25 + Terrain.getHeightOffsetL1(plan.provider.seed(), cx - 1, cz - 1));
+            plan.getXmin().heights.updateMinMaxL1(minMax, 20 + Terrain.getHeightOffsetL1(plan.provider.seed(), cx - 1, cz));
+            plan.getXmin().getZmax().heights.updateMinMaxL1(minMax, 25 + Terrain.getHeightOffsetL1(plan.provider.seed(), cx - 1, cz + 1));
+
+            plan.getZmin().heights.updateMinMaxL1(minMax, 20 + Terrain.getHeightOffsetL1(plan.provider.seed(), cx, cz - 1));
+            plan.getZmax().heights.updateMinMaxL1(minMax, 20 + Terrain.getHeightOffsetL1(plan.provider.seed(), cx, cz + 1));
+
+            plan.getXmax().getZmin().heights.updateMinMaxL1(minMax, 25 + Terrain.getHeightOffsetL1(plan.provider.seed(), cx + 1, cz - 1));
+            plan.getXmax().heights.updateMinMaxL1(minMax, 20 + Terrain.getHeightOffsetL1(plan.provider.seed(), cx + 1, cz));
+            plan.getXmax().getZmax().heights.updateMinMaxL1(minMax, 25 + Terrain.getHeightOffsetL1(plan.provider.seed(), cx + 1, cz + 1));
+
+            maxHeightL1 = minMax;
+        }
+        return maxHeightL1;
+    }
+
+
+    /**
+     * Given adjacent (city) chunks, calculate the desired height to interpolate the
+     * landscape too. This is calculated for the reference position of this chunk (0,0 point)
+     * This is the level 2 version which looks at L1 heights of adjacent chunks
+     */
+    ChunkPlan.MinMax desiredMaxHeightL2() {
+        if (correctionHeights == null) {
+            ChunkPlan.MinMax mm = desiredMaxHeightL1();
+            // @todo build limit
+            if (mm.min < plan.provider.shape().maxBuildHeight()) {
+                // The L1 height at this corner is fixed so we return that
+                correctionHeights = new ChunkPlan.MinMax(mm);
+                return correctionHeights;
+            }
+
+            int cx = plan.coord.chunkX();
+            int cz = plan.coord.chunkZ();
+
+            ChunkPlan.MinMax minMax = new ChunkPlan.MinMax();
+
+            plan.getXmin().getZmin().updateMinMaxL2(minMax, 25 + Terrain.getHeightOffsetL2(plan.provider.seed(), cx - 1, cz - 1));
+            plan.getXmin().updateMinMaxL2(minMax, 20 + Terrain.getHeightOffsetL2(plan.provider.seed(), cx - 1, cz));
+            plan.getXmin().getZmax().updateMinMaxL2(minMax, 25 + Terrain.getHeightOffsetL2(plan.provider.seed(), cx - 1, cz + 1));
+
+            plan.getZmin().updateMinMaxL2(minMax, 20 + Terrain.getHeightOffsetL2(plan.provider.seed(), cx, cz - 1));
+            plan.getZmax().updateMinMaxL2(minMax, 20 + Terrain.getHeightOffsetL2(plan.provider.seed(), cx, cz + 1));
+
+            plan.getXmax().getZmin().updateMinMaxL2(minMax, 25 + Terrain.getHeightOffsetL2(plan.provider.seed(), cx + 1, cz - 1));
+            plan.getXmax().updateMinMaxL2(minMax, 20 + Terrain.getHeightOffsetL2(plan.provider.seed(), cx + 1, cz));
+            plan.getXmax().getZmax().updateMinMaxL2(minMax, 25 + Terrain.getHeightOffsetL2(plan.provider.seed(), cx + 1, cz + 1));
+            correctionHeights = minMax;
+        }
+        return correctionHeights;
+    }
+
+    void updateMinMaxL2(ChunkPlan.MinMax minMax, int offs) {
+        ChunkPlan.MinMax h = desiredMaxHeightL1();
+        if ((h.min - offs) < minMax.min) {
+            minMax.min = h.min - offs;
+        }
+        if ((h.max + offs) < minMax.max) {
+            minMax.max = h.max + offs;
+        }
+    }
+
+
+    private void updateMinMaxL1(ChunkPlan.MinMax minMax, int offs) {
+        int h = lowestCityHeightAtCorner();
+        if ((h - offs) < minMax.min) {
+            minMax.min = h - offs;
+        }
+        if ((h + offs) < minMax.max) {
+            minMax.max = h + offs;
+        }
+    }
+
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Highway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Highway.java
@@ -97,20 +97,20 @@ public class Highway {
             if (higher.getCoord(orientation)-lower.getCoord(orientation) >= 5) {
                 boolean valid;
                 if (profile.highwayRequiresTwoCities()) {
-                    valid = ChunkPlan.isCityRaw(lower, provider, profile) && ChunkPlan.isCityRaw(higher, provider, profile);
+                    valid = CityField.isCityRaw(lower, provider, profile) && CityField.isCityRaw(higher, provider, profile);
                 } else {
-                    valid = ChunkPlan.isCityRaw(lower, provider, profile) || ChunkPlan.isCityRaw(higher, provider, profile);
+                    valid = CityField.isCityRaw(lower, provider, profile) || CityField.isCityRaw(higher, provider, profile);
                 }
                 if (valid) {
                     // We have at least one city. Valid highway:
                     level = switch (profile.highwayLevelFromCities()) {
-                        case 0 -> ChunkPlan.getCityLevel(lower, provider);
-                        case 1 -> Math.min(ChunkPlan.getCityLevel(lower, provider),
-                                ChunkPlan.getCityLevel(higher, provider));
-                        case 2 -> Math.max(ChunkPlan.getCityLevel(lower, provider),
-                                ChunkPlan.getCityLevel(higher, provider));
-                        case 3 -> (ChunkPlan.getCityLevel(lower, provider) +
-                                ChunkPlan.getCityLevel(higher, provider)) / 2;
+                        case 0 -> CityField.getCityLevel(lower, provider);
+                        case 1 -> Math.min(CityField.getCityLevel(lower, provider),
+                                CityField.getCityLevel(higher, provider));
+                        case 2 -> Math.max(CityField.getCityLevel(lower, provider),
+                                CityField.getCityLevel(higher, provider));
+                        case 3 -> (CityField.getCityLevel(lower, provider) +
+                                CityField.getCityLevel(higher, provider)) / 2;
                         default -> throw new RuntimeException("Bad value for 'highwayLevelFromCities'!");
                     };
                     for (ChunkCoord cc = lower; cc.getCoord(orientation) <= higher.getCoord(orientation); cc = cc.higher(orientation)) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/MultiChunk.java
@@ -85,7 +85,7 @@ public class MultiChunk {
         }
 
         ChunkCoord topleft = new ChunkCoord(mc.dimension(), mc.chunkX() * areasize, mc.chunkZ() * areasize);
-        int cityLevel = ChunkPlan.getCityLevel(topleft, provider);
+        int cityLevel = CityField.getCityLevel(topleft, provider);
 
         // Find all city styles in this multichunk and count them.
         //
@@ -232,7 +232,7 @@ public class MultiChunk {
                 RailChunkType type = railChunkInfo.getType();
                 boolean atSurface = type.isSurface() || type.isStation();
 
-                if (atSurface || !ChunkPlan.isCityRaw(coord, provider, profile) || ChunkPlan.hasHighway(coord, provider, profile)) {
+                if (atSurface || !CityField.isCityRaw(coord, provider, profile) || ChunkPlan.hasHighway(coord, provider, profile)) {
                     return false;
                 }
                 WorldSettings.RailwayAvoidance avoidance = provider.worldStyles().primary().getWorldSettings().railwayAvoidance();

--- a/src/main/java/dev/krona/urbex/worldgen/lost/PrimaryBridgePlanner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/PrimaryBridgePlanner.java
@@ -291,7 +291,7 @@ public final class PrimaryBridgePlanner {
 
             @Override
             public boolean isCity(ChunkCoord coord) {
-                return ChunkPlan.isCityRaw(coord, provider, provider.preset());
+                return CityField.isCityRaw(coord, provider, provider.preset());
             }
 
             @Override
@@ -302,7 +302,7 @@ public final class PrimaryBridgePlanner {
 
             @Override
             public int cityLevel(ChunkCoord coord) {
-                return ChunkPlan.getCityLevel(coord, provider);
+                return CityField.getCityLevel(coord, provider);
             }
 
             @Override

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
@@ -108,17 +108,17 @@ public class Railway {
         int mx = Math.floorMod(chunkX + 1, 20);       // The +1 to avoid having them on highways
         int mz = Math.floorMod(chunkZ + 1, 20);
         if (mx == 0 && mz == 10) {
-            if (!ChunkPlan.isCityRaw(key, provider, profile)) {
+            if (!CityField.isCityRaw(key, provider, profile)) {
                 // There is no city here. So no station. But we still need a railway. A station at this
                 // point will get a three line rail through it
                 if (profile.railwaysCanEnd()) {
                     // Check if there are stations at either side
-                    boolean cityEast = ChunkPlan.isCityRaw(key.offset(10, 0), provider, profile) ||
-                            ChunkPlan.isCityRaw(key.offset(10, - 10), provider, profile) ||
-                            ChunkPlan.isCityRaw(key.offset(10, 10), provider, profile);
-                    boolean cityWest = ChunkPlan.isCityRaw(key.offset(- 10, 0), provider, profile) ||
-                            ChunkPlan.isCityRaw(key.offset(- 10, - 10), provider, profile) ||
-                            ChunkPlan.isCityRaw(key.offset(- 10, 10), provider, profile);
+                    boolean cityEast = CityField.isCityRaw(key.offset(10, 0), provider, profile) ||
+                            CityField.isCityRaw(key.offset(10, - 10), provider, profile) ||
+                            CityField.isCityRaw(key.offset(10, 10), provider, profile);
+                    boolean cityWest = CityField.isCityRaw(key.offset(- 10, 0), provider, profile) ||
+                            CityField.isCityRaw(key.offset(- 10, - 10), provider, profile) ||
+                            CityField.isCityRaw(key.offset(- 10, 10), provider, profile);
                     if (!cityEast && !cityWest) {
                         return RailChunkInfo.NOTHING;
                     }
@@ -135,15 +135,15 @@ public class Railway {
                     randomRailChunkType.nextFloat() < .5f ? railwayParts.stationOpen() : railwayParts.stationOpenRoof());
         }
         if (mx == 10 && mz == 0) {
-            if (!ChunkPlan.isCityRaw(key, provider, profile)) {
+            if (!CityField.isCityRaw(key, provider, profile)) {
                 // There is no city here. So no station either. But we still need a railway. A station at this
                 // point will get a two line rail through it
                 if (profile.railwaysCanEnd()) {
                     // Check if there are stations at either side
-                    boolean cityEast = ChunkPlan.isCityRaw(key.offset(10, -10), provider, profile) ||
-                            ChunkPlan.isCityRaw(key.offset(10, 10), provider, profile);
-                    boolean cityWest = ChunkPlan.isCityRaw(key.offset(-10, -10), provider, profile) ||
-                            ChunkPlan.isCityRaw(key.offset(- 10, 10), provider, profile);
+                    boolean cityEast = CityField.isCityRaw(key.offset(10, -10), provider, profile) ||
+                            CityField.isCityRaw(key.offset(10, 10), provider, profile);
+                    boolean cityWest = CityField.isCityRaw(key.offset(-10, -10), provider, profile) ||
+                            CityField.isCityRaw(key.offset(- 10, 10), provider, profile);
                     if (!cityEast && !cityWest) {
                         return RailChunkInfo.NOTHING;
                     }
@@ -160,13 +160,13 @@ public class Railway {
                     randomRailChunkType.nextFloat() < .5f ? railwayParts.stationOpen() : railwayParts.stationOpenRoof());
         }
         if (mx == 10 && mz == 10) {
-            if (!ChunkPlan.isCityRaw(key, provider, profile)) {
+            if (!CityField.isCityRaw(key, provider, profile)) {
                 // There is no city here. So no station either. But we still need a railway. A station at this
                 // point will get a single line rail through it
                 if (profile.railwaysCanEnd()) {
                     // Check if there are stations at either side
-                    boolean cityEast = ChunkPlan.isCityRaw(key.offset(10, 0), provider, profile);
-                    boolean cityWest = ChunkPlan.isCityRaw(key.offset(-10, 0), provider, profile);
+                    boolean cityEast = CityField.isCityRaw(key.offset(10, 0), provider, profile);
+                    boolean cityWest = CityField.isCityRaw(key.offset(-10, 0), provider, profile);
                     if (!cityEast && !cityWest) {
                         return RailChunkInfo.NOTHING;
                     }
@@ -208,9 +208,9 @@ public class Railway {
             }
             if (mz == 0 && mx == 5) {
                 if (profile.railwaysCanEnd()) {
-                    boolean cityWest = ChunkPlan.isCityRaw(key.offset(-5, -10), provider, profile) ||
-                            ChunkPlan.isCityRaw(key.offset(-5, 10), provider, profile);
-                    boolean cityEast = ChunkPlan.isCityRaw(key.offset(5, 0), provider, profile);
+                    boolean cityWest = CityField.isCityRaw(key.offset(-5, -10), provider, profile) ||
+                            CityField.isCityRaw(key.offset(-5, 10), provider, profile);
+                    boolean cityEast = CityField.isCityRaw(key.offset(5, 0), provider, profile);
                     if (!cityEast && !cityWest) {
                         return RailChunkInfo.NOTHING;
                     }
@@ -219,9 +219,9 @@ public class Railway {
             }
             if (mz == 0 && mx == 15) {
                 if (profile.railwaysCanEnd()) {
-                    boolean cityEast = ChunkPlan.isCityRaw(key.offset(5, -10), provider, profile) ||
-                            ChunkPlan.isCityRaw(key.offset(5, 10), provider, profile);
-                    boolean cityWest = ChunkPlan.isCityRaw(key.offset(-5, 0), provider, profile);
+                    boolean cityEast = CityField.isCityRaw(key.offset(5, -10), provider, profile) ||
+                            CityField.isCityRaw(key.offset(5, 10), provider, profile);
+                    boolean cityWest = CityField.isCityRaw(key.offset(-5, 0), provider, profile);
                     if (!cityEast && !cityWest) {
                         return RailChunkInfo.NOTHING;
                     }
@@ -230,8 +230,8 @@ public class Railway {
             }
             if (mz == 10 && mx == 5) {
                 if (profile.railwaysCanEnd()) {
-                    boolean cityEast = ChunkPlan.isCityRaw(key.offset(5, 0), provider, profile);
-                    boolean cityWest = ChunkPlan.isCityRaw(key.offset(-5, 0), provider, profile);
+                    boolean cityEast = CityField.isCityRaw(key.offset(5, 0), provider, profile);
+                    boolean cityWest = CityField.isCityRaw(key.offset(-5, 0), provider, profile);
                     if (!cityEast && !cityWest) {
                         // Check the double bends
                         RailChunkInfo typeNorth = getRailChunkType(key.offset(0, - 10), provider, profile);
@@ -247,8 +247,8 @@ public class Railway {
             }
             if (mz == 10 && mx == 15) {
                 if (profile.railwaysCanEnd()) {
-                    boolean cityEast = ChunkPlan.isCityRaw(key.offset(5, 0), provider, profile);
-                    boolean cityWest = ChunkPlan.isCityRaw(key.offset(-5, 0), provider, profile);
+                    boolean cityEast = CityField.isCityRaw(key.offset(5, 0), provider, profile);
+                    boolean cityWest = CityField.isCityRaw(key.offset(-5, 0), provider, profile);
                     if (!cityEast && !cityWest) {
                         // Check the double bends
                         RailChunkInfo typeNorth = getRailChunkType(key.offset(0, - 10), provider, profile);
@@ -289,7 +289,7 @@ public class Railway {
     }
 
     private static RailChunkInfo getStationType(ChunkCoord coord, PlanningContext provider, Preset profile, float r, int rails, List<String> part) {
-        int cityLevel = ChunkPlan.getCityLevel(coord, provider);
+        int cityLevel = CityField.getCityLevel(coord, provider);
         if (cityLevel > 2 || !profile.railwaySurfaceStationsEnabled()) {
             // We are too high here. We need an underground station
             return new RailChunkInfo(STATION_UNDERGROUND, BI, RAILWAY_LEVEL_OFFSET, rails);

--- a/src/main/java/dev/krona/urbex/worldgen/lost/SlopeDecisions.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/SlopeDecisions.java
@@ -1,0 +1,141 @@
+package dev.krona.urbex.worldgen.lost;
+
+import dev.krona.urbex.worldgen.PlanningContext;
+
+import dev.krona.urbex.varia.ChunkCoord;
+
+import javax.annotation.Nullable;
+
+/**
+ * Which way a street chunk slopes, and where its stairs face.
+ *
+ * <p>Both are decided by looking at the neighbours - a street slopes towards the lower of the two
+ * city levels either side of it, and stairs face whichever way the slope runs - so both are memoised
+ * per plan rather than recomputed by every caller that asks.</p>
+ *
+ * <p>Same concurrency shape as {@link BridgeDecisions}, and for the same reason: volatile fields,
+ * flag written after the value it guards, no lock, because resolving one chunk's answer reads its
+ * neighbours'. Split out of {@link ChunkPlan} with the state it memoises (issue #11).</p>
+ */
+final class SlopeDecisions {
+
+    private final ChunkPlan plan;
+
+    private volatile boolean slopeCalculated = false;
+    private volatile Direction slopeDirection;
+
+    private volatile boolean stairCalculated = false;
+    private volatile Direction stairFacing;
+    private volatile boolean actualCalculated = false;
+    private volatile Direction actualFacing;
+
+    SlopeDecisions(ChunkPlan plan) {
+        this.plan = plan;
+    }
+
+    Direction streetSlope() {
+        if (slopeCalculated) {
+            return slopeDirection;
+        }
+        Direction direction = computeStreetSlope();
+        // Value first, then the flag: a reader that sees the flag set must see the value.
+        slopeDirection = direction;
+        slopeCalculated = true;
+        return direction;
+    }
+
+    @Nullable
+    private Direction computeStreetSlope() {
+        if (!plan.isMinorRoadSection()) {
+            return null;
+        }
+        Direction slopeDirection = null;
+        for (Direction direction : Direction.VALUES) {
+            ChunkPlan adjacent = direction.get(plan);
+            if (adjacent.isMinorRoadSection() && adjacent.cityLevel == plan.cityLevel + 1) {
+                if (slopeDirection != null) {
+                    // Two ways up out of one chunk: which one the ramp should face is not decided.
+                    return null;
+                }
+                slopeDirection = direction;
+            }
+        }
+        if (slopeDirection == null) {
+            return null;
+        }
+
+        ChunkPlan upper = slopeDirection.get(plan);
+        ChunkPlan approach = slopeDirection.getOpposite().get(plan);
+        if (!approach.isMinorRoadSection() || approach.cityLevel != plan.cityLevel) {
+            return null;
+        }
+        ChunkPlan departure = slopeDirection.get(upper);
+        if (!departure.isMinorRoadSection() || departure.cityLevel != upper.cityLevel) {
+            return null;
+        }
+
+        for (Direction direction : Direction.VALUES) {
+            if (direction != slopeDirection && direction != slopeDirection.getOpposite()) {
+                ChunkPlan side = direction.get(plan);
+                if (side.isPlannedRoadSection() && side.cityLevel == plan.cityLevel) {
+                    return null;
+                }
+                ChunkPlan upperSide = direction.get(upper);
+                if (upperSide.isPlannedRoadSection() && upperSide.cityLevel == upper.cityLevel) {
+                    return null;
+                }
+            }
+        }
+        return slopeDirection;
+    }
+
+    private Direction stair() {
+        if (stairCalculated) {
+            return stairFacing;
+        }
+        Direction direction = null;
+        // A sloped chunk already carries the whole level change across its full width. The narrow
+        // stair decoration on top of it would be a second, contradictory way up.
+        if (streetSlope() == null && plan.streetType != ChunkPlan.StreetType.PARK && !plan.hasBuilding && plan.isCity) {
+            if (plan.cityLevel == plan.getXmin().cityLevel - 1 && !plan.getXmin().hasBuilding && plan.getXmin().isCity) {
+                direction = Direction.XMIN;
+            } else if (plan.cityLevel == plan.getXmax().cityLevel - 1 && !plan.getXmax().hasBuilding && plan.getXmax().isCity) {
+                direction = Direction.XMAX;
+            } else if (plan.cityLevel == plan.getZmin().cityLevel - 1 && !plan.getZmin().hasBuilding && plan.getZmin().isCity) {
+                direction = Direction.ZMIN;
+            } else if (plan.cityLevel == plan.getZmax().cityLevel - 1 && !plan.getZmax().hasBuilding && plan.getZmax().isCity) {
+                direction = Direction.ZMAX;
+            }
+        }
+        // Value first, then the flag: a reader that sees the flag set must see the value.
+        stairFacing = direction;
+        stairCalculated = true;
+        return direction;
+    }
+
+    // This returns the actual stair direction. It keeps track if there are stair chunks around
+    // it those have higher stair priority
+    Direction actualStair() {
+        if (actualCalculated) {
+            return actualFacing;
+        }
+        Direction direction = stair();
+        if (direction != null) {
+            for (int cx = -1; cx <= 1; cx++) {
+                for (int cz = -1; cz <= 1; cz++) {
+                    if (cx != 0 || cz != 0) {
+                        ChunkCoord key = plan.coord.offset(cx, cz);
+                        ChunkPlan adjacent = ChunkPlan.getChunkPlan(key, plan.provider);
+                        if (adjacent.slopes.stair() != null && adjacent.stairPriority > plan.stairPriority) {
+                            direction = null;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        actualFacing = direction;
+        actualCalculated = true;
+        return direction;
+    }
+}

--- a/src/test/java/dev/krona/urbex/data/CityStyleLookupSitesTest.java
+++ b/src/test/java/dev/krona/urbex/data/CityStyleLookupSitesTest.java
@@ -54,7 +54,9 @@ class CityStyleLookupSitesTest {
 
         assertEquals(List.of(
                         // The style of the chunk, blended from the styles its neighbours resolved.
-                        "ChunkPlan.java",
+                        // Was ChunkPlan.java until issue #11 split candidate resolution out of it;
+                        // the same lookup, in the class that now performs it.
+                        "ChunkCandidates.java",
                         // The world style's selectors, the preset alternative, the predefined city.
                         "City.java",
                         // Route 4: the per-world cityStyleAlternative override, which arrives as JSON


### PR DESCRIPTION
Continues #11 — the `BuildingInfo` half, which the earlier phase-4 work did not touch. Phase 4 of #134.

`ChunkPlan` **1939 → 965 lines** — under half. Six collaborators.

| Commit | What moved | Lines |
| --- | --- | --- |
| `CityField` | where a city is, and which of the nine level bands it sits in | 167 |
| `BridgeDecisions` | whether a bridge crosses this chunk and which deck part it uses | 244 |
| `SlopeDecisions` | which way a street slopes and where its stairs face | 141 |
| `HeightDecisions` | how high the city sits, and what terrain correction it asks for | 217 |
| `ConnectionGraph` | corridors, roads extending out, and which floors line up next door | 240 |
| `ChunkCandidates` | the first planning pass: city, road, highway, railway, which building | 311 |

## This half is a different shape from `CityGenerator`'s, as expected

When I proposed this split I said `ChunkPlan` would be harder because its clusters *are* computed values other chunks read — state and readers aren't separable the way `CityGenerator`'s passes were. That turned out to be exactly right, and it shaped all three cuts.

**`CityField` was the easy one.** Static, pure functions of seed and coordinate, no instance state. The only wrinkle is that `isCityRaw` and the city-level resolution are mutually recursive — averaging the heightmap over a neighbourhood only counts neighbours that are themselves city — so they had to move together. All 40 external call sites were fully qualified `ChunkPlan.x(`, so rewiring carried no ambiguity.

**The other two are memoised decisions that read and write their neighbours.** For those the state had to move *with* the behaviour, because the interesting thing about them is a concurrency rationale that belongs to neither half alone:

> A `ChunkPlan` is read by every chunk that neighbours it, so these fields are filled from whichever thread arrives first while others read. All volatile, every `…Calculated` flag written **after** the value it guards. Racy-single-check, not double-checked locking — and the missing lock is deliberate, because the scan walks into its neighbours, so a per-instance lock would be a lock-ordering deadlock waiting to happen.

That comment used to sit on a block of fields in `ChunkPlan` explaining code 1100 lines away. It now sits on the class it describes.

The extractions also made the cross-plan reaching legible. `i.xBridgeType = bt` was one `ChunkPlan` writing another's private field; it is now `i.bridges.xType`. `adjacent.getStairDirection()` with `adjacent.stairPriority` is now `adjacent.slopes.stair()`. Same behaviour, but the fact that resolving one chunk marks its neighbours is now visible in the call.

## Verified as pure motion

Token-for-token against the originals, normalising only the deliberate renames — identical on both sides every time:

```
CityField        612      HeightDecisions   939
BridgeDecisions  742      ConnectionGraph   823
SlopeDecisions   443      ChunkCandidates  1455
```

One thing the token check did *not* catch: a javadoc and an `@Nullable` belonging to `getPlannedBridge` were swept into the `SlopeDecisions` cut, because the cut boundary was the method signature and they sat above it. That surfaced as a compile error and is restored — worth noting because a token comparison that normalises whitespace will not notice a comment migrating to the wrong method.

## Narrowest possible widening

`isMinorRoadSection`, `isPlannedRoadSection` and `stairPriority` go from private to package-private — the minimum that lets a decisions object see what it decides from. No field or method became public.

## Verification

Unit tests green. All seven digest suites unchanged on every commit:

| Suite | Golden | Moved? |
| --- | --- | --- |
| `runDigestCheck` | `688914e862e938fb` | no |
| `runDigestCheckShuffled` | `688914e862e938fb` | no |
| `runDigestCheckFeatures` | `7b5348f28e0a6d23` | no |
| `runDigestCheckAvoid` | `b37050817cd94b93` | no |
| `runDigestCheckAvoidModes` | `53290e1a9849c43d` | no |
| `runDigestCheckRail` | `3fff027c14eea4a9` | no |
| `runDigestCheckAvoidExpire` | `b37050817cd94b93` | no |

## Two other things the split turned up

**`calculateTopLeft` looked dead and is not.** From inside the moved block it had no callers; the constructor calls it, and the constructor is not moving. Left in place.

**`CityStyleLookupSitesTest` failed, which is the test doing its job.** It pins the exact set of files that resolve a city style by name, so a new lookup site fails the build. This was the same lookup in a new file, not a new one — confirmed by checking `ChunkPlan` went from one occurrence to zero as `ChunkCandidates` went zero to one. Its javadoc explicitly warns against widening the list, so the entry *moved* rather than being added to.

## Where this stops, and why

`ChunkPlan`'s remaining 965 lines are:

| | |
| --- | --- |
| The 222-line constructor | its own job |
| 46 field declarations | its data |
| ~24 delegating one-liners | to the six collaborators above |
| Construction helpers, road classification, trivial accessors, nested types | the rest |

Against the responsibility list in this issue: **city level, the road clip, bridges, the neighbour graph and the per-chunk cache are all out.** Two are not — **floors/cellars** and **palette** — and both are bound to construction ordering rather than sitting beside it. `createPalette` writes a field partway through the constructor, before the building fields it would need are assigned; extracting either means restructuring how a `ChunkPlan` is built, which is a design change rather than a move, and not one to make at the tail of a mechanical split.

That leaves a coherent value class: its data, its construction, and delegation. Whether that closes #11 or leaves it open for a construction pass is a call worth making deliberately rather than by momentum.
