### PR TITLE
perf: city generation allocates 71% less, with output unchanged (#196)

### DIFF
--- a/src/main/java/dev/krona/urbex/worldgen/BlockShaper.java
+++ b/src/main/java/dev/krona/urbex/worldgen/BlockShaper.java
@@ -59,8 +59,14 @@ final class BlockShaper {
     private final long seed;
 
     /** Reused across every shape update: thread-confined, reseeded per position via Rng.posSeed. */
-    private final XoroshiroRandomSource shapeRandom = new XoroshiroRandomSource(0);
+    private final ReseedOnDemandRandomSource shapeRandom = new ReseedOnDemandRandomSource();
     private final BlockPos.MutableBlockPos scratch = new BlockPos.MutableBlockPos();
+    /**
+     * The far side of the block being reshaped. Separate from {@link #scratch}, which is holding
+     * the neighbour's own position at the same time, and mutable because {@code updateShape} only
+     * reads it - the same reason vanilla passes mutable positions through its own neighbour walks.
+     */
+    private final BlockPos.MutableBlockPos facing = new BlockPos.MutableBlockPos();
 
     BlockShaper(ChunkView chunk, LevelAccessor region, long seed) {
         this.chunk = chunk;
@@ -184,7 +190,8 @@ final class BlockShaper {
             // -RNG design exists to keep out of generation. Anyone adding direction to this address
             // is trading determinism for independence no vanilla block asks for.
             shapeRandom.setSeed(Rng.posSeed(seed, pos.getX(), pos.getY(), pos.getZ(), Rng.Purpose.SHAPE));
-            newAdjacent = adjacent.updateShape(region, region, pos, direction, pos.relative(direction), state, shapeRandom);
+            newAdjacent = adjacent.updateShape(region, region, pos, direction,
+                    facing.setWithOffset(pos, direction), state, shapeRandom);
         } catch (Exception e) {
             // We got an exception. For example for beehives there can potentially be a problem so in this case we just ignore it
             return adjacent;

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -124,6 +124,23 @@ public class ChunkDriver {
      */
     private Long2ObjectOpenHashMap<BlockState> written;
 
+    /**
+     * What {@link #written} is sized for on creation, rather than grown into from fastutil's
+     * default of 16.
+     *
+     * <p>A driven chunk writes about 9200 positions - measured at 9241 on both the
+     * {@code digestCheckAvoid} window and a 625-chunk {@code onlycities} one - so the map was
+     * doubling its way up through eleven rehashes, and the last few of those allocate the
+     * expensive pairs. Growing to capacity C allocates about 2C of backing arrays; starting at C
+     * allocates C. At fastutil's 0.75 load factor this asks for the 16384-slot table that 9200
+     * entries were going to end up in anyway.</p>
+     *
+     * <p>Chunks that write far less than that over-allocate, which is the trade: the map is
+     * created lazily on the first write, so a chunk the driver never touches still costs nothing,
+     * and one that writes at all is overwhelmingly a city chunk writing thousands.</p>
+     */
+    private static final int EXPECTED_WRITES_PER_CHUNK = 12288;
+
     private boolean published;
     private boolean loggedLateWrite;
 
@@ -134,7 +151,7 @@ public class ChunkDriver {
             return;
         }
         if (written == null) {
-            written = new Long2ObjectOpenHashMap<>();
+            written = new Long2ObjectOpenHashMap<>(EXPECTED_WRITES_PER_CHUNK);
         }
         // put, not putIfAbsent: within one driver, the last write to a position wins - the same
         // property the old read-the-final-world approach had for driver-internal overwrites

--- a/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DimensionCaches.java
@@ -43,6 +43,19 @@ public final class DimensionCaches {
      */
     public final TimedCache<ChunkCoord, WorldStyle> worldStyle = new TimedCache<>(Config::cacheCleanupSeconds, "worldStyle");
     public final TimedCache<ChunkCoord, MultiChunk> multiChunk = new TimedCache<>(Config::cacheCleanupSeconds, "multiChunk");
+    /**
+     * Whether a coordinate rolled a city centre and, if so, that city's radius - {@code NaN} when
+     * it is not one. See {@code City.centreRadiusOrNone}: the city-factor scan asks this of every
+     * coordinate within {@code cityMaxRadius} of the chunk being planned, so neighbouring chunks
+     * ask overwhelmingly the same questions.
+     */
+    public final TimedCache<ChunkCoord, Float> cityCentre = new TimedCache<>(Config::cacheCleanupSeconds, "cityCentre");
+    /**
+     * How strongly a coordinate sits inside a city. See {@code City.getCityFactor}: the value is
+     * asked for the same chunk from several planning passes, and computing it scans every
+     * coordinate within {@code cityMaxRadius}.
+     */
+    public final TimedCache<ChunkCoord, Float> cityFactor = new TimedCache<>(Config::cacheCleanupSeconds, "cityFactor");
     public final TimedCache<ChunkCoord, BiomeInfo> biomeInfo = new TimedCache<>(Config::cacheCleanupSeconds, "biomeInfo");
     /**
      * The railway and highway coordinate maps.
@@ -107,6 +120,8 @@ public final class DimensionCaches {
         cityStyle.clear();
         worldStyle.clear();
         multiChunk.clear();
+        cityCentre.clear();
+        cityFactor.clear();
         biomeInfo.clear();
         railInfo.clear();
         xHighwayLevel.clear();

--- a/src/main/java/dev/krona/urbex/worldgen/ReseedOnDemandRandomSource.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ReseedOnDemandRandomSource.java
@@ -1,0 +1,102 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
+
+/**
+ * A {@link XoroshiroRandomSource} whose {@code setSeed} costs nothing until something actually
+ * draws from it.
+ *
+ * <p>{@link BlockShaper} addresses one random stream per position and then hands the source to
+ * {@code updateShape}, which for almost every block never touches it - a fence, wall, pane or
+ * stair resolves its connections from neighbour states alone. The seed was still being applied on
+ * every call, and {@code XoroshiroRandomSource.setSeed} is not free: it allocates a fresh
+ * {@code Xoroshiro128PlusPlus} and resets the gaussian source. Against a 625-chunk
+ * {@code onlycities} window that was the single largest allocation site in generation, 1.5 GiB of
+ * {@code Xoroshiro128PlusPlus} for streams that were overwhelmingly never read.</p>
+ *
+ * <p>So the seed is remembered and applied on first use. Every draw goes through {@link #source()},
+ * which reseeds if a {@link #setSeed} has landed since the last one. The observable sequence is
+ * unchanged - the only difference is <em>when</em> the underlying source is seeded, and nothing
+ * else holds a reference to it - so this is invisible to generated output. The digest goldens
+ * cover that claim.</p>
+ *
+ * <p>Every method {@link XoroshiroRandomSource} overrides is delegated, {@code consumeCount}
+ * included: it overrides the interface default with a cheaper skip, and inheriting the default
+ * here instead would quietly change the stream. The three methods it does <em>not</em> override
+ * ({@code nextIntBetweenInclusive}, {@code triangle}, {@code nextInt(int, int)}) are left to the
+ * interface defaults, which reach the delegate through the methods below.</p>
+ *
+ * <p>Thread-confined, like the shaper that owns it: one per driver, per chunk, per thread.</p>
+ */
+final class ReseedOnDemandRandomSource implements RandomSource {
+
+    private final XoroshiroRandomSource delegate = new XoroshiroRandomSource(0L);
+    private long pendingSeed;
+    private boolean needsReseed = true;
+
+    @Override
+    public void setSeed(long seed) {
+        pendingSeed = seed;
+        needsReseed = true;
+    }
+
+    private XoroshiroRandomSource source() {
+        if (needsReseed) {
+            delegate.setSeed(pendingSeed);
+            needsReseed = false;
+        }
+        return delegate;
+    }
+
+    @Override
+    public RandomSource fork() {
+        return source().fork();
+    }
+
+    @Override
+    public PositionalRandomFactory forkPositional() {
+        return source().forkPositional();
+    }
+
+    @Override
+    public int nextInt() {
+        return source().nextInt();
+    }
+
+    @Override
+    public int nextInt(int bound) {
+        return source().nextInt(bound);
+    }
+
+    @Override
+    public long nextLong() {
+        return source().nextLong();
+    }
+
+    @Override
+    public boolean nextBoolean() {
+        return source().nextBoolean();
+    }
+
+    @Override
+    public float nextFloat() {
+        return source().nextFloat();
+    }
+
+    @Override
+    public double nextDouble() {
+        return source().nextDouble();
+    }
+
+    @Override
+    public double nextGaussian() {
+        return source().nextGaussian();
+    }
+
+    @Override
+    public void consumeCount(int count) {
+        source().consumeCount(count);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/City.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/City.java
@@ -65,7 +65,46 @@ public class City {
     }
 
 
+    /**
+     * The memo value for a coordinate that is not a city centre. A radius is always a real
+     * number, so this cannot collide with one - which a negative sentinel could, since a
+     * predefined city carries whatever radius its datapack declares.
+     */
+    private static final float NOT_A_CENTRE = Float.NaN;
+
+    /**
+     * Whether this coordinate rolled a city centre and, if it did, that city's radius - memoized,
+     * because {@link #getCityFactor} asks this of every chunk within {@code cityMaxRadius}.
+     *
+     * <p>That scan is {@code (2 * ceil(maxRadius / 16) + 1)^2} coordinates per chunk planned:
+     * 1089 of them at the shipped {@code onlycities} radius of 256. Both rolls are pure functions
+     * of the seed and the coordinate - neither depends on which chunk is doing the asking - so
+     * every chunk was re-rolling almost exactly the window its neighbour had just rolled, and
+     * paying two {@link Rng#at} allocations per coordinate to do it. Against a 625-chunk
+     * {@code onlycities} window that was 0.9 GiB, the largest remaining allocation site in
+     * generation after the shape-update fix.</p>
+     *
+     * <p>One entry covers both rolls because nothing ever wants the radius of a coordinate that
+     * is not a centre except {@link #getCityRadius}, which stays total by falling through to the
+     * uncached roll for that case.</p>
+     */
+    private static float centreRadiusOrNone(ChunkCoord coord, PlanningContext provider) {
+        Float cached = provider.caches().cityCentre.get(coord);
+        if (cached != null) {
+            return cached;
+        }
+        float result = isCityCentreUncached(coord, provider)
+                ? cityRadiusUncached(coord, provider)
+                : NOT_A_CENTRE;
+        Float raced = provider.caches().cityCentre.putIfAbsent(coord, result);
+        return raced != null ? raced : result;
+    }
+
     public static boolean isCityCenter(ChunkCoord coord, PlanningContext provider) {
+        return !Float.isNaN(centreRadiusOrNone(coord, provider));
+    }
+
+    private static boolean isCityCentreUncached(ChunkCoord coord, PlanningContext provider) {
         PredefinedCity city = getPredefinedCity(provider, coord);
         if (city != null) {
             return true;
@@ -80,6 +119,16 @@ public class City {
      * Return the radius of the city with the given center
      */
     public static float getCityRadius(ChunkCoord coord, PlanningContext provider) {
+        float cached = centreRadiusOrNone(coord, provider);
+        if (!Float.isNaN(cached)) {
+            return cached;
+        }
+        // Not a centre. Callers reach here only by asking for the radius of a coordinate that
+        // never rolled one; answer exactly as before rather than inventing a value.
+        return cityRadiusUncached(coord, provider);
+    }
+
+    private static float cityRadiusUncached(ChunkCoord coord, PlanningContext provider) {
         PredefinedCity city = getPredefinedCity(provider, coord);
         if (city != null) {
             return city.getRadius();
@@ -178,7 +227,33 @@ public class City {
         return provider.assets().cityStyles().get(cityStyleName);
     }
 
+    /**
+     * How strongly this chunk sits inside a city, memoized per coordinate.
+     *
+     * <p>The uncached body scans every coordinate within {@code cityMaxRadius} - 1089 of them at
+     * the shipped {@code onlycities} radius - and it is asked several times for the same chunk:
+     * once from {@code ChunkCandidates.candidate}, once from {@code ChunkPlan}, and up to four
+     * more from {@code CityField.getCityLevelNormal}, whose averaging path calls
+     * {@code isCityRaw} on the four neighbours it samples. Nothing in the scan depends on which
+     * chunk is asking, so those repeats re-derived an identical answer.</p>
+     *
+     * <p>get-then-{@code putIfAbsent} rather than {@code getOrCompute} deliberately, for the
+     * reason {@code getCityStyle} documents: the computation reaches other planning state, and
+     * running it inside a {@code ConcurrentHashMap} bin lock is how that deadlocks. Two threads
+     * racing on one coordinate both compute and agree, because this is a pure function of the
+     * seed, the coordinate and the preset.</p>
+     */
     public static float getCityFactor(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        Float cached = provider.caches().cityFactor.get(coord);
+        if (cached != null) {
+            return cached;
+        }
+        float result = cityFactorUncached(coord, provider, profile);
+        Float raced = provider.caches().cityFactor.putIfAbsent(coord, result);
+        return raced != null ? raced : result;
+    }
+
+    private static float cityFactorUncached(ChunkCoord coord, PlanningContext provider, Preset profile) {
         ResourceKey<Level> type = provider.dimension();
         // If we have a predefined building here we force a high city factor
 

--- a/src/test/java/dev/krona/urbex/worldgen/ReseedOnDemandRandomSourceTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/ReseedOnDemandRandomSourceTest.java
@@ -1,0 +1,90 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The deferred reseed is invisible: the sequence matches an eagerly seeded
+ * {@link XoroshiroRandomSource} exactly.
+ * <p>
+ * {@link ReseedOnDemandRandomSource} exists to stop {@code setSeed} allocating for the
+ * overwhelming majority of shape updates that never draw from the stream, and the whole argument
+ * for it being safe is that it changes <em>when</em> the delegate is seeded and nothing else. That
+ * argument is worth a test rather than a comment: a shape update feeds generated output, and
+ * getting it wrong would move every fence, wall and stair in the world.
+ * <p>
+ * The digest goldens cover this too, but only for the streams those windows happen to draw. These
+ * pin every method the delegate overrides, including {@code consumeCount} - which
+ * {@code XoroshiroRandomSource} overrides with a cheaper skip than the interface default, so a
+ * wrapper that inherited the default instead would silently desynchronise the stream.
+ */
+class ReseedOnDemandRandomSourceTest {
+
+    private static final long[] SEEDS = {0L, 1L, -1L, 1337L, 135132278163449878L, Long.MIN_VALUE, Long.MAX_VALUE};
+
+    @Test
+    void matchesAnEagerlySeededSourceAcrossEveryDrawingMethod() {
+        for (long seed : SEEDS) {
+            XoroshiroRandomSource expected = new XoroshiroRandomSource(0L);
+            expected.setSeed(seed);
+            ReseedOnDemandRandomSource actual = new ReseedOnDemandRandomSource();
+            actual.setSeed(seed);
+
+            for (int i = 0; i < 64; i++) {
+                assertEquals(expected.nextInt(), actual.nextInt(), "nextInt at seed " + seed);
+                assertEquals(expected.nextInt(97), actual.nextInt(97), "nextInt(bound) at seed " + seed);
+                assertEquals(expected.nextLong(), actual.nextLong(), "nextLong at seed " + seed);
+                assertEquals(expected.nextBoolean(), actual.nextBoolean(), "nextBoolean at seed " + seed);
+                assertEquals(expected.nextFloat(), actual.nextFloat(), "nextFloat at seed " + seed);
+                assertEquals(expected.nextDouble(), actual.nextDouble(), "nextDouble at seed " + seed);
+                assertEquals(expected.nextGaussian(), actual.nextGaussian(), "nextGaussian at seed " + seed);
+            }
+        }
+    }
+
+    /** The one method whose interface default differs from what the delegate does. */
+    @Test
+    void consumeCountSkipsTheSameDistanceAsTheDelegate() {
+        XoroshiroRandomSource expected = new XoroshiroRandomSource(0L);
+        expected.setSeed(1337L);
+        ReseedOnDemandRandomSource actual = new ReseedOnDemandRandomSource();
+        actual.setSeed(1337L);
+
+        expected.consumeCount(11);
+        actual.consumeCount(11);
+        assertEquals(expected.nextLong(), actual.nextLong(), "the streams are still aligned after a skip");
+    }
+
+    /**
+     * Reseeding without drawing in between must not advance anything - this is the case the
+     * shaper is in for almost every position it corrects.
+     */
+    @Test
+    void aReseedThatNobodyDrawsFromCostsTheNextStreamNothing() {
+        ReseedOnDemandRandomSource actual = new ReseedOnDemandRandomSource();
+        actual.setSeed(1L);
+        actual.setSeed(2L);
+        actual.setSeed(1337L);
+
+        XoroshiroRandomSource expected = new XoroshiroRandomSource(0L);
+        expected.setSeed(1337L);
+        assertEquals(expected.nextLong(), actual.nextLong(),
+                "only the last seed applied should be observable");
+    }
+
+    /** Each new seed restarts the stream, rather than continuing the previous one. */
+    @Test
+    void everySeedRestartsTheStream() {
+        ReseedOnDemandRandomSource actual = new ReseedOnDemandRandomSource();
+        for (long seed : SEEDS) {
+            XoroshiroRandomSource expected = new XoroshiroRandomSource(0L);
+            expected.setSeed(seed);
+            actual.setSeed(seed);
+            actual.nextInt();
+            expected.nextInt();
+            assertEquals(expected.nextLong(), actual.nextLong(), "restart at seed " + seed);
+        }
+    }
+}


### PR DESCRIPTION
Cuts what city generation allocates by **71%** on an `onlycities` window and **62%** on the
`digestCheckAvoid` one, without moving a single block of generated output.

Three changes, each found by profiling rather than by reading. Closes the measurement half of #196.

## Results

Generation-only, driven by one loop that does nothing but
`level.getChunk(x, z, ChunkStatus.FULL, true)` - no digest hashing, no write recording, so these
are generation numbers rather than harness numbers (which is #195's complaint). 625 chunks,
2-4 repeats each, round-to-round spread 1.4-3.2%. "City-only" subtracts a cities-off run on the
same seed, so vanilla terrain generation is out of it.

**`onlycities`, seed 1337**

| | before | after | |
|---|---|---|---|
| end-to-end allocation | 11683 MiB | 7138 MiB | **−38.9%** |
| city-only allocation | 6404 MiB | 1859 MiB | **−71.0%** |
| per city chunk | 10.25 MiB | **2.97 MiB** | |
| end-to-end time | 17302 ms | 17005 ms | −1.7% |
| city-only time | 4688 ms | 4391 ms | −6.3% |

**default preset, seed 135132278163449878 - the `digestCheckAvoid` window #132 baselines on**

| | before | after | |
|---|---|---|---|
| end-to-end allocation | 8208 MiB | 6700 MiB | **−18.4%** |
| city-only allocation | 2450 MiB | 942 MiB | **−61.5%** |
| per city chunk | 3.92 MiB | **1.51 MiB** | |
| end-to-end time | 15358 ms | 15247 ms | −0.7% |
| city-only time | 2318 ms | 2207 ms | −4.8% |

For scale, upstream Lost Cities 26.1.2 allocates 5.77 MiB per city chunk on the same window and
machine. Urbex was at 10.25 and is now at 2.97 - roughly half of upstream's, while still writing
about 2.3x more city data per chunk and still running `useAvgHeightmap`, which Lost Cities ships
off.

## Why time barely moved, and why that is the honest answer

A CPU profile of the same window says only **20% of samples touch Urbex code at all**. The other
80% is vanilla: `PerlinNoise.getValue`, `Aquifer.computeSubstance`, `SurfaceRules`, `NoiseChunk`,
biome climate search. Cities-off is already 12.6 s of the 17.0 s.

So end-to-end throughput was never going to move much, and anyone quoting a big chunks/sec win
here would be quoting noise. What did move is what this actually set out to fix: the garbage rate.
The scan removed below no longer appears in a CPU profile at all, which is where the ~5-6% of
city-only time comes from.

## The three changes

**1. A shape update stops allocating a random source and a position** (f9b28ab)

`BlockShaper` reseeds one stream per position and hands it to `updateShape`, which for almost
every block never draws from it. `XoroshiroRandomSource.setSeed` allocates a fresh
`Xoroshiro128PlusPlus` and resets the gaussian source, so reusing the instance - which the class
already did - did not avoid the allocation. `ReseedOnDemandRandomSource` remembers the seed and
applies it on first use. Separately, `pos.relative(direction)` allocated an immutable `BlockPos`
four times per corrected block; that is now a second scratch `MutableBlockPos`.

2.817 GB → 0.289 GB. This was the largest single site in generation.

**2. The driver's write log starts at the size it ends up** (3499382)

The per-chunk write log grew from fastutil's default of 16 into a map holding ~9200 positions -
measured at 9241 on both windows - so it doubled through eleven rehashes, and the last few
allocate the expensive pairs. Growing to capacity C allocates about 2C; starting at C allocates C.

0.818 GB → 0.377 GB.

**3. The city-factor scan is computed once per coordinate** (09cc2bf)

The big one. `getCityFactor` scans every coordinate within `cityMaxRadius` of the chunk being
planned - **1089 of them** at the shipped `onlycities` radius of 256 - rolling `isCityCenter` and
`getCityRadius` for each, at two `Rng.at` allocations a coordinate. Neither roll depends on which
chunk is asking; both are pure functions of the seed and the coordinate. And the whole scan ran
several times per chunk: `ChunkCandidates.candidate` asks, `ChunkPlan` asks again, and
`CityField.getCityLevelNormal`'s averaging path asks `isCityRaw` of the four neighbours it samples.

Two memos, `cityCentre` and `cityFactor`, both get-then-`putIfAbsent` rather than `getOrCompute`
for the reason `getCityStyle` already documents - these computations reach other planning state,
and running them inside a `ConcurrentHashMap` bin lock is how that deadlocks.

The size of the redundancy: `cityCentre` takes **18,305,901 lookups at a 99.97% hit rate** over one
625-chunk window.

`NaN` marks "not a city centre" rather than a negative sentinel, because a predefined city carries
whatever radius its datapack declares and could legitimately be negative. `getCityRadius` stays
total by falling through to the uncached roll for a non-centre, so its behaviour for that case is
byte-identical to before.

## Verification

Output is unchanged. All five digest goldens, unmodified:

| suite | digest |
|---|---|
| `runDigestCheck` | `688914e862e938fb` |
| `runDigestCheckAvoid` | `b37050817cd94b93` |
| `runDigestCheckFeatures` | `7b5348f28e0a6d23` |
| `runDigestCheckAvoidModes` | `53290e1a9849c43d` |
| `runDigestCheckRail` | `3fff027c14eea4a9` |

The three that matter most for a change that adds caches also pass:

- `runDigestCheckShuffled` and `runDigestCheckAvoidShuffled` - generation order still cannot affect
  output;
- **`runDigestCheckAvoidExpire`** - clears every planning cache every N chunks mid-drive and still
  produces `b37050817cd94b93`, which is the mechanical proof that the two new memos are pure
  functions of seed and coordinate rather than load-bearing state;
- `runDigestCheckAvoidThreads` - unchanged under a different worker count.

`./gradlew test` green, plus a new `ReseedOnDemandRandomSourceTest` that pins the deferred reseed
as sequence-identical to an eager `XoroshiroRandomSource` across seven seeds and every method the
delegate overrides - `consumeCount` included, since it overrides the interface default with a
cheaper skip and a wrapper inheriting the default would silently desynchronise the stream.

## Not done, and why

- **`CompiledPalette` is the largest remaining site** (~0.89 GB) under
  `PaletteCharacterCheck.hasFailingSelection`, now filed as #198. An earlier revision of this
  section said it allocated *during generation*; that was wrong. Bucketing the allocation
  recording by second shows all 890 MB landing at asset-compile time on the `Server thread` and
  exactly zero once the drive starts, so it is a world-load cost and does not affect chunks per
  second at all. Still the single largest allocation site in the mod, hence its own issue.
- **`Rng.at` still allocates three objects per call** (`XoroshiroRandomSource` +
  `Xoroshiro128PlusPlus` + `MarsagliaPolarGaussian`, the last for a gaussian almost nothing draws).
  Fixing it means reimplementing vanilla's algorithm bit-exactly; caching the callers was the
  better trade and removed most of the calls anyway.
- **`ChunkBuffer$Section` (~0.29 GB)** is a `BlockState[4096]` per touched section. Inherent.

## One thing found on the way that is not a perf issue

Under a `settings=profile` JFR recording, generation hung with
`MissingPaletteEntryException: Missing Palette entry for index 2` thrown from the vanilla light
engine (`BlockLightEngine.checkNode` → `ProtoChunk.getBlockState`) on a worker thread, after which
the drive never completed. It did not reproduce under a lighter recording or in ~40 unprofiled
runs, so it is timing-dependent and I could not pin it. Flagging it rather than filing a bug on one
observation - but a torn palette read from the light engine is the signature of a chunk section
being written while lighting reads it, and that is worth someone's attention independently of this
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
