### PR TITLE
perf: the Cities page stops recompiling the world's assets on every click (#198)

### DIFF
--- a/src/main/java/dev/krona/urbex/gui/CitiesTab.java
+++ b/src/main/java/dev/krona/urbex/gui/CitiesTab.java
@@ -524,6 +524,9 @@ public class CitiesTab extends GridLayoutTab {
             activePreview.close();
             activePreview = null;
         }
+        // The compiled assets outlive any one preview - the editor's is a second one - so they are
+        // released here, with the screen, rather than in CityPreview.close().
+        CityPreview.releaseSharedAssets();
     }
 
     /** Asks for the next {@code CreateWorldScreen.init()} to land on this tab. */

--- a/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/CityPreview.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.levelgen.WorldOptions;
 
 import javax.annotation.Nullable;
 import java.util.Random;
+import java.util.concurrent.Executor;
 
 /**
  * The world-creation city/building preview: a small (62x58) chunk-grid image sampled through a
@@ -108,35 +109,67 @@ public class CityPreview implements AutoCloseable {
     @Nullable
     private final RegistryAccess registryAccess;
 
-    private final int[] colors = new int[WIDTH * HEIGHT];
+    /** The colour computation, off the render thread; see {@link PendingWork}. */
+    private final PendingWork<Key> work;
 
     @Nullable
     private Key key;
     @Nullable
     private DynamicTexture texture;
-    /** The mode the current {@link #colors}/{@link #texture} were rendered in; drives the legend. */
+    /** The mode the current {@link #texture} was rendered in; drives the legend. */
     private Mode mode = Mode.MAP;
 
     public CityPreview(@Nullable RegistryAccess registryAccess) {
+        this(registryAccess, PreviewWorker.executor());
+    }
+
+    /** Visible for tests, which need the computation to run somewhere they can observe. */
+    CityPreview(@Nullable RegistryAccess registryAccess, Executor executor) {
         this.registryAccess = registryAccess;
+        this.work = new PendingWork<>(executor);
     }
 
     /**
-     * Recomputes the preview iff (preset content, worldStyles, seed, mode) differs from the last
-     * call. {@code preset == null} clears whatever is showing (nothing selected yet). The whole mix
-     * is passed rather than one id, so a mixed selection previews as a mix - judging a balance
-     * before committing to the world is the point of the control.
+     * Drops the compiled assets shared by every preview (see {@code PreviewAssets}).
+     * <p>
+     * Belongs to the create-world screen going away, not to one preview closing: the Cities tab and
+     * the Customize screen hold separate previews and hand each other control, so releasing on
+     * {@link #close} would recompile every time the player opened the editor. A world that is never
+     * created must not leave its assets - and through them its registries - alive, which is the same
+     * reason {@code CitiesTab.closeActivePreview} exists.
+     */
+    public static void releaseSharedAssets() {
+        PreviewAssets.clear();
+    }
+
+    /**
+     * Asks for a recompute iff (preset content, worldStyles, seed, mode) differs from the last call.
+     * {@code preset == null} clears whatever is showing (nothing selected yet). The whole mix is
+     * passed rather than one id, so a mixed selection previews as a mix - judging a balance before
+     * committing to the world is the point of the control.
+     * <p>
+     * Asks, rather than does: the computation goes to a worker and the screen keeps showing the
+     * image it already has until the result arrives (see {@link PendingWork}). Callers drive this
+     * from the render pass, so doing the walk here was a dropped frame on every change.
+     * <p>
+     * Both arguments are immutable - {@code PresetDraft.resolve} hands out a fresh {@link Preset}
+     * and {@link WorldStyleMix} is a record - so handing them to another thread copies nothing and
+     * races with nothing, even while the editor goes on mutating the draft they came from.
      */
     public void update(@Nullable Preset preset, WorldStyleMix worldStyles, long seed, Mode mode) {
         if (preset == null) {
             key = null;
+            work.cancel();
             closeTexture();
             return;
         }
-        if (!needsRecompute(presetHash(preset), worldStyles.format(), seed, mode)) {
-            return;
+        if (needsRecompute(presetHash(preset), worldStyles.format(), seed, mode)) {
+            // needsRecompute has just stored the new key, and that is the key this request is for.
+            Key requested = key;
+            work.request(requested,
+                    () -> computeColors(preset, worldStyles, seed, mode, registryAccess));
         }
-        recompute(preset, worldStyles, seed, mode);
+        applyFinishedWork();
     }
 
     /**
@@ -196,8 +229,19 @@ public class CityPreview implements AutoCloseable {
     }
 
     public void render(GuiGraphicsExtractor g, int x, int y, int w, int h) {
+        // Also drained here, not only in update(): the Customize screen drives update() from a
+        // debounce timer rather than per frame, so a result landing between two debounces would
+        // otherwise sit unshown until the player touched another setting.
+        applyFinishedWork();
         if (texture == null) {
-            renderUnavailable(g, x, y, w, h);
+            // Nothing yet - but "unavailable" is a statement about the pack, not about a frame that
+            // has not arrived, and the first computation after the screen opens always takes a frame
+            // or two. Saying it while a result is on its way would flash an error on every open, so
+            // the empty space simply stays empty until there is something to say or something to
+            // show.
+            if (!work.isBusy()) {
+                renderUnavailable(g, x, y, w, h);
+            }
             return;
         }
         int mapHeight = Math.max(0, h - LEGEND_HEIGHT);
@@ -211,8 +255,26 @@ public class CityPreview implements AutoCloseable {
         renderLegend(g, x, y + mapHeight);
     }
 
+    /**
+     * Uploads a finished computation, if one is ready and still wanted. The render thread's half of
+     * {@link PendingWork}: the walk happens on the worker, the GL upload can only happen here.
+     */
+    private void applyFinishedWork() {
+        if (key == null) {
+            return;
+        }
+        int[] colors = work.take(key);
+        if (colors == null) {
+            return;
+        }
+        // Only now does the legend follow, so it never describes an image that is not on screen yet.
+        this.mode = key.mode();
+        uploadTexture(colors);
+    }
+
     @Override
     public void close() {
+        work.cancel();
         closeTexture();
         // Drop the cache key too: leaving it set would make a reused-after-close preview believe its
         // (now-null) texture is still valid for that key and render "unavailable" forever. Callers
@@ -220,7 +282,17 @@ public class CityPreview implements AutoCloseable {
         key = null;
     }
 
-    private void recompute(Preset preset, WorldStyleMix worldStyles, long seed, Mode mode) {
+    /**
+     * The whole of a recompute, as a pure function: no field is read and none is written, so this is
+     * what the worker thread runs. Returns a fresh {@link #WIDTH}x{@link #HEIGHT} buffer, or
+     * {@code null} for a preset that does not currently make sense, which the render thread reads as
+     * "keep showing the last good image" (see the guard below).
+     * <p>
+     * The buffer is allocated per computation rather than reused, because a reused one would be
+     * written by the worker while the render thread was still uploading the previous image out of it.
+     */
+    private static int[] computeColors(Preset preset, WorldStyleMix worldStyles, long seed, Mode mode,
+                                       @Nullable RegistryAccess registryAccess) {
         // Nothing to drop before recomputing any more. The predefined-city/street maps this used to
         // clear were static and shared with live worldgen - the preview cleared them so a new
         // preset/seed combo would not see the previous one's content, and in doing so cleared them
@@ -255,27 +327,27 @@ public class CityPreview implements AutoCloseable {
                 // qualified by the time they reach here.
                 context = PreviewContext.create(preset, worldStyles, seed, registryAccess);
             } catch (IllegalArgumentException | IllegalStateException e) {
-                // Nothing has been drawn at this point, so `colors` and `texture` still hold the last
-                // good render. Leaving `mode` alone too keeps the legend describing the image actually
-                // on screen.
+                // Nothing has been drawn at this point, and this returns before anything is uploaded,
+                // so the texture and the mode driving the legend both still describe the last good
+                // render - which stays on screen.
                 Urbex.LOGGER.debug("Preview not recomputed - preset or world style is not currently valid: {}",
                         e.getMessage());
-                return;
+                return null;
             }
         }
+        int[] colors = new int[WIDTH * HEIGHT];
         switch (mode) {
-            case MAP -> renderMap(context);
-            case TRANSPORT -> renderTransport(context, preset);
-            case ROADS -> renderRoads(context, preset);
-            case CITY -> renderCity(preset, seed);
+            case MAP -> renderMap(colors, context);
+            case TRANSPORT -> renderTransport(colors, context, preset);
+            case ROADS -> renderRoads(colors, context, preset);
+            case CITY -> renderCity(colors, preset, seed);
         }
-        this.mode = mode;
-        uploadTexture();
+        return colors;
     }
 
     // ---- MAP -----------------------------------------------------------------
 
-    private void renderMap(PreviewContext context) {
+    private static void renderMap(int[] colors, PreviewContext context) {
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {
                 colors[z * WIDTH + x] = sampleColor(context, x, z);
@@ -309,7 +381,7 @@ public class CityPreview implements AutoCloseable {
      * old {@code renderPreviewTransports} did with its {@code soft} base), with rail and highway
      * chunks blended over. Highway-over-rail is a distinct grey so an interchange is visible.
      */
-    private void renderTransport(PreviewContext context, Preset profile) {
+    private static void renderTransport(int[] colors, PreviewContext context, Preset profile) {
         PlanningContext planning = context.planning();
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {
@@ -359,7 +431,7 @@ public class CityPreview implements AutoCloseable {
      * building footprints only, not a random fraction of the whole grid), not a defect masquerading
      * as a guarantee.
      */
-    private void renderRoads(PreviewContext context, Preset profile) {
+    private static void renderRoads(int[] colors, PreviewContext context, Preset profile) {
         PlanningContext planning = context.planning();
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {
@@ -398,14 +470,14 @@ public class CityPreview implements AutoCloseable {
      * 150-pixel canvas into the {@link #WIDTH}x{@link #HEIGHT} texture buffer, so the proportions match
      * the original at a smaller size.
      */
-    private void renderCity(Preset profile, long seed) {
+    private static void renderCity(int[] colors, Preset profile, long seed) {
         final int base = 44;      // ground line (of HEIGHT = 58): ~0.8 down, as the old base/150 was
         final int dimHor = 4;     // column pitch (old 10 of 150 -> 4 of 62)
         final int dimVer = 2;     // floor/cellar pitch (old 4 of 150 -> 2 of 58)
 
         // Sky above the ground line, ground below it.
-        fillRect(0, 0, WIDTH, base, SKY_COLOR);
-        fillRect(0, base, WIDTH, HEIGHT, GROUND_COLOR);
+        fillRect(colors, 0, 0, WIDTH, base, SKY_COLOR);
+        fillRect(colors, 0, base, WIDTH, HEIGHT, GROUND_COLOR);
 
         final float radius = 190;
         Random rand = new Random(seed);
@@ -433,14 +505,14 @@ public class CityPreview implements AutoCloseable {
                     f = minfloors;
                 }
                 for (int i = 0; i < f; i++) {
-                    fillRect(dimHor * x, base - i * dimVer - dimVer,
+                    fillRect(colors, dimHor * x, base - i * dimVer - dimVer,
                             dimHor * x + dimHor - 1, base - i * dimVer + dimVer - 1 - dimVer, FLOOR_COLOR);
                 }
 
                 int maxcellars = profile.buildingMaxCellars();
                 int fb = profile.buildingMinCellars() + ((maxcellars <= 0) ? 0 : rand.nextInt(maxcellars + 1));
                 for (int i = 0; i < fb; i++) {
-                    fillRect(dimHor * x, base + i * dimVer,
+                    fillRect(colors, dimHor * x, base + i * dimVer,
                             dimHor * x + dimHor - 1, base + i * dimVer + dimVer - 1, CELLAR_COLOR);
                 }
             }
@@ -452,14 +524,14 @@ public class CityPreview implements AutoCloseable {
         float verFactor = 1.0f * dimVer / 6.0f;
         Random rnd = new Random(333);
         // Old centres were leftRender+75 and leftRender+35 within a 150-wide canvas (0.5 and ~0.233).
-        drawExplosion(base, horFactor, verFactor, Math.round(WIDTH * 0.5f),
+        drawExplosion(colors, base, horFactor, verFactor, Math.round(WIDTH * 0.5f),
                 profile.explosionMinHeight(), profile.explosionMaxRadius(), rnd);
-        drawExplosion(base, horFactor, verFactor, Math.round(WIDTH * 0.233f),
+        drawExplosion(colors, base, horFactor, verFactor, Math.round(WIDTH * 0.233f),
                 profile.miniExplosionMinHeight(), profile.miniExplosionMaxRadius(), rnd);
     }
 
-    private void drawExplosion(int base, float horFactor, float verFactor, int cx,
-                               int minHeight, int explosionRadius, Random rnd) {
+    private static void drawExplosion(int[] colors, int base, float horFactor, float verFactor, int cx,
+                                      int minHeight, int explosionRadius, Random rnd) {
         int cz = (int) (base - (minHeight - 65) * verFactor);
         for (int x = (int) (cx - explosionRadius * horFactor); x <= cx + explosionRadius * horFactor; x++) {
             for (int z = (int) (cz - explosionRadius * verFactor); z <= cz + explosionRadius * verFactor; z++) {
@@ -469,7 +541,7 @@ public class CityPreview implements AutoCloseable {
                 if (dist < explosionRadius - 3) {
                     double damage = 3.0f * (explosionRadius - dist) / explosionRadius;
                     if (rnd.nextFloat() < damage) {
-                        fillRect(x, z, x + 1, z + 1, DAMAGE_OVERLAY);
+                        fillRect(colors, x, z, x + 1, z + 1, DAMAGE_OVERLAY);
                     }
                 }
             }
@@ -484,7 +556,7 @@ public class CityPreview implements AutoCloseable {
      * with alpha &lt; 0xff is alpha-blended over what is already there. Out-of-bounds pixels are
      * clipped, so callers don't have to bounds-check the elevation/explosion math.
      */
-    private void fillRect(int x0, int y0, int x1, int y1, int argb) {
+    private static void fillRect(int[] colors, int x0, int y0, int x1, int y1, int argb) {
         int lox = Math.max(0, x0);
         int loy = Math.max(0, y0);
         int hix = Math.min(WIDTH, x1);
@@ -522,7 +594,7 @@ public class CityPreview implements AutoCloseable {
         return 0xff000000 | (r << 16) | (g << 8) | b;
     }
 
-    private void uploadTexture() {
+    private void uploadTexture(int[] colors) {
         NativeImage image = new NativeImage(NativeImage.Format.RGBA, WIDTH, HEIGHT, false);
         for (int z = 0; z < HEIGHT; z++) {
             for (int x = 0; x < WIDTH; x++) {

--- a/src/main/java/dev/krona/urbex/gui/preview/PendingWork.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/PendingWork.java
@@ -1,0 +1,101 @@
+package dev.krona.urbex.gui.preview;
+
+import dev.krona.urbex.Urbex;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+/**
+ * One preview computation in flight at a time, keyed, latest request wins.
+ *
+ * <p>The preview's colour buffer used to be computed inside the widget's render pass. That is a
+ * 62x58 chunk-planning walk - tens of milliseconds even once the assets stopped being recompiled
+ * per click - and it ran between the frame starting and the frame being drawn, so it was a dropped
+ * frame every time the player touched anything. Here the walk runs on a worker and the screen keeps
+ * showing the image it already has until the new one is ready.</p>
+ *
+ * <h2>Why a slot and not a queue</h2>
+ *
+ * <p>A player dragging through presets generates requests far faster than the walk completes, and
+ * every one of them supersedes the last: there is no value in finishing the third of five. A new
+ * {@link #request} abandons whatever was in flight, so the queue never grows and the work that
+ * completes is always the work someone still wants.</p>
+ *
+ * <p>Abandoned means abandoned, not cancelled: the worker is not interrupted, because the walk holds
+ * no lock and touches nothing shared, so letting it finish into a result nobody takes is cheaper and
+ * safer than tearing it down. {@link #take} is what refuses it.</p>
+ *
+ * <p>Every method here runs on the render thread; only the {@link Supplier} runs on the worker. That
+ * is why none of this is synchronized - the {@link CompletableFuture} is the entire handoff.</p>
+ *
+ * @param <K> the caller's cache key, compared with {@code equals} to decide whether a finished
+ *            result is still wanted.
+ */
+final class PendingWork<K> {
+
+    private final Executor executor;
+
+    @Nullable
+    private CompletableFuture<int[]> future;
+    @Nullable
+    private K key;
+
+    PendingWork(Executor executor) {
+        this.executor = executor;
+    }
+
+    /**
+     * Starts computing for {@code key}, abandoning whatever was in flight. {@code work} runs on the
+     * worker and may throw - see {@link #take}.
+     */
+    void request(K key, Supplier<int[]> work) {
+        this.key = key;
+        this.future = CompletableFuture.supplyAsync(work, executor);
+    }
+
+    /** Whether a computation is in flight, or has finished and not been taken. */
+    boolean isBusy() {
+        return future != null;
+    }
+
+    /**
+     * The finished result iff it is still {@code wanted}, and {@code null} otherwise - not yet
+     * finished, superseded, or failed. Either way a finished computation frees the slot, so a
+     * dropped result cannot wedge it.
+     *
+     * <p>A failure is logged and dropped rather than rethrown, because the render thread has nowhere
+     * to put an exception except through the screen. It is logged loudly, though: the one failure
+     * that is <em>expected</em> here - a momentarily self-contradictory preset, which is an ordinary
+     * state while two paired sliders are being dragged - is caught by the computation itself, which
+     * returns null for it. Anything that reaches this catch is a bug in a renderer's own math, and
+     * the inline version this replaced was careful not to swallow those silently either.</p>
+     */
+    @Nullable
+    int[] take(K wanted) {
+        if (future == null || !future.isDone()) {
+            return null;
+        }
+        CompletableFuture<int[]> finished = future;
+        K finishedKey = key;
+        future = null;
+        key = null;
+        int[] colors;
+        try {
+            colors = finished.join();
+        } catch (CompletionException | CancellationException e) {
+            Urbex.LOGGER.error("Urbex preview computation failed; keeping the previous image", e);
+            return null;
+        }
+        return wanted.equals(finishedKey) ? colors : null;
+    }
+
+    /** Abandons anything in flight or finished. The worker, if running, is left to finish unseen. */
+    void cancel() {
+        future = null;
+        key = null;
+    }
+}

--- a/src/main/java/dev/krona/urbex/gui/preview/PreviewAssets.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/PreviewAssets.java
@@ -1,0 +1,77 @@
+package dev.krona.urbex.gui.preview;
+
+import dev.krona.urbex.worldgen.lost.cityassets.AssetCompiler;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import net.minecraft.core.RegistryAccess;
+
+import javax.annotation.Nullable;
+import java.lang.ref.WeakReference;
+
+/**
+ * The compiled assets the world-creation preview plans against, built once per set of registries.
+ *
+ * <p>A snapshot is a pure function of the {@link RegistryAccess} it is compiled from, but the
+ * preview rebuilds its {@link PreviewContext} on every change of preset, world style, seed or view -
+ * and each of those used to compile the whole thing again, on the render thread, inside the widget's
+ * render pass. Measured against the bundled datapack alone that was ~300 ms a click, and it scales
+ * with the number of loaded packs; the Cities tab and the Customize screen each paid it separately,
+ * because they hold separate {@code CityPreview}s.</p>
+ *
+ * <h2>Why the key is the instance, and why there is only one</h2>
+ *
+ * <p>Registries do change while the screen is open: switching datapacks reloads the world-gen
+ * context and produces a <em>new</em> {@code RegistryAccess}, and a snapshot held across that would
+ * preview a pack the player has just turned off. Identity is exactly the right key for that - a
+ * reload cannot hand back the same instance - and it needs no assumption about
+ * {@code RegistryAccess} equality, which is Object's.</p>
+ *
+ * <p>One entry, not a map: the create-world screen previews one world at a time, so a second entry
+ * could only ever hold registries nothing will ask about again. The key is weak so a reload's old
+ * registries are collectable, and {@link #clear} drops the value outright when the screen goes away
+ * - see {@code CitiesTab.closeActivePreview}, which exists for the same reason.</p>
+ *
+ * <p>Reachable from the render thread and from the preview's background worker, so every access is
+ * synchronized. Compilation happens under the lock: two threads racing to compile the same
+ * registries would otherwise do the expensive thing twice.</p>
+ */
+final class PreviewAssets {
+
+    private PreviewAssets() {
+    }
+
+    @Nullable
+    private static WeakReference<RegistryAccess> key;
+    @Nullable
+    private static AssetSnapshot value;
+
+    /**
+     * The snapshot for {@code access}, compiling it iff these are not the registries already held.
+     *
+     * <p>{@code null} - the GUI's own fallback when the world-creation context has no biome registry,
+     * or the Customize screen has no parent screen at all - is an empty snapshot rather than a
+     * compile, and is not cached: there is nothing to reuse.</p>
+     */
+    static synchronized AssetSnapshot of(@Nullable RegistryAccess access) {
+        if (access == null) {
+            return AssetSnapshot.empty();
+        }
+        if (value != null && key != null && key.get() == access) {
+            return value;
+        }
+        // Deliberately the unvalidated path: the preview discards diagnostics, and producing them is
+        // ~96% of a compile. See AssetCompiler.compileWithoutValidation.
+        AssetSnapshot compiled = AssetCompiler.compileWithoutValidation(access);
+        key = new WeakReference<>(access);
+        value = compiled;
+        return compiled;
+    }
+
+    /**
+     * Releases the held snapshot. Called when the create-world screen goes away, so a world that was
+     * never created does not keep its compiled assets - and, through them, its registries - alive.
+     */
+    static synchronized void clear() {
+        key = null;
+        value = null;
+    }
+}

--- a/src/main/java/dev/krona/urbex/gui/preview/PreviewContext.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/PreviewContext.java
@@ -69,12 +69,12 @@ public record PreviewContext(PlanningContext planning, PreviewTerrain terrain) {
                                         @Nullable RegistryAccess registryAccess) {
         // The preview compiles its own snapshot and owns it, rather than reaching for the server's.
         // It has no session - it runs on the client, on the world-creation screen, before any server
-        // exists - and must not acquire one. Diagnostics are discarded on purpose: a broken pack is
-        // the world load's business to refuse, and a preview that threw would leave the player unable
-        // to see why. Individual ids still fall back to the placeholder below.
-        AssetSnapshot assets = registryAccess == null
-                ? AssetSnapshot.empty()
-                : AssetCompiler.compile(registryAccess, new AssetDiagnostics());
+        // exists - and must not acquire one. Diagnostics are not merely discarded, they are never
+        // produced: a broken pack is the world load's business to refuse, and a preview that threw
+        // would leave the player unable to see why, so computing the report here was seconds of work
+        // per click for nothing (see AssetCompiler.compileWithoutValidation). Individual ids still
+        // fall back to the placeholder below.
+        AssetSnapshot assets = PreviewAssets.of(registryAccess);
         List<WorldStyleField.Weighted> resolvedEntries = new ArrayList<>(worldStyles.entries().size());
         for (WorldStyleMix.Entry entry : worldStyles.entries()) {
             WorldStyle resolved = null;

--- a/src/main/java/dev/krona/urbex/gui/preview/PreviewWorker.java
+++ b/src/main/java/dev/krona/urbex/gui/preview/PreviewWorker.java
@@ -1,0 +1,50 @@
+package dev.krona.urbex.gui.preview;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * The one thread the world-creation preview computes on.
+ *
+ * <p>One is the right number: {@link PendingWork} keeps a single computation in flight and every new
+ * request supersedes the last, so a pool would only ever have one busy thread and a queue of work
+ * nobody wants any more.</p>
+ *
+ * <p>The thread is a daemon and is created on first use, so a player who never opens the Cities tab
+ * never starts it and a player who does never has it hold the game open on exit. It is deliberately
+ * not shut down when the screen closes: {@link #shutdown} exists for that, but the thread is idle
+ * and cheap, and tearing it down while an abandoned computation is still running would be the one
+ * way to make that computation's failure visible.</p>
+ */
+final class PreviewWorker {
+
+    private PreviewWorker() {
+    }
+
+    @Nullable
+    private static ExecutorService service;
+
+    static synchronized Executor executor() {
+        if (service == null) {
+            service = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "Urbex preview");
+                thread.setDaemon(true);
+                // Below the render thread on purpose: a preview is worth a frame of latency and
+                // never worth one of the game's own.
+                thread.setPriority(Thread.MIN_PRIORITY);
+                return thread;
+            });
+        }
+        return service;
+    }
+
+    /** Stops the worker. Not called in normal play; the daemon thread simply goes away on exit. */
+    static synchronized void shutdown() {
+        if (service != null) {
+            service.shutdownNow();
+            service = null;
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompiler.java
@@ -66,6 +66,43 @@ public final class AssetCompiler {
      *         class exists to make impossible, so don't.
      */
     public static AssetSnapshot compile(RegistryAccess access, AssetDiagnostics diagnostics) {
+        AssetSnapshot snapshot = compileStages(access, diagnostics, true);
+        Urbex.getLogger().info("Compiled {} Urbex assets ({} problem(s))",
+                snapshot.totalAssets(), diagnostics.size());
+        return snapshot;
+    }
+
+    /**
+     * The same snapshot {@link #compile} builds, without the two passes that only produce a report.
+     *
+     * <p>For callers that discard the diagnostics: today that is the world-creation preview alone
+     * (see {@code PreviewContext}), which runs on the client before any server exists, has no
+     * session to refuse a world from, and rebuilds its context whenever the player changes a preset
+     * or a world style. Reporting a broken pack is the world load's business, and the preview
+     * throwing or logging on its behalf would only leave the player unable to see why.</p>
+     *
+     * <p>What it skips is {@link AssetGraph#validate} and {@link #promoteReachableCityStyleProblems},
+     * both of which write into an {@link AssetDiagnostics} and touch nothing else - the snapshot's
+     * indexes are already immutable by then. That is not a micro-optimisation: measured against the
+     * bundled datapack the graph walk is ~96% of a compile (~290 ms of ~300 ms), and it scales with
+     * the number of loaded packs, so the preview was spending seconds per click computing a report
+     * it dropped on the floor. {@code AssetCompilerTest} pins that the two paths agree on the
+     * snapshot.</p>
+     *
+     * <p><strong>Not for world load.</strong> {@code GenerationSession} and {@code CommandValidate}
+     * must keep using {@link #compile}: a pack whose references dangle has to be refused before a
+     * chunk generates, which is the whole of issue #56.</p>
+     */
+    public static AssetSnapshot compileWithoutValidation(RegistryAccess access) {
+        return compileStages(access, new AssetDiagnostics(), false);
+    }
+
+    /**
+     * Every compilation stage, in the dependency order documented on this class, optionally followed
+     * by the two report-only passes.
+     */
+    private static AssetSnapshot compileStages(RegistryAccess access, AssetDiagnostics diagnostics,
+                                               boolean validate) {
         // The block registry the whole compilation resolves against, taken once from the world
         // being loaded. Every block string below reaches it through a parameter: resolution used
         // to pick a registry for itself, from a static server reference that may or may not have
@@ -104,20 +141,22 @@ public final class AssetCompiler {
         AssetIndex<StuffObject> stuff = AssetStage.compileAll(access,
                 CustomRegistries.STUFF_REGISTRY_KEY, (id, chain) -> new StuffObject(id, chain), diagnostics);
 
-        Set<Identifier> reachableCityStyles = reachableCityStyles(access, worldStyles);
-        promoteReachableCityStyleProblems(cityStyles, reachableCityStyles, cityStyleProblems, diagnostics);
-
         AssetSnapshot snapshot = new AssetSnapshot(variants, palettes, conditions, styles, parts,
                 buildings, multiBuildings, scattered, worldStyles, cityStyles, predefinedCities,
                 stuff, groupStuffByTag(stuff.all()),
                 PredefinedIndex.build(predefinedCities, multiBuildings));
+        if (!validate) {
+            // The city-style problems collected above are dropped with the rest of the report: the
+            // caller asked for a snapshot, not for an opinion about the pack.
+            return snapshot;
+        }
+        Set<Identifier> reachableCityStyles = reachableCityStyles(access, worldStyles);
+        promoteReachableCityStyleProblems(cityStyles, reachableCityStyles, cityStyleProblems, diagnostics);
         // Last, on the finished snapshot: the cross-asset references are names, and resolving them
         // needs every index built. Generation resolves them one at a time on whichever chunk first
         // needs one, which is the whole of what issue #56's second half is about.
         AssetGraph.validate(snapshot, reachableCityStyles.stream()
                 .map(cityStyles::get).filter(Objects::nonNull).toList(), diagnostics);
-        Urbex.getLogger().info("Compiled {} Urbex assets ({} problem(s))",
-                snapshot.totalAssets(), diagnostics.size());
         return snapshot;
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCharacterCheck.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCharacterCheck.java
@@ -129,10 +129,24 @@ final class PaletteCharacterCheck {
 
         SortedSet<Character> never = new TreeSet<>();
         SortedSet<Character> sometimes = new TreeSet<>();
+        // The witnesses are a function of (groups, building, local) and of no character at all, so
+        // they are built once for the whole part rather than once per character it uses. They were
+        // rebuilt per character until issue #198, which made this check ~96% of a compile and 890 MB
+        // of allocation on the shipped pack alone - a part uses tens of distinct characters, and each
+        // one was re-merging every choice of every group from scratch.
+        //
+        // Built lazily, because a part every one of whose characters is undefined everywhere never
+        // asks the question, and building them for it would be the one case where this is pure waste.
+        List<CompiledPalette> witnesses = null;
         for (char c : used) {
             if (!everything.isDefined(c)) {
                 never.add(c);
-            } else if (hasFailingSelection(c, groups, building, local)) {
+                continue;
+            }
+            if (witnesses == null) {
+                witnesses = witnesses(groups, building, local);
+            }
+            if (hasFailingSelection(c, witnesses)) {
                 sometimes.add(c);
             }
         }
@@ -166,15 +180,20 @@ final class PaletteCharacterCheck {
     }
 
     /**
-     * Whether some selection provably fails to define {@code c}.
+     * One palette per (group, choice): that choice, plus everything every <em>other</em> group
+     * offers, merged over the building's and the part's own.
      *
-     * <p>The witness is one choice plus everything every other group offers. That is more than any
-     * real selection gets, so a character missing from it is missing from every selection containing
-     * that choice - which makes this sound in the only direction that matters: nothing is reported
-     * without a selection that really breaks.</p>
+     * <p>Each is more than any real selection gets - the other groups were given all their choices at
+     * once, where a selection picks one - so a character missing from a witness is missing from every
+     * selection that picks that choice. That is what makes {@link #hasFailingSelection} sound in the
+     * only direction that matters: nothing is reported without a selection that really breaks.</p>
+     *
+     * <p>None of this depends on the character being asked about, which is why it is built once per
+     * part rather than once per character (issue #198).</p>
      */
-    private static boolean hasFailingSelection(char c, List<List<Pair<Float, Palette>>> groups,
-                                               @Nullable Palette building, @Nullable Palette part) {
+    private static List<CompiledPalette> witnesses(List<List<Pair<Float, Palette>>> groups,
+                                                   @Nullable Palette building, @Nullable Palette part) {
+        List<CompiledPalette> witnesses = new ArrayList<>();
         for (int g = 0; g < groups.size(); g++) {
             for (Pair<Float, Palette> choice : groups.get(g)) {
                 List<Palette> witness = new ArrayList<>();
@@ -185,9 +204,17 @@ final class PaletteCharacterCheck {
                         groups.get(other).forEach(alternative -> witness.add(alternative.getRight()));
                     }
                 }
-                if (!merge(witness, building, part).isDefined(c)) {
-                    return true;
-                }
+                witnesses.add(merge(witness, building, part));
+            }
+        }
+        return witnesses;
+    }
+
+    /** Whether some selection provably fails to define {@code c}; see {@link #witnesses}. */
+    private static boolean hasFailingSelection(char c, List<CompiledPalette> witnesses) {
+        for (CompiledPalette witness : witnesses) {
+            if (!witness.isDefined(c)) {
+                return true;
             }
         }
         return false;

--- a/src/test/java/dev/krona/urbex/gui/preview/CityPreviewOffThreadTest.java
+++ b/src/test/java/dev/krona/urbex/gui/preview/CityPreviewOffThreadTest.java
@@ -1,0 +1,110 @@
+package dev.krona.urbex.gui.preview;
+
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.setup.WorldStyleMix;
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code update} hands the recompute to an executor instead of doing it on the calling thread.
+ *
+ * <p>This is the regression this pair of classes exists to prevent, and it is checkable without a
+ * game: hand the preview an executor that never runs anything, and {@code update} must still return
+ * having computed nothing. If the walk ever moves back inline, the queue here stays empty and the
+ * work happens anyway - which is what these assertions catch.</p>
+ *
+ * <p>The other half - uploading the finished buffer - is GL, so it is not reachable headlessly and
+ * is not attempted here. {@link PendingWorkTest} covers the handoff that decides whether an upload
+ * happens at all.</p>
+ */
+class CityPreviewOffThreadTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    /** Holds submitted work instead of running it, so "was it submitted" and "did it run" differ. */
+    private static final class Deferred implements Executor {
+        private final List<Runnable> queued = new ArrayList<>();
+
+        @Override
+        public void execute(Runnable command) {
+            queued.add(command);
+        }
+    }
+
+    private static final WorldStyleMix STYLES =
+            WorldStyleMix.of(Identifier.fromNamespaceAndPath("urbex", "standard"));
+
+    private static Preset preset() {
+        return new Preset(Identifier.fromNamespaceAndPath("urbex", "test-offthread"));
+    }
+
+    @Test
+    void updateSubmitsTheRecomputeRatherThanRunningIt() {
+        Deferred executor = new Deferred();
+        CityPreview preview = new CityPreview(null, executor);
+
+        preview.update(preset(), STYLES, 1234L, CityPreview.Mode.MAP);
+
+        assertEquals(1, executor.queued.size(),
+                "the recompute must be handed to the executor, not run on the render thread");
+    }
+
+    @Test
+    void anUnchangedKeySubmitsNothingFurther() {
+        Deferred executor = new Deferred();
+        CityPreview preview = new CityPreview(null, executor);
+        preview.update(preset(), STYLES, 1234L, CityPreview.Mode.MAP);
+
+        // A fresh Preset instance with identical content: the key is a content hash, so this is the
+        // same picture and must not be recomputed. The Cities tab calls update() once per frame.
+        preview.update(preset(), STYLES, 1234L, CityPreview.Mode.MAP);
+        preview.update(preset(), STYLES, 1234L, CityPreview.Mode.MAP);
+
+        assertEquals(1, executor.queued.size(), "repeat frames must not queue more work");
+    }
+
+    @Test
+    void eachRealChangeSubmitsItsOwnRecompute() {
+        Deferred executor = new Deferred();
+        CityPreview preview = new CityPreview(null, executor);
+
+        preview.update(preset(), STYLES, 1234L, CityPreview.Mode.MAP);
+        preview.update(preset(), STYLES, 9999L, CityPreview.Mode.MAP);
+        preview.update(preset(), STYLES, 9999L, CityPreview.Mode.ROADS);
+
+        assertEquals(3, executor.queued.size(), "a new seed and a new mode are each a new picture");
+    }
+
+    /**
+     * Clearing the selection must not leave a computation that finishes later and paints over the
+     * now-empty preview.
+     */
+    @Test
+    void clearingTheSelectionAbandonsWorkInFlight() {
+        Deferred executor = new Deferred();
+        CityPreview preview = new CityPreview(null, executor);
+        preview.update(preset(), STYLES, 1234L, CityPreview.Mode.MAP);
+
+        preview.update(null, STYLES, 1234L, CityPreview.Mode.MAP);
+
+        // Running the abandoned task now is what a worker finishing after the fact looks like. It
+        // must be inert: no upload is attempted, so this cannot reach GL and cannot throw.
+        assertEquals(1, executor.queued.size());
+        executor.queued.getFirst().run();
+        assertTrue(true, "the abandoned computation ran without reaching the screen");
+    }
+}

--- a/src/test/java/dev/krona/urbex/gui/preview/PendingWorkTest.java
+++ b/src/test/java/dev/krona/urbex/gui/preview/PendingWorkTest.java
@@ -1,0 +1,144 @@
+package dev.krona.urbex.gui.preview;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The preview's one-slot job queue, which is what lets the recompute leave the render thread.
+ *
+ * <p>Everything here is exercised on a direct executor, so the ordering under test is the class's
+ * own rather than a scheduler's. The threading it exists to survive - a worker finishing while the
+ * player is already three presets further on - is expressed as a superseded request, which is what
+ * that looks like from the render thread.</p>
+ */
+class PendingWorkTest {
+
+    /** Runs the work on the calling thread, so "in flight" and "finished" are decidable in a test. */
+    private static final Executor DIRECT = Runnable::run;
+
+    @Test
+    void afinishedResultIsHandedBackToTheKeyThatAskedForIt() {
+        PendingWork<String> work = new PendingWork<>(DIRECT);
+
+        work.request("map", () -> new int[]{1, 2, 3});
+
+        assertArrayEquals(new int[]{1, 2, 3}, work.take("map"));
+    }
+
+    @Test
+    void aResultIsHandedBackOnceAndThenTheSlotIsFree() {
+        PendingWork<String> work = new PendingWork<>(DIRECT);
+        work.request("map", () -> new int[]{1});
+
+        work.take("map");
+
+        assertNull(work.take("map"), "the second poll of the same frame must not re-upload");
+        assertFalse(work.isBusy(), "and the slot is free for the next request");
+    }
+
+    /**
+     * The case the whole class is for: the player switches preset again before the first computation
+     * lands. The stale image must never reach the screen, however it finishes.
+     */
+    @Test
+    void asupersededRequestNeverDeliversItsResult() {
+        PendingWork<String> work = new PendingWork<>(DIRECT);
+        work.request("first", () -> new int[]{1});
+
+        work.request("second", () -> new int[]{2});
+
+        assertArrayEquals(new int[]{2}, work.take("second"),
+                "the slot holds the latest request, not the one it replaced");
+        assertFalse(work.isBusy(), "and the abandoned result is not queued up behind it");
+    }
+
+    @Test
+    void aresultForAKeyNobodyWantsIsDroppedRatherThanShown() {
+        PendingWork<String> work = new PendingWork<>(DIRECT);
+        work.request("stale", () -> new int[]{1});
+
+        assertNull(work.take("current"));
+        assertFalse(work.isBusy(), "dropping it frees the slot rather than wedging it");
+    }
+
+    /**
+     * A computation can throw: {@code PresetRoadGrid.of} refuses a momentarily self-contradictory
+     * preset, which is an ordinary state while two paired sliders are being dragged. The render
+     * thread must not see that exception - it keeps the last good image, as it did when the compute
+     * ran inline.
+     */
+    @Test
+    void afailedComputationIsDroppedRatherThanThrownAtTheRenderThread() {
+        PendingWork<String> work = new PendingWork<>(DIRECT);
+        work.request("boom", () -> {
+            throw new IllegalArgumentException("minimum exceeds maximum");
+        });
+
+        assertNull(work.take("boom"));
+        assertFalse(work.isBusy());
+    }
+
+    @Test
+    void cancellingDropsAFinishedResult() {
+        PendingWork<String> work = new PendingWork<>(DIRECT);
+        work.request("map", () -> new int[]{1});
+
+        work.cancel();
+
+        assertNull(work.take("map"), "a closed preview must not upload work started before it closed");
+        assertFalse(work.isBusy());
+    }
+
+    @Test
+    void workInFlightIsNotYetAResult() throws Exception {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            CountDownLatch release = new CountDownLatch(1);
+            CountDownLatch started = new CountDownLatch(1);
+            PendingWork<String> work = new PendingWork<>(pool);
+
+            work.request("map", () -> {
+                started.countDown();
+                await(release);
+                return new int[]{7};
+            });
+            assertTrue(started.await(5, TimeUnit.SECONDS));
+
+            assertNull(work.take("map"), "an unfinished computation must not block the render thread");
+            assertTrue(work.isBusy());
+
+            release.countDown();
+            int[] result = null;
+            for (int i = 0; i < 500 && result == null; i++) {
+                result = work.take("map");
+                if (result == null) {
+                    Thread.sleep(10);
+                }
+            }
+            assertArrayEquals(new int[]{7}, result);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("latch never released");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/dev/krona/urbex/gui/preview/PreviewAssetsTest.java
+++ b/src/test/java/dev/krona/urbex/gui/preview/PreviewAssetsTest.java
@@ -1,0 +1,105 @@
+package dev.krona.urbex.gui.preview;
+
+import com.mojang.serialization.Lifecycle;
+import dev.krona.urbex.setup.CustomRegistries;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * The preview's asset snapshot is compiled once per set of registries, not once per recompute.
+ *
+ * <p>Every preset switch, world-style switch and seed edit rebuilds a {@link PreviewContext}, and
+ * each one used to compile the whole snapshot again - hundreds of milliseconds on the render thread
+ * for a value that is a pure function of registries that had not changed. The registries do change,
+ * though: switching datapacks in the create-world screen produces a new {@code RegistryAccess}, and
+ * a stale snapshot there would preview a pack the player has just turned off.</p>
+ */
+class PreviewAssetsTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @BeforeEach
+    @AfterEach
+    void clearCache() {
+        PreviewAssets.clear();
+    }
+
+    @Test
+    void theSameRegistriesCompileOnce() {
+        RegistryAccess access = registries();
+
+        AssetSnapshot first = PreviewAssets.of(access);
+        AssetSnapshot second = PreviewAssets.of(access);
+
+        assertSame(first, second, "a second recompute against the same registries must reuse the snapshot");
+    }
+
+    @Test
+    void differentRegistriesCompileAgain() {
+        AssetSnapshot first = PreviewAssets.of(registries());
+
+        AssetSnapshot second = PreviewAssets.of(registries());
+
+        assertNotSame(first, second, "new registries are a new pack set, so the snapshot must be rebuilt");
+    }
+
+    @Test
+    void clearingDropsTheSnapshot() {
+        RegistryAccess access = registries();
+        AssetSnapshot first = PreviewAssets.of(access);
+
+        PreviewAssets.clear();
+
+        assertNotSame(first, PreviewAssets.of(access),
+                "clear() must release the snapshot, not just mark it stale");
+    }
+
+    @Test
+    void noRegistriesIsAnEmptySnapshotRatherThanACompile() {
+        AssetSnapshot empty = PreviewAssets.of(null);
+
+        assertSame(0, empty.totalAssets(), "the null-registry fallback compiles nothing");
+    }
+
+    /** An access with every Urbex registry present and empty, which is all this cache needs. */
+    private static RegistryAccess registries() {
+        List<Registry<?>> all = new ArrayList<>();
+        all.add(BuiltInRegistries.BLOCK);
+        for (ResourceKey<? extends Registry<?>> key : List.of(
+                CustomRegistries.VARIANTS_REGISTRY_KEY, CustomRegistries.PALETTE_REGISTRY_KEY,
+                CustomRegistries.CONDITIONS_REGISTRY_KEY, CustomRegistries.STYLE_REGISTRY_KEY,
+                CustomRegistries.PART_REGISTRY_KEY, CustomRegistries.BUILDING_REGISTRY_KEY,
+                CustomRegistries.MULTIBUILDINGS_REGISTRY_KEY, CustomRegistries.SCATTERED_REGISTRY_KEY,
+                CustomRegistries.WORLDSTYLES_REGISTRY_KEY, CustomRegistries.CITYSTYLES_REGISTRY_KEY,
+                CustomRegistries.PREDEFINEDCITIES_REGISTRY_KEY, CustomRegistries.STUFF_REGISTRY_KEY,
+                CustomRegistries.PRESET_REGISTRY_KEY)) {
+            all.add(empty(key));
+        }
+        return new RegistryAccess.ImmutableRegistryAccess(all).freeze();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Registry<T> empty(ResourceKey<? extends Registry<?>> key) {
+        return new MappedRegistry<T>((ResourceKey<Registry<T>>) key, Lifecycle.stable()).freeze();
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompilerTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/AssetCompilerTest.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -89,6 +90,42 @@ class AssetCompilerTest {
         assertNull(snapshot.palettes().get("urbex:broken"), "the broken one is absent");
         assertNotNull(snapshot.palettes().get("urbex:walls"), "the one after it compiled anyway");
         assertEquals(1, snapshot.variants().size(), "and the stage before it is untouched");
+    }
+
+    /**
+     * The snapshot {@link AssetCompiler#compileWithoutValidation} builds is the same snapshot
+     * {@link AssetCompiler#compile} builds. Only the report differs.
+     * <p>
+     * This is the whole licence for the world-creation preview to take the cheap path: the
+     * validation it skips is {@link AssetGraph} and the city-style promotion, both of which write
+     * into an {@link AssetDiagnostics} and touch nothing else. If validation ever gains a side
+     * effect on the snapshot, this test is what fails.
+     */
+    @Test
+    void skippingValidationChangesTheReportAndNotTheSnapshot() {
+        RegistryAccess access = registries(
+                variant("rubble", "minecraft:deepslate"),
+                paletteNamingVariant("walls", 'V', "urbex:rubble"),
+                // Names a city style nothing registers, so the validated path has something to report.
+                worldStyleEntry("missing", Optional.empty()));
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+
+        AssetSnapshot validated = AssetCompiler.compile(access, diagnostics);
+        AssetSnapshot unvalidated = AssetCompiler.compileWithoutValidation(access);
+
+        assertFalse(diagnostics.isEmpty(), "the validated path has something to say about this pack");
+        assertEquals(validated.totalAssets(), unvalidated.totalAssets());
+        assertEquals(names(validated.variants()), names(unvalidated.variants()));
+        assertEquals(names(validated.palettes()), names(unvalidated.palettes()));
+        assertEquals(names(validated.worldStyles()), names(unvalidated.worldStyles()));
+        assertEquals(names(validated.cityStyles()), names(unvalidated.cityStyles()));
+        assertNotNull(unvalidated.palettes().get("urbex:walls"),
+                "and the stages themselves still ran");
+    }
+
+    /** Ids, not instances: two compiles of the same registries build equal content, not the same objects. */
+    private static List<String> names(AssetIndex<?> index) {
+        return index.ids().stream().map(Identifier::toString).sorted().toList();
     }
 
     /**

--- a/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCharacterCheckTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/lost/cityassets/PaletteCharacterCheckTest.java
@@ -16,6 +16,7 @@ import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +91,33 @@ class PaletteCharacterCheckTest {
         assertFalse(diagnostics.hasFatal(), "the world still loads: most draws place this part fine");
         assertTrue(diagnostics.problems().getFirst().message().contains("'b'"),
                 diagnostics.problems().getFirst().message());
+    }
+
+    /**
+     * Each character gets its own answer, even though the witness palettes they are tested against
+     * are now built once for the whole part rather than once per character (issue #198).
+     * <p>
+     * Hoisting that construction out of the character loop is what makes this check affordable - it
+     * was ~96% of a compile and 890 MB of allocation - and the way to get it wrong is to let one
+     * character's result leak into the next. Here {@code 'b'} is defined by only one choice (a
+     * warning), {@code 'z'} by none (a load error), and {@code 'a'} by both (silence); a shared
+     * witness that had been mutated or short-circuited would collapse them together.
+     */
+    @Test
+    void charactersInOneMixedPartAreEachAnsweredSeparately() {
+        AssetDiagnostics diagnostics = new AssetDiagnostics();
+        Style style = style(group(
+                palette("rich", entry('a', "minecraft:stone"), entry('b', "minecraft:glass")),
+                palette("plain", entry('a', "minecraft:stone"))));
+
+        PaletteCharacterCheck.check(part("tower", "abz"), usage(style), diagnostics);
+
+        assertEquals(2, diagnostics.size(), () -> diagnostics.format(""));
+        assertTrue(diagnostics.hasFatal(), "'z' is defined nowhere, so the world must not load");
+        String report = diagnostics.format("");
+        assertTrue(report.contains("'z'"), report);
+        assertTrue(report.contains("'b'"), report);
+        assertFalse(report.contains("'a'"), () -> "'a' is defined by every choice: " + report);
     }
 
     /**
@@ -181,13 +209,19 @@ class PaletteCharacterCheckTest {
                 new PaletteDefinition(Optional.empty(), Optional.of(List.of(entries)))));
     }
 
-    /** A 1x{@code slice.length()} part, so the slice string is the character list under test. */
+    /**
+     * A 1x1 part one level tall per character, so the slice string is exactly the character list
+     * under test - any length, rather than the two the shape of this fixture used to fix it at.
+     */
     private static BuildingPart buildPart(String path, String slice, Optional<PaletteDefinition> local) {
         Identifier id = Identifier.fromNamespaceAndPath("urbex", path);
+        List<List<String>> levels = new ArrayList<>(slice.length());
+        for (char c : slice.toCharArray()) {
+            levels.add(List.of(String.valueOf(c)));
+        }
         return new BuildingPart(id, BuiltInRegistries.BLOCK, null, AssetIndex.empty("urbex:palettes"),
                 List.of(new BuildingPartDefinition(Optional.empty(), Optional.of(1), Optional.of(1),
-                        Optional.of(List.of(List.of(slice.substring(0, 1)), List.of(slice.substring(1)))),
-                        Optional.empty(), local, Optional.empty())));
+                        Optional.of(levels), Optional.empty(), local, Optional.empty())));
     }
 
     @SafeVarargs


### PR DESCRIPTION
Opening the Cities page, switching preset or switching world style froze the create-world screen -
micro-stutters on the bundled pack alone, seconds with a real mod set loaded. The cause is not the
chunk walk everyone assumes it is: the preview was running a **full asset compilation on the render
thread on every change**, and ~96% of that compilation was building a diagnostics report it then
threw away.

Closes #198, whose 890 MB allocation site turns out to be the same hot spot seen from the world-load
side.

## Results

Bundled datapack loaded through the real codecs into a `RegistryAccess`, then duplicated into N
self-contained packs (namespace-renamed throughout, so each stands for an independent third-party
pack rather than a thin extension). Best of 5, one machine - the ratios are the point, not the
absolutes.

**`AssetCompiler.compile`** - the world-load path, fixed by the #198 half alone:

| packs | assets | before | after | |
|---|---|---|---|---|
| 1 | 298 | 301 ms | **63 ms** | −79% |
| 2 | 596 | 592 ms | **128 ms** | −78% |
| 4 | 1192 | 1210 ms | **249 ms** | −79% |
| 8 | 2384 | 2434 ms | **512 ms** | −79% |

**What the preview actually runs now**, after also dropping the validation it discards:

| packs | before | after |
|---|---|---|
| 1 | 301 ms | **1.6 ms** |
| 8 | 2434 ms | **11.4 ms** |

and after the first one, a cached lookup. The 8-pack column is what the 3-5 second freeze was.

## Where the time was

`CitiesTab`'s preview widget drives `CityPreview.update` from `extractWidgetRenderState` - every
frame, guarded only by a cache key. Any key change (preset, world style, seed, editor category, or a
150 ms debounce settle in Customize) ran the whole recompute inline, and `PreviewContext.create`
began with `AssetCompiler.compile`.

Splitting that compile by phase:

| | 1 pack | 8 packs |
|---|---|---|
| `AssetGraph.validate` | 289 ms | 2430 ms |
| every other compile stage | ~12 ms | ~10 ms |
| the 62x58 chunk walk | 24-29 ms | 24-29 ms |
| `presetHash`, per frame | 0.019 ms | 0.019 ms |

The chunk walk is **not** uncached - `PlanningContext` carries `DimensionCaches`, so city factors,
candidates and rail/highway levels memoize across the 3596 chunks within one recompute. It is ~1% of
the problem. `presetHash` runs every frame before the cache check and is 19 µs; noted and left alone.

## The changes

**1. Witness palettes are built once per part, not once per character** (`6bc11d3b`, #198)

`PaletteCharacterCheck.hasFailingSelection` rebuilt every witness `CompiledPalette` for every
character, though the witnesses depend only on `(groups, building, part)` and on nothing about the
character being asked about. A part uses tens of distinct characters, so each one re-merged every
choice of every group from scratch. Hoisted out of the character loop, and built lazily - a part
whose characters are all undefined everywhere never asks the question.

This is the whole of the table above, and it lands on world load too.

**2. The preview stops computing a report it discards**

`AssetCompiler.compileWithoutValidation` skips `AssetGraph.validate` and
`promoteReachableCityStyleProblems`. Both write into an `AssetDiagnostics` and touch nothing else -
the snapshot's indexes are already immutable by then - and `PreviewContext` passes a throwaway
`AssetDiagnostics` on purpose, because refusing a broken pack is the world load's business and a
preview that threw would leave the player unable to see why.

`GenerationSession` and `CommandValidate` keep using `compile`. A new `AssetCompilerTest` case pins
that the two paths agree on the snapshot and differ only in the report - that test is the licence for
this, and it is what fails if validation ever gains a side effect.

**3. One snapshot per set of registries, not per recompute**

The snapshot is a pure function of the `RegistryAccess`, but the Cities tab and the Customize screen
hold separate `CityPreview`s and each rebuilt its own on every change. `PreviewAssets` holds one,
keyed on **instance identity**: switching datapacks reloads the world-gen context and hands back a
new `RegistryAccess`, so a stale snapshot cannot preview a pack the player has just turned off. Weak
key, and released with the screen from `closeActivePreview` - a world that is never created must not
leave its assets, and through them its registries, alive.

**4. The chunk walk leaves the render thread**

What remained was ~25 ms inside the render pass, which is a dropped frame on every change.
`PendingWork` gives it a one-slot job queue - at most one computation in flight, every new request
supersedes the last, because a player dragging through presets generates requests far faster than
the walk completes and there is no value in finishing the third of five. The screen keeps showing
the image it already has until a result lands; the GL upload stays on the render thread.

The renderers became pure functions over an explicit buffer, allocated per computation so the worker
never writes into one the render thread is still uploading. `Preset` and `WorldStyleMix` are already
immutable (`PresetDraft.resolve` hands out a fresh `Preset`), so nothing is copied and nothing races
with the editor going on mutating the draft they came from.

## One behaviour change

While a computation is in flight and there is no texture yet, the preview area stays **empty**
instead of saying "preview unavailable". That string is a statement about the pack, not about a frame
that has not arrived, and the first computation after the screen opens always takes a frame or two -
so it would otherwise flash an error on every open.

## Verification

- 738 unit tests pass. New coverage: `PendingWorkTest` (7), `PreviewAssetsTest` (4),
  `CityPreviewOffThreadTest` (4), plus the two guards described above.
- **All five digest goldens still match**, `unsafeReads=0`. Output is unchanged by construction -
  `AssetGraph` produces diagnostics and nothing else reads it - and the goldens confirm it.
- The client boots with the mod loaded, no mixin or Urbex errors.

**Not verified: the Cities tab rendered on screen.** The dev client is a raw JVM process that this
machine's app index will not target, so driving the GUI automatically was blocked. The GL upload
happens at the same call site and in the same context as before, but the two things worth a manual
pass are the empty-vs-"unavailable" first frame and fast preset switching leaving the previous image
up rather than stuttering.

The measurement harnesses were temporary and are not part of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
