### PR TITLE
perf: cut the corrections pass by 30%, and stop the digest harness inflating every measurement

### DIFF
--- a/src/main/java/dev/krona/urbex/varia/GenerationMetrics.java
+++ b/src/main/java/dev/krona/urbex/varia/GenerationMetrics.java
@@ -34,15 +34,117 @@ public final class GenerationMetrics {
     /** {@code -Durbex.metrics} to switch the counters on. */
     public static final String ENABLED_PROPERTY = "urbex.metrics";
 
+    /**
+     * {@code -Durbex.metrics.warmup=N} discards the first {@code N} chunks a run generates.
+     *
+     * <p>Nothing here is measured from a cold JVM by choice. The asset compile is already outside
+     * the window - {@code AssetCompiler.compile} runs at level load and {@link #reset} runs when the
+     * drive starts - but two things still warm up inside it: the palette cache, whose misses are
+     * almost entirely in the first few hundred chunks, and the JIT, which over a three-minute run
+     * has compiled the generation path long before the run ends. Both inflate the early chunks and
+     * neither is a property of the steady state.</p>
+     *
+     * <p>Zero by default, so an unasked run measures exactly what it measured before. The point is
+     * to run the same drive twice and compare, rather than to pick one number and defend it: if the
+     * two lines agree, warm-up was not distorting anything and the exclusion can be forgotten.</p>
+     */
+    public static final String WARMUP_PROPERTY = "urbex.metrics.warmup";
+
     private static final boolean ENABLED = System.getProperty(ENABLED_PROPERTY) != null;
 
+    private static final int WARMUP_CHUNKS = Math.max(0, Integer.getInteger(WARMUP_PROPERTY, 0));
+
     private static final com.sun.management.ThreadMXBean THREADS = threadBean();
+
+    /**
+     * Which half of a chunk's generation a sample belongs to.
+     *
+     * <p>The split is the one {@code CityGenerator.generateOrThrow} already makes and that every
+     * proposal to move work off the chunk pipeline's critical path depends on. {@link #PLAN} is a
+     * pure function of the seed and the coordinate - {@code TerrainSampler} reads no block, and
+     * {@code DimensionCaches} documents every value in it as recomputable by any thread at any time
+     * - so it is the half that <em>could</em> be computed before anyone asks for the chunk.
+     * {@link #BUILD} needs the real chunk and the real region, so it cannot.</p>
+     *
+     * <p>Measuring them separately is what turns "planning looks expensive" into a ratio.
+     * {@link #PLAN} and {@link #BUILD} are contiguous and exhaustive: every nanosecond
+     * {@link #chunk} counts is in exactly one of them, which is why the report can print each as a
+     * percentage of the chunk mean.</p>
+     *
+     * <p>Every phase after {@code BUILD} is one pass <em>inside</em> it, so those overlap {@code
+     * BUILD} rather than partitioning the chunk - they sum to roughly what {@code BUILD} reports,
+     * and the shortfall is the glue between passes. Each is a share of the same chunk mean, which
+     * is the comparison that matters: a pass owning a visible fraction of a chunk is worth opening
+     * up, and one owning 0.3% is not, whatever its internals look like.</p>
+     */
+    public enum Phase {
+        /** The heightmap copy and the chunk plan: pure, cached, speculatable. */
+        PLAN,
+        /** Everything after it, as one figure. The sub-phases below partition this. */
+        BUILD,
+        /** The village/structure blacklist probe, and the floating-profile void test. */
+        PROBE,
+        /** {@code doCityChunk}: streets, buildings, parts. The city itself. */
+        CITY,
+        /** {@code doNormalChunk}: the terrain a non-city chunk gets instead. */
+        TERRAIN,
+        /** Railways, their dungeons, and the building-collision test that can cancel them. */
+        RAIL,
+        /** The deferred optional lights, planned and placed. */
+        LIGHTS,
+        /** Explosion damage and the floating-block repair that follows it. */
+        DAMAGE,
+        /** Scattered debris. */
+        DEBRIS,
+        /** {@code driver.actuallyGenerate}: the buffered blocks reaching the chunk. */
+        COMMIT,
+        /** Inside {@code COMMIT}: the connection/shape corrections pass over every written position. */
+        CORRECT,
+        /** Inside {@code CORRECT}: extracting and sorting the written positions. */
+        CORRECT_SORT,
+        /** Inside {@code CORRECT}: the shape/connection resolution over those positions. */
+        CORRECT_SHAPE,
+        /** Inside {@code COMMIT}: the buffered sections being flushed into the chunk. */
+        FLUSH,
+        /** Inside {@code COMMIT}: {@code Heightmap.primeHeightmaps} over four heightmap types. */
+        HEIGHTMAP,
+        /**
+         * Inside {@code COMMIT}: handing this chunk's write log to the digest harness.
+         *
+         * <p><strong>Harness overhead, not generation.</strong> It does nothing unless
+         * {@code /urbex digest} switched write recording on - which the digest suites do for every
+         * run, including the soak this report comes from. So it is measured precisely so it can be
+         * subtracted: a figure taken from a digest run describes the mod as shipped only once this
+         * phase is taken out of it.</p>
+         */
+        PUBLISH,
+        /** {@code ChunkFixer.fix} and the block-entity sweep after it. */
+        FIXER
+    }
 
     /** Chunk generation times, bucketed by {@code floor(log2(micros))}. */
     private static final LongAdder[] CHUNK_BUCKETS = newBuckets();
     private static final LongAdder CHUNK_COUNT = new LongAdder();
     private static final LongAdder CHUNK_NANOS = new LongAdder();
     private static final AtomicLong CHUNK_MAX_NANOS = new AtomicLong();
+
+    /**
+     * How many chunks have <em>started</em> generating, which is what an ordinal is taken from.
+     *
+     * <p>Counted at the start rather than derived from {@link #CHUNK_COUNT} because a phase is
+     * recorded before its chunk finishes, and the warm-up rule has to reach the same verdict for a
+     * chunk's phases as it does for the chunk itself. An ordinal handed out once, at the top,
+     * settles that for every sample the chunk will produce.</p>
+     */
+    private static final AtomicLong CHUNK_ORDINAL = new AtomicLong();
+
+    /** How many chunks the warm-up exclusion discarded, so a report can say so rather than imply it. */
+    private static final LongAdder WARMUP_SKIPPED = new LongAdder();
+
+    private static final LongAdder[] PHASE_NANOS = newPhaseAdders();
+    private static final LongAdder[] PHASE_COUNT = newPhaseAdders();
+    private static final LongAdder[] PHASE_ALLOC = newPhaseAdders();
+    private static final AtomicLong[] PHASE_MAX_NANOS = newPhaseMaxima();
 
     /** Thread id -> allocated bytes when that thread first generated something. */
     private static final Map<Long, Long> ALLOCATION_BASELINE = new ConcurrentHashMap<>();
@@ -67,6 +169,17 @@ public final class GenerationMetrics {
         CHUNK_COUNT.reset();
         CHUNK_NANOS.reset();
         CHUNK_MAX_NANOS.set(0);
+        // The ordinal too, so the warm-up exclusion applies to the first chunks of *this* run. A
+        // counter that kept climbing would exclude nothing on a second run in the same JVM, which is
+        // the shape the digest suites use.
+        CHUNK_ORDINAL.set(0);
+        WARMUP_SKIPPED.reset();
+        for (int i = 0; i < PHASE_NANOS.length; i++) {
+            PHASE_NANOS[i].reset();
+            PHASE_COUNT[i].reset();
+            PHASE_ALLOC[i].reset();
+            PHASE_MAX_NANOS[i].set(0);
+        }
         ALLOCATION_BASELINE.clear();
         ALLOCATION_LATEST.clear();
         // Zeroed in place, not dropped: a TimedCache takes its CacheStats once, at construction, so
@@ -83,8 +196,12 @@ public final class GenerationMetrics {
      * allocation is the sum over threads of {@code latest - baseline}. Sampling here rather than
      * around the whole run is what keeps it to the threads that actually generated.</p>
      */
-    public static void chunk(long nanos) {
+    public static void chunk(long ordinal, long nanos) {
         if (!ENABLED) {
+            return;
+        }
+        if (isWarmup(ordinal)) {
+            WARMUP_SKIPPED.increment();
             return;
         }
         CHUNK_COUNT.increment();
@@ -99,6 +216,81 @@ public final class GenerationMetrics {
                 ALLOCATION_LATEST.put(id, allocated);
             }
         }
+    }
+
+    /**
+     * Claims this chunk's ordinal, at the top of its generation.
+     *
+     * <p>Every sample the chunk goes on to produce carries it, so the warm-up rule reaches one
+     * verdict per chunk rather than one per sample - a chunk cannot have its planning discarded as
+     * warm-up and its building counted. Returns zero, and counts nothing, when metrics are off.</p>
+     */
+    public static long beginChunk() {
+        return ENABLED ? CHUNK_ORDINAL.getAndIncrement() : 0L;
+    }
+
+    /** A nanosecond baseline for {@link #phase}, or zero when nobody is measuring. */
+    public static long mark() {
+        return ENABLED ? System.nanoTime() : 0L;
+    }
+
+    /**
+     * An allocation baseline for {@link #phase}, in bytes, or zero when nobody is measuring.
+     *
+     * <p>Per thread and cumulative, so the delta across a phase is exactly what that phase
+     * allocated on the thread that ran it - which is the only figure worth having here, since
+     * worldgen fans out and a heap delta would measure the collector's mood instead. Zero when the
+     * JVM is not HotSpot or the counter is off, and a phase whose baseline is zero contributes no
+     * allocation rather than a nonsense one.</p>
+     */
+    public static long allocMark() {
+        if (!ENABLED || THREADS == null) {
+            return 0L;
+        }
+        long allocated = THREADS.getCurrentThreadAllocatedBytes();
+        // The bean answers -1 when the counter is unavailable for this thread. Normalised to zero so
+        // the "no baseline" test below is one condition rather than two.
+        return allocated < 0 ? 0L : allocated;
+    }
+
+    /**
+     * One half of a chunk's generation cost, closing the marks taken before it started.
+     *
+     * <p>The two phases are contiguous and exhaustive, so their nanoseconds sum to what
+     * {@link #chunk} recorded for the same chunk and each can be reported as a share of it. Both
+     * are recorded before the chunk is, and all three agree about warm-up because all three are
+     * told the same {@code ordinal}.</p>
+     *
+     * @param ordinal from {@link #beginChunk}, for this chunk
+     * @param phase   which half this is
+     * @param nanoMark  the {@link #mark} taken when the phase started
+     * @param allocMark the {@link #allocMark} taken when the phase started, or zero if there was none
+     */
+    public static void phase(long ordinal, Phase phase, long nanoMark, long allocMark) {
+        if (!ENABLED || isWarmup(ordinal)) {
+            return;
+        }
+        int index = phase.ordinal();
+        long nanos = System.nanoTime() - nanoMark;
+        PHASE_NANOS[index].add(nanos);
+        PHASE_COUNT[index].increment();
+        PHASE_MAX_NANOS[index].accumulateAndGet(nanos, Math::max);
+        if (allocMark > 0) {
+            long allocated = allocMark();
+            if (allocated > allocMark) {
+                PHASE_ALLOC[index].add(allocated - allocMark);
+            }
+        }
+    }
+
+    /**
+     * Whether this chunk is early enough in the run to be discarded.
+     *
+     * <p>By ordinal rather than by elapsed time: the run is driven chunk by chunk, so "the first N
+     * chunks" is the unit warm-up actually happens in, and it is the same N whatever the machine.</p>
+     */
+    private static boolean isWarmup(long ordinal) {
+        return ordinal < WARMUP_CHUNKS;
     }
 
     /**
@@ -147,6 +339,11 @@ public final class GenerationMetrics {
         line.append(" allocMiB=").append(allocatedBytes() >> 20);
         line.append(" allocThreads=").append(ALLOCATION_BASELINE.size());
         line.append(" queueHighWater=").append(QUEUE_HIGH_WATER.get());
+        line.append(" warmup=").append(WARMUP_CHUNKS);
+        line.append(" warmupSkipped=").append(WARMUP_SKIPPED.sum());
+        for (Phase phase : Phase.values()) {
+            line.append(' ').append(phaseReport(phase, totalNanos));
+        }
         CACHES.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .forEach(entry -> line.append(' ').append(entry.getKey()).append('=')
@@ -193,6 +390,50 @@ public final class GenerationMetrics {
         long micros = Math.max(1, nanos / 1000);
         int bucket = 63 - Long.numberOfLeadingZeros(micros);
         return Math.min(bucket, CHUNK_BUCKETS.length - 1);
+    }
+
+    /**
+     * One phase's block of the report: its share of the chunk mean, its own mean and tail, and what
+     * it allocated per chunk.
+     *
+     * <p>The share is of {@code totalNanos} - the sum {@link #chunk} recorded - rather than of the
+     * two phases added together, so a share that does not add up to 100% is visible rather than
+     * normalised away. It should: the phases are contiguous and cover the whole of the generation
+     * {@link #chunk} times.</p>
+     *
+     * <p>Allocation is per chunk rather than a total, because a total only means something next to
+     * a chunk count and the whole point of this figure is to be compared with the {@code allocMiB}
+     * beside it. In KiB: a phase allocating single-digit MiB per chunk rounds to nothing otherwise,
+     * and single-digit MiB per chunk is the interesting case.</p>
+     */
+    private static String phaseReport(Phase phase, long totalNanos) {
+        int index = phase.ordinal();
+        long count = PHASE_COUNT[index].sum();
+        long nanos = PHASE_NANOS[index].sum();
+        long alloc = PHASE_ALLOC[index].sum();
+        return String.format("%s=%.0f%%(meanUs=%.1f maxUs=%d allocKiB=%d n=%d)",
+                phase.name().toLowerCase(java.util.Locale.ROOT),
+                totalNanos == 0 ? 0.0 : nanos * 100.0 / totalNanos,
+                count == 0 ? 0.0 : nanos / 1000.0 / count,
+                PHASE_MAX_NANOS[index].get() / 1000,
+                count == 0 ? 0L : (alloc / count) >> 10,
+                count);
+    }
+
+    private static LongAdder[] newPhaseAdders() {
+        LongAdder[] adders = new LongAdder[Phase.values().length];
+        for (int i = 0; i < adders.length; i++) {
+            adders[i] = new LongAdder();
+        }
+        return adders;
+    }
+
+    private static AtomicLong[] newPhaseMaxima() {
+        AtomicLong[] maxima = new AtomicLong[Phase.values().length];
+        for (int i = 0; i < maxima.length; i++) {
+            maxima[i] = new AtomicLong();
+        }
+        return maxima;
     }
 
     private static LongAdder[] newBuckets() {

--- a/src/main/java/dev/krona/urbex/worldgen/BlockShaper.java
+++ b/src/main/java/dev/krona/urbex/worldgen/BlockShaper.java
@@ -174,6 +174,26 @@ final class BlockShaper {
             }
             return adjacent;
         }
+        // Air cannot be reshaped, so the call below would hand back exactly what was passed in.
+        //
+        // Identity-compared against the three vanilla air blocks rather than asking
+        // BlockState.isAir(). isAir is a property any block may set, so a modded block could answer
+        // true and still override updateShape - and this skip is only sound for blocks that
+        // inherit BlockBehaviour's identity implementation. These three are AirBlock instances from
+        // the vanilla registry and cannot be anything else, which turns "probably fine" into a
+        // fact. Everything a caller can observe is unchanged: the returned state is the same object
+        // updateShape would have returned, nothing is written, and the seed that is skipped with it
+        // would have gone unread (air draws nothing) and is reset before the next call that does
+        // draw.
+        //
+        // Worth the special case because of how many there are: a chunk runs this four times per
+        // written position, tens of thousands of times, and a city is mostly hollow - rooms,
+        // streets and the space above roofs are all air.
+        Block adjacentBlock = adjacent.getBlock();
+        if (adjacentBlock == Blocks.AIR || adjacentBlock == Blocks.CAVE_AIR
+                || adjacentBlock == Blocks.VOID_AIR) {
+            return adjacent;
+        }
         BlockState newAdjacent = null;
         try {
             // updateShape hands the block a RandomSource; almost none use it, but the level's own

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -1,6 +1,7 @@
 package dev.krona.urbex.worldgen;
 
 import dev.krona.urbex.Urbex;
+import dev.krona.urbex.varia.GenerationMetrics;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.WorldGenLevel;
@@ -284,16 +285,43 @@ public class ChunkDriver {
         commitState = CommitState.COMMITTED;
     }
 
+    /** @see #actuallyGenerate(ChunkAccess, long) */
     public void actuallyGenerate(ChunkAccess chunk) {
-        correctionsPass();
+        actuallyGenerate(chunk, 0L);
+    }
+
+    /**
+     * @param ordinal this chunk's {@link dev.krona.urbex.varia.GenerationMetrics#beginChunk}, so the
+     *                three passes below can be measured apart. This step is two thirds of a chunk's
+     *                cost and the three things it does have nothing in common, so one figure for it
+     *                names no target; the overload above exists for callers that have no ordinal to
+     *                give and are not being measured.
+     */
+    public void actuallyGenerate(ChunkAccess chunk, long ordinal) {
+        long mark = GenerationMetrics.mark();
+        long alloc = GenerationMetrics.allocMark();
+        correctionsPass(ordinal);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CORRECT, mark, alloc);
+
+        mark = GenerationMetrics.mark();
+        alloc = GenerationMetrics.allocMark();
         flushToChunk(chunk);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.FLUSH, mark, alloc);
+
         // Full recompute instead of the old fake-bedrock Heightmap.update calls, which could
         // only ever raise heights and lied to MOTION_BLOCKING_NO_LEAVES (issue #46). O(chunk),
         // once, unconditionally correct in both directions.
+        mark = GenerationMetrics.mark();
+        alloc = GenerationMetrics.allocMark();
         Heightmap.primeHeightmaps(chunk, java.util.EnumSet.of(
                 Heightmap.Types.MOTION_BLOCKING, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
                 Heightmap.Types.OCEAN_FLOOR, Heightmap.Types.WORLD_SURFACE));
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.HEIGHTMAP, mark, alloc);
+
+        mark = GenerationMetrics.mark();
+        alloc = GenerationMetrics.allocMark();
         publishRecordedWrites();
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.PUBLISH, mark, alloc);
     }
 
     /**
@@ -303,12 +331,18 @@ public class ChunkDriver {
      * run once per finally-written position, against the finished chunk, in sorted order so the
      * result cannot depend on write order.
      */
-    private void correctionsPass() {
+    private void correctionsPass(long ordinal) {
         if (written == null || written.isEmpty()) {
             return;
         }
+        long mark = GenerationMetrics.mark();
+        long alloc = GenerationMetrics.allocMark();
         long[] positions = written.keySet().toLongArray();
         Arrays.sort(positions);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CORRECT_SORT, mark, alloc);
+
+        mark = GenerationMetrics.mark();
+        alloc = GenerationMetrics.allocMark();
         for (long packed : positions) {
             int x = BlockPos.getX(packed);
             int y = BlockPos.getY(packed);
@@ -320,6 +354,7 @@ public class ChunkDriver {
                 setBlock(pos, corrected);
             }
         }
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CORRECT_SHAPE, mark, alloc);
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -338,7 +338,8 @@ public class ChunkDriver {
         long mark = GenerationMetrics.mark();
         long alloc = GenerationMetrics.allocMark();
         long[] positions = written.keySet().toLongArray();
-        Arrays.sort(positions);
+        // Not Arrays.sort: same order, a fraction of the cost on this input. See PositionSort.
+        PositionSort.sort(positions);
         GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CORRECT_SORT, mark, alloc);
 
         mark = GenerationMetrics.mark();

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -161,7 +161,11 @@ public class CityGenerator {
     private void generateOrThrow(DimensionRuntime runtime, WorldGenRegion region,
                                  ChunkAccess chunk, ChunkCoord coord) {
         long start = System.currentTimeMillis();
+        // One ordinal for this chunk, claimed before anything is measured, so the warm-up exclusion
+        // reaches the same verdict for both phases and for the chunk itself (issue #132).
+        long ordinal = GenerationMetrics.beginChunk();
         long startNanos = GenerationMetrics.enabled() ? System.nanoTime() : 0;
+        long planAlloc = GenerationMetrics.allocMark();
 
         int chunkX = coord.chunkX();
         int chunkZ = coord.chunkZ();
@@ -175,11 +179,25 @@ public class CityGenerator {
         // order. See Arilas/urbex#24.
         ChunkHeightmap heightmap = new ChunkHeightmap(provider.heightmap(coord));
         ChunkPlan info = ChunkPlan.getChunkPlan(coord, provider);
+        // The planning/building boundary, and the only place in this method it exists. Everything
+        // above is a pure function of the seed and the coordinate - the heightmap comes from
+        // TerrainSampler, which reads no block, and the plan from caches DimensionCaches documents
+        // as recomputable by any thread - so it is the half that could in principle be computed
+        // before this chunk was ever asked for. Everything below needs this region and this chunk.
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.PLAN, startNanos, planAlloc);
+        long buildNanos = GenerationMetrics.mark();
+        long buildAlloc = GenerationMetrics.allocMark();
         // runtime.tags() is read here and nowhere else in this generation: one call, at the start,
         // so a /reload landing mid-chunk cannot be observed halfway through a building (issue #128).
         ChunkGenContext ctx = new ChunkGenContext(region, chunk, coord, provider, profile, info,
                 runtime.tasks(), runtime.tags());
         try {
+
+        // Reused for each pass below rather than one pair of locals per pass: the passes are
+        // strictly sequential, so a single mark that is closed and immediately retaken measures each
+        // of them exactly once, and the alternative is eighteen names for the same two numbers.
+        long phaseNanos = GenerationMetrics.mark();
+        long phaseAlloc = GenerationMetrics.allocMark();
 
         boolean doCity = info.isCity;
 
@@ -210,18 +228,29 @@ public class CityGenerator {
             boolean v = isVoid(ctx, 2, 2) || isVoid(ctx, 2, 14) || isVoid(ctx, 14, 2) || isVoid(ctx, 14, 14) || isVoid(ctx, 8, 8);
             doCity = !v;
         }
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.PROBE, phaseNanos, phaseAlloc);
 
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         if (doCity) {
             doCityChunk(ctx, info, heightmap, chunk);
+            GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CITY, phaseNanos, phaseAlloc);
         } else {
             // We already have a prefilled core chunk (as generated from doCoreChunk)
             doNormalChunk(ctx, info, heightmap, avoidChunk);
+            // Counted apart from CITY rather than together with it: the two are alternatives, and a
+            // combined figure would average a city chunk with a field and describe neither. Their
+            // sample counts also say how much of the window is city at all, which is the number that
+            // decides whether a city-side saving is worth anything here.
+            GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.TERRAIN, phaseNanos, phaseAlloc);
         }
 
         // Suppressed here rather than removed from the plan, the same way a village suppresses this
         // chunk's city above: a building deep enough to hit the line cancels the rails where they
         // would be drawn, and the neighbouring chunks keep planning and rendering the line as though
         // it ran through (issue #126, and see Railway.buildingBlocksRail for the precedence).
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         Railway.RailChunkInfo railInfo = Railway.buildingBlocksRail(coord, provider)
                 ? Railway.RailChunkInfo.NOTHING
                 : info.getRailInfo();
@@ -229,26 +258,46 @@ public class CityGenerator {
             Railways.generateRailways(ctx, this, info, railInfo, heightmap);
         }
         Railways.generateRailwayDungeons(ctx, this, info);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.RAIL, phaseNanos, phaseAlloc);
 
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         placeOptionalLights(ctx, info);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.LIGHTS, phaseNanos, phaseAlloc);
 
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         if (info.getDamageArea().hasExplosions()) {
             Damage.breakBlocks(ctx, this, chunkX, chunkZ, info);
             Damage.fixFloatingBlocks(ctx, this, info);
         }
-        generateDebris(ctx, info);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.DAMAGE, phaseNanos, phaseAlloc);
 
-        ctx.driver.actuallyGenerate(chunk);
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
+        generateDebris(ctx, info);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.DEBRIS, phaseNanos, phaseAlloc);
+
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
+        ctx.driver.actuallyGenerate(chunk, ordinal);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.COMMIT, phaseNanos, phaseAlloc);
+
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         ChunkFixer.fix(ctx);
         // After the fixer, so the post-todos have placed their blocks and what we see is final
         Parts.forgetBlockEntities(chunk);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.FIXER, phaseNanos, phaseAlloc);
+
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.BUILD, buildNanos, buildAlloc);
 
         long time = System.currentTimeMillis() - start;
         statistics.addTime(time);
         // Nanoseconds, separately from the millisecond Statistics that /urbex stats reports: a
         // chunk taking under a millisecond rounds to zero there, which is most of them, and a tail
         // latency built out of those numbers would be made of zeroes (issue #132).
-        GenerationMetrics.chunk(System.nanoTime() - startNanos);
+        GenerationMetrics.chunk(ordinal, System.nanoTime() - startNanos);
         } catch (Throwable t) {
             throw new ChunkGenerationFailure(coord, ctx.driver.commitState(), t);
         }

--- a/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
+++ b/src/main/java/dev/krona/urbex/worldgen/DigestRunner.java
@@ -39,6 +39,27 @@ public final class DigestRunner {
      */
     public static final String EXPIRE_EVERY_PROPERTY = "urbex.digestCheck.expireEvery";
 
+    /**
+     * Plan the whole square before the timed drive starts, so generation meets warm planning caches.
+     *
+     * <p>A measurement rather than a feature, and the only honest way to size one: "how much of a
+     * chunk is planning?" cannot be answered by bracketing {@code getChunkPlan} in
+     * {@code CityGenerator}, because planning recurses into neighbours and the build half calls back
+     * into it - a chunk's plan is usually built while a neighbour was generating and charged there.
+     * Driving the same square with everything already planned moves that cost out of the timed
+     * window entirely, so the difference between the two runs is the whole of what planning costs,
+     * wherever it was being charged. That difference is also the ceiling on what any scheme that
+     * computes plans ahead of demand could ever return.</p>
+     *
+     * <p><strong>The digest must not move.</strong> Planning claims to be a pure function of the
+     * seed and the coordinate - {@code PlanningContext} says so, and {@code DimensionCaches} relies
+     * on it to let racing threads recompute freely. Planning every chunk in a different order from
+     * the one generation would have planned them in, before any of them generates, is the strongest
+     * available test of that claim: if the {@code DRIVERDIGEST} moves, some planning answer depends
+     * on when it was asked, and that is a defect in generation rather than in this flag.</p>
+     */
+    public static final String PREWARM_PROPERTY = "urbex.digestCheck.prewarm";
+
     private DigestRunner() {
     }
 
@@ -119,6 +140,11 @@ public final class DigestRunner {
         List<ChunkPos> chunks = chunkSquare(radius, order, offset);
 
         UnsafeReadCounter.reset();
+        // Before the reset below, deliberately: the point of pre-warming is that its cost lands
+        // outside the measured window. See PREWARM_PROPERTY.
+        if (System.getProperty(PREWARM_PROPERTY) != null) {
+            prewarm(level, chunks);
+        }
         // Reset here rather than at server start: a digest run is the measured unit, and a run that
         // included whatever the spawn-area generation did would not be comparable with the next one.
         GenerationMetrics.reset();
@@ -201,6 +227,41 @@ public final class DigestRunner {
         return new Result(driverDigest, digest, driverBlocks, recordedChunks, chunks.size(), elapsed, bridgeChunks,
                 slopeChunks, avoidedChunks, railCollisionChunks, unsafeReads,
                 GenerationMetrics.report(chunks.size(), elapsed));
+    }
+
+    /**
+     * Plans every chunk of the square before any of it generates. See {@link #PREWARM_PROPERTY}.
+     *
+     * <p>Asks for exactly what {@code CityGenerator.generateOrThrow} asks for at its top - the
+     * heightmap and the chunk plan - and nothing else. Everything the rest of a chunk consults
+     * (candidates, city styles, rail info, highway levels, the two city fields) is reached
+     * transitively from those two, so warming them by hand would be a second, drifting copy of what
+     * planning already does. What is left cold afterwards is exactly what is <em>not</em>
+     * precomputable, which is the distinction the measurement is trying to draw.</p>
+     *
+     * <p>Single-threaded and in the drive's own order. A pre-warm pass that fanned out over a pool
+     * would measure the pool as much as the work, and the point here is to move a known quantity of
+     * work outside the timed window, not to discover how fast it can be made to run.</p>
+     *
+     * <p>Says what it cost on its own line. That figure is the other half of the comparison: the
+     * timed drive shows what warm caches save, and this shows what filling them took - and a saving
+     * bought for more than it is worth is not a saving.</p>
+     */
+    private static void prewarm(ServerLevel level, List<ChunkPos> chunks) {
+        PlanningContext planning = GenerationSession.planningFor(level);
+        if (planning == null) {
+            // No Urbex profile here. Nothing to warm, and the driver-writes check already fails this
+            // case loudly, so this stays quiet rather than inventing a second complaint about it.
+            return;
+        }
+        long start = System.currentTimeMillis();
+        for (ChunkPos pos : chunks) {
+            ChunkCoord coord = new ChunkCoord(level.dimension(), pos.x(), pos.z());
+            planning.heightmap(coord);
+            ChunkPlan.getChunkPlan(coord, planning);
+        }
+        Urbex.getLogger().info("PREWARM chunks={} ms={}", chunks.size(),
+                System.currentTimeMillis() - start);
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/PositionSort.java
+++ b/src/main/java/dev/krona/urbex/worldgen/PositionSort.java
@@ -1,0 +1,129 @@
+package dev.krona.urbex.worldgen;
+
+import java.util.Arrays;
+
+/**
+ * Sorts the driver's written positions, in the order {@link java.util.Arrays#sort(long[])} would.
+ *
+ * <p>The corrections pass has to run in a deterministic order - it writes to neighbours, so the
+ * result depends on which position is corrected first, and sorting is what keeps that from
+ * depending on write order (see {@code ChunkDriver.correctionsPass}). Sorting is therefore not
+ * optional. Sorting <em>this way</em> is: measured against the radius-40 soak, {@code Arrays.sort}
+ * over a chunk's ~11k packed positions cost 489us per generated chunk, which was 43% of the whole
+ * corrections pass and about a sixth of everything Urbex spends on a chunk.</p>
+ *
+ * <p>Quicksort is the wrong shape for this input. It is O(n log n) <em>comparisons</em> - about
+ * 147k of them for 11k elements - and each is an unpredictable branch. These keys are
+ * {@link net.minecraft.core.BlockPos#asLong} values from a single chunk, so most of their bits are
+ * identical across the whole array: X and Z contribute four varying bits each and Y about nine, and
+ * the other forty-odd bits are the chunk's own coordinates repeated 11,000 times. An LSD radix sort
+ * does a fixed number of branch-free passes and skips every byte that turns out to be constant, so
+ * this input costs four or five passes rather than eight.</p>
+ *
+ * <h2>Why this cannot move the digest</h2>
+ *
+ * <p>It is a sort, and it produces the same total order as the one it replaces, so the corrections
+ * pass visits the same positions in the same sequence and writes the same blocks. That is a
+ * stronger guarantee than "equivalent output": there is no output to compare, because the input to
+ * everything downstream is byte-identical. {@link PositionSortTest} pins it against
+ * {@code Arrays.sort} directly, and the five digest goldens cover it end to end.</p>
+ */
+final class PositionSort {
+
+    /**
+     * Below this, {@code Arrays.sort} wins and this is not worth the buffer.
+     *
+     * <p>Radix pays a fixed cost per pass - a 256-entry histogram and two walks of the array -
+     * that quicksort does not, so it only pays off once n is large enough to amortise it. A chunk
+     * with a building in it writes tens of thousands of positions and is far above this; a chunk
+     * that only clipped a street corner may write a few dozen and is far below. Both happen, so
+     * both paths are real rather than one being a formality.</p>
+     */
+    private static final int RADIX_THRESHOLD = 512;
+
+    /**
+     * The scratch half of the double buffer, one per worldgen thread.
+     *
+     * <p>Per thread rather than per driver because a driver lives for one chunk: a buffer it owned
+     * would be allocated once per chunk, which is the allocation this is trying not to add. The
+     * worldgen pool is a fixed handful of long-lived threads, so this is a bounded number of arrays
+     * that stop growing once each thread has met its biggest chunk.</p>
+     */
+    private static final ThreadLocal<long[]> SCRATCH = new ThreadLocal<>();
+
+    private PositionSort() {
+    }
+
+    /** Sorts {@code keys} ascending, in place, exactly as {@code Arrays.sort(keys)} would. */
+    static void sort(long[] keys) {
+        int n = keys.length;
+        if (n < RADIX_THRESHOLD) {
+            Arrays.sort(keys);
+            return;
+        }
+        long[] buffer = scratch(n);
+        int[] counts = new int[256];
+        long[] from = keys;
+        long[] to = buffer;
+        boolean sortedIntoBuffer = false;
+
+        for (int byteIndex = 0; byteIndex < 8; byteIndex++) {
+            int shift = byteIndex << 3;
+            Arrays.fill(counts, 0);
+            int firstBucket = bucket(from[0], shift, byteIndex);
+            boolean constant = true;
+            for (int i = 0; i < n; i++) {
+                int b = bucket(from[i], shift, byteIndex);
+                counts[b]++;
+                constant &= b == firstBucket;
+            }
+            // Every key agrees on this byte, so a pass over it would copy the array unchanged. This
+            // is the common case here rather than a lucky one - see the class note on which bits of
+            // a single chunk's positions actually vary.
+            if (constant) {
+                continue;
+            }
+            int start = 0;
+            for (int i = 0; i < 256; i++) {
+                int count = counts[i];
+                counts[i] = start;
+                start += count;
+            }
+            for (int i = 0; i < n; i++) {
+                long value = from[i];
+                to[counts[bucket(value, shift, byteIndex)]++] = value;
+            }
+            long[] swap = from;
+            from = to;
+            to = swap;
+            sortedIntoBuffer = !sortedIntoBuffer;
+        }
+        if (sortedIntoBuffer) {
+            System.arraycopy(from, 0, keys, 0, n);
+        }
+    }
+
+    /**
+     * Which bucket {@code value} lands in for this pass.
+     *
+     * <p>The top byte is flipped. Radix sorts unsigned, {@code Arrays.sort} sorts signed, and these
+     * keys really do go negative: {@code BlockPos.asLong} puts X in the top 26 bits, so every
+     * position west of the origin packs with its sign bit set. Flipping the sign bit of the most
+     * significant byte maps signed order onto unsigned order, which is what makes this a drop-in
+     * replacement rather than one that agrees only in the eastern hemisphere.</p>
+     */
+    private static int bucket(long value, int shift, int byteIndex) {
+        int b = (int) ((value >>> shift) & 0xFF);
+        return byteIndex == 7 ? b ^ 0x80 : b;
+    }
+
+    /** This thread's scratch buffer, grown if this is the biggest chunk it has seen. */
+    private static long[] scratch(int length) {
+        long[] buffer = SCRATCH.get();
+        if (buffer == null || buffer.length < length) {
+            buffer = new long[length];
+            SCRATCH.set(buffer);
+        }
+        return buffer;
+    }
+}

--- a/src/test/java/dev/krona/urbex/varia/GenerationMetricsTest.java
+++ b/src/test/java/dev/krona/urbex/varia/GenerationMetricsTest.java
@@ -32,12 +32,51 @@ class GenerationMetricsTest {
 
     @Test
     void recordingWhileOffCostsNothingAndChangesNothing() {
-        GenerationMetrics.chunk(5_000_000L);
+        long ordinal = GenerationMetrics.beginChunk();
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.PLAN, 0L, 0L);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.BUILD, 0L, 0L);
+        GenerationMetrics.chunk(ordinal, 5_000_000L);
         GenerationMetrics.queueDepth(4096);
 
         assertEquals(0, GenerationMetrics.percentileMicros(99),
                 "a chunk recorded while off must not appear in a later measured run");
         assertEquals(0, GenerationMetrics.allocatedBytes());
+    }
+
+    /**
+     * The marks are the two values a phase is closed against, and off they must be free. Zero is
+     * also what {@code phase} reads as "there was no baseline", so an off run records no allocation
+     * rather than a delta against a clock it never started.
+     */
+    @Test
+    void theMarksAnswerZeroWhileOffRatherThanReadingAClock() {
+        assertEquals(0, GenerationMetrics.mark());
+        assertEquals(0, GenerationMetrics.allocMark());
+        assertEquals(0, GenerationMetrics.beginChunk(),
+                "no ordinal is handed out when nothing is counting them");
+    }
+
+    /**
+     * Both phases appear in every measured report, including one where nothing generated. A phase
+     * that only appeared once it had samples would make "planning cost nothing" and "planning was
+     * not measured" the same line.
+     */
+    @Test
+    void anUnaskedReportNamesNoPhasesBecauseItReportsNothingAtAll() {
+        String report = GenerationMetrics.report(625, 24000);
+
+        assertFalse(report.contains("plan="), report);
+        assertFalse(report.contains("build="), report);
+    }
+
+    /**
+     * Warm-up exclusion is off by default, so an unasked run measures what it always measured. The
+     * property exists to be set for one comparison run and then compared against a run without it.
+     */
+    @Test
+    void warmupExclusionIsOffUnlessAskedFor() {
+        assertEquals(null, System.getProperty(GenerationMetrics.WARMUP_PROPERTY),
+                "the test JVM sets no warm-up, so this is the shipped default");
     }
 
     /**

--- a/src/test/java/dev/krona/urbex/worldgen/PositionSortTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/PositionSortTest.java
@@ -1,0 +1,159 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.core.BlockPos;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * {@link PositionSort} is a drop-in for {@code Arrays.sort(long[])}, so every test here asserts the
+ * same thing: the two agree, element for element.
+ *
+ * <p>That is the whole contract, and it is deliberately not "the output looks sorted". The
+ * corrections pass writes to neighbours, so the order it visits positions in decides what the world
+ * ends up looking like; a sort that were merely <em>a</em> valid order would change generated output
+ * and move all five digest goldens. Equality with the implementation it replaces is what makes the
+ * swap invisible.</p>
+ */
+class PositionSortTest {
+
+    /**
+     * Above {@code RADIX_THRESHOLD}, so this is the radix path rather than the delegation below it.
+     * A chunk with a building in it writes tens of thousands of positions.
+     */
+    private static final int ABOVE_THRESHOLD = 4096;
+
+    @Test
+    void agreesWithArraysSortOnRealChunkPositions() {
+        long[] positions = chunkPositions(37, -12, ABOVE_THRESHOLD, 0xC0FFEEL);
+
+        assertAgreesWithArraysSort(positions);
+    }
+
+    /**
+     * The case the sign flip exists for. {@code BlockPos.asLong} packs X into the top 26 bits, so
+     * every position west of the origin has its sign bit set - an unsigned radix sort without the
+     * flip would put the whole western hemisphere after the eastern one, and a world generated at
+     * negative X would come out different from the same world generated at positive X.
+     */
+    @Test
+    void agreesWithArraysSortAtNegativeCoordinates() {
+        long[] positions = chunkPositions(-40, -40, ABOVE_THRESHOLD, 0x5EEDL);
+
+        assertAgreesWithArraysSort(positions);
+    }
+
+    /**
+     * Keys spanning both signs in one array. A driver's writes come from one chunk so this should
+     * not arise in production, but the sort must not be the thing that assumes it.
+     */
+    @Test
+    void agreesWithArraysSortAcrossTheSignBoundary() {
+        Random random = new Random(0xA5A5A5L);
+        long[] positions = new long[ABOVE_THRESHOLD];
+        for (int i = 0; i < positions.length; i++) {
+            positions[i] = BlockPos.asLong(random.nextInt(-2048, 2048), random.nextInt(-64, 320),
+                    random.nextInt(-2048, 2048));
+        }
+
+        assertAgreesWithArraysSort(positions);
+    }
+
+    /** Arbitrary longs, including {@code Long.MIN_VALUE}/{@code MAX_VALUE}, not just packed positions. */
+    @Test
+    void agreesWithArraysSortOnArbitraryLongs() {
+        Random random = new Random(0xD00DL);
+        long[] values = new long[ABOVE_THRESHOLD];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = random.nextLong();
+        }
+        values[0] = Long.MIN_VALUE;
+        values[1] = Long.MAX_VALUE;
+        values[2] = 0L;
+        values[3] = -1L;
+
+        assertAgreesWithArraysSort(values);
+    }
+
+    /**
+     * Duplicates must survive in the same number. The driver's map cannot produce them - it is keyed
+     * by position - but a sort that silently deduplicated would drop corrections, and nothing else
+     * here would notice.
+     */
+    @Test
+    void keepsDuplicates() {
+        long[] values = new long[ABOVE_THRESHOLD];
+        Arrays.fill(values, BlockPos.asLong(8, 70, 8));
+        values[0] = BlockPos.asLong(1, 2, 3);
+
+        assertAgreesWithArraysSort(values);
+    }
+
+    /**
+     * A chunk whose writes all share every varying byte. Every radix pass finds its byte constant
+     * and is skipped, so this is the path where the sort does no scatter at all and must still
+     * leave the array correct.
+     */
+    @Test
+    void handlesAnArrayOfOneRepeatedValue() {
+        long[] values = new long[ABOVE_THRESHOLD];
+        Arrays.fill(values, BlockPos.asLong(-3, 64, 9));
+
+        assertAgreesWithArraysSort(values);
+    }
+
+    /** Below the threshold it delegates, but the contract is the same and is worth pinning. */
+    @Test
+    void agreesWithArraysSortBelowTheRadixThreshold() {
+        long[] positions = chunkPositions(2, 5, 64, 0xBEEFL);
+
+        assertAgreesWithArraysSort(positions);
+    }
+
+    @Test
+    void handlesEmptyAndSingleElementArrays() {
+        assertAgreesWithArraysSort(new long[0]);
+        assertAgreesWithArraysSort(new long[]{BlockPos.asLong(4, 5, 6)});
+    }
+
+    /**
+     * The buffer is reused across calls on one thread, so a later, shorter sort runs against a
+     * buffer still holding a longer one's data. Sorting descending input after ascending input is
+     * the shape that catches a pass reading past its own length.
+     */
+    @Test
+    void reusesItsBufferWithoutCarryingDataBetweenSorts() {
+        assertAgreesWithArraysSort(chunkPositions(1, 1, ABOVE_THRESHOLD * 2, 0x11L));
+        assertAgreesWithArraysSort(chunkPositions(1, 1, ABOVE_THRESHOLD, 0x22L));
+        assertAgreesWithArraysSort(chunkPositions(-7, 3, ABOVE_THRESHOLD, 0x33L));
+    }
+
+    private static void assertAgreesWithArraysSort(long[] values) {
+        long[] expected = values.clone();
+        Arrays.sort(expected);
+        long[] actual = values.clone();
+
+        PositionSort.sort(actual);
+
+        assertArrayEquals(expected, actual);
+    }
+
+    /**
+     * {@code count} distinct positions inside one chunk, which is what the driver actually hands
+     * the sort: X and Z confined to sixteen values each, Y spanning the world height.
+     */
+    private static long[] chunkPositions(int chunkX, int chunkZ, int count, long seed) {
+        Random random = new Random(seed);
+        long[] positions = new long[count];
+        for (int i = 0; i < count; i++) {
+            positions[i] = BlockPos.asLong(
+                    (chunkX << 4) + random.nextInt(16),
+                    random.nextInt(-64, 320),
+                    (chunkZ << 4) + random.nextInt(16));
+        }
+        return positions;
+    }
+}


### PR DESCRIPTION
Urbex costs **10.2% less CPU per chunk in real play** after this branch, with generated output bit-identical.

## The measurement problem, first

The mod's performance harness is the digest run — `GenerationMetrics` deliberately lives there rather than in a harness of its own. That harness has been reporting a number ~40% larger than the mod as shipped.

`DigestRunner` turns on `ChunkDriver` write recording for every run, including the soak. `publishRecordedWrites` then splits ~11k positions into a per-chunk map and copy-merges them into a static — **1450 µs and 869 KiB per chunk**, none of which runs in normal play. Every `PERF=` line ever recorded here includes it.

The first commit measures a chunk in phases, `PUBLISH` among them, so a digest-run figure describes the shipped mod once that phase is subtracted. Real cost on the radius-40 soak is **~2255 µs/chunk, not ~3700**.

That immediately named the target:

| pass | µs/chunk | share of real cost |
|---|---|---|
| **`correctionsPass`** | **866** | **38%** |
| `doCityChunk` | 587 | 26% |
| `doNormalChunk` | 335 | 15% |
| `Damage` / `debris` / `flush` / `primeHeightmaps` | 454 | 20% |
| planning | 4.4 | 0.2% |

## Two optimizations

**Radix sort** (`PositionSort`). `Arrays.sort` spent 489 µs/chunk ordering ~11k packed `BlockPos` longs — ~147k unpredictable-branch comparisons. These keys come from one chunk, so ~40 of their 64 bits are that chunk's coordinate repeated 11,000 times; an LSD radix sort skips constant bytes and does 4–5 branch-free passes. The top byte is sign-flipped so it reproduces `Arrays.sort`'s *signed* order — without that it would agree only at positive X.

**Skip air neighbours** (`BlockShaper`). `correct()` shape-updated all four neighbours of every written position before checking whether anything could reshape — tens of thousands of `updateShape` calls on a chunk that is mostly hollow. Air can't reshape. Identity-compared against `Blocks.AIR`/`CAVE_AIR`/`VOID_AIR` rather than `BlockState.isAir()`, since `isAir` is a property a modded block can set while still overriding `updateShape`.

## Results

| | before | after |
|---|---|---|
| `correct_sort` | 488.9 µs | 244.1 µs |
| `correct_shape` | 638.0 µs | 543.9 µs |
| **`correctionsPass`** | **866.3 µs** | **607.2 µs (−30%)** |
| **real in-play chunk** | **2255 µs** | **2025 µs (−10.2%)** |
| worst chunk | 75.9 ms | 66.6 ms (−12%) |

Worst case improved alongside the mean, which is what matters for stutter in a heavily modded game.

## Verification

**All ten digest checks pass against unmodified goldens**, including the five order-independence variants (shuffled, threads, expire) that are exactly what a change to the corrections pass could break. Those checks are the acceptance signal here: they are radius 3–12, well below `cacheMaxEntries`, and are reproducible run to run.

> **Correction.** An earlier version of this description also cited the radius-40 soak's `DRIVERDIGEST` as unchanged. That evidence has been withdrawn. While working on this branch I found that the soak is **not** reproducible run to run — see #207 — so a matching soak digest proves nothing, and nine consecutive matches did not stop the tenth from differing. #207 reproduces on `main` with none of this branch's code present, so it is independent of these changes; it does not affect the ten pinned checks, which never evict.

Both changes are order-preserving *by construction*, not by inspection — a correct sort producing the same total order, and a skipped call whose return value is the same object. That is why no golden needed regenerating.

`PositionSortTest` pins the sort against `Arrays.sort` element-for-element across nine cases: real chunk positions, negative coordinates, the sign boundary, arbitrary longs including `MIN_VALUE`, duplicates, all-constant input, below-threshold delegation, and buffer reuse.

## Also in the first commit

- `-Durbex.digestCheck.prewarm` plans the whole square before the timed drive. It puts a ceiling on what moving planning off the critical path could ever buy: 5% of chunk mean, nothing of wall clock. (Its run's digest also matched, but per #207 a single matching soak digest is not evidence of purity, so no claim is made from it.)
- `-Durbex.metrics.warmup=N` discards the first N chunks. Warm-up does not move the mean (excluding 500 chunks raises it slightly) but owns the extreme tail: 67.8 ms → 50.7 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
