### PR TITLE
perf: stop reading the sky one block at a time to find the ground

### DIFF
--- a/src/main/java/dev/krona/urbex/varia/GenerationMetrics.java
+++ b/src/main/java/dev/krona/urbex/varia/GenerationMetrics.java
@@ -88,6 +88,24 @@ public final class GenerationMetrics {
         CITY,
         /** {@code doNormalChunk}: the terrain a non-city chunk gets instead. */
         TERRAIN,
+        /** Inside {@code CITY}: the bedrock floor and the high-water fill. */
+        CITY_BEDROCK,
+        /** Inside {@code CITY}: surface levelling - 256 columns through {@code Terrain.moveDown/moveUp}. */
+        CITY_LEVEL,
+        /** Inside {@code CITY}: the building itself, for a chunk that has one. */
+        CITY_BUILDING,
+        /** Inside {@code CITY}: the street, for a chunk that has no building. */
+        CITY_STREET,
+        /** Inside {@code CITY}: ruins, street decorations, highways and rubble. */
+        CITY_DECOR,
+        /** Inside {@code CITY}: {@code Stuff.generateStuff}. */
+        CITY_STUFF,
+        /** Inside {@code TERRAIN}: {@code correctTerrainShape} - the same 256-column scan as {@code CITY_LEVEL}. */
+        TERRAIN_SHAPE,
+        /** Inside {@code TERRAIN}: bridges and highways. */
+        TERRAIN_LINKS,
+        /** Inside {@code TERRAIN}: scattered structures. */
+        TERRAIN_SCATTERED,
         /** Railways, their dungeons, and the building-collision test that can cancel them. */
         RAIL,
         /** The deferred optional lights, planned and placed. */

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkBuffer.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkBuffer.java
@@ -167,6 +167,26 @@ final class ChunkBuffer {
         }
     }
 
+    /**
+     * Whether this buffer has never touched the section holding {@code y} - neither written to it
+     * nor remembered a world block in it.
+     *
+     * <p>Both count, and they are the same test because both go through {@link #sectionFor}: a
+     * remembered block is a block this buffer is now the authority on, so a caller cannot conclude
+     * anything about the section from the world alone once one is in there. Out-of-range y answers
+     * false rather than throwing - the caller is scanning and a coordinate past the world is simply
+     * not skippable.</p>
+     */
+    boolean sectionUntouched(int y) {
+        int index = (y - minY) / SECTION_HEIGHT;
+        return index >= 0 && index < sections && cache[index] == null;
+    }
+
+    /** The lowest {@code y} in the section holding {@code y}. */
+    int sectionBottom(int y) {
+        return minY + ((y - minY) / SECTION_HEIGHT) * SECTION_HEIGHT;
+    }
+
     /** What this buffer holds at a position, or null if it has never seen it. */
     @Nullable
     BlockState get(int x, int y, int z) {

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -9,6 +9,7 @@ import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.BulkSectionAccess;
 import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.levelgen.Heightmap;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
@@ -432,6 +433,41 @@ public class ChunkDriver {
             buffer.remember(p.getX(), p.getY(), p.getZ(), state);
         }
         return state;
+    }
+
+    /**
+     * Whether every block in the section holding {@code y} is air, in this column's chunk.
+     *
+     * <p>For a caller scanning down a column looking for the first non-air block. Answering yes
+     * means the next sixteen levels can be stepped over without reading any of them, which is worth
+     * a great deal here: {@link #getBlock(BlockPos)} misses go to {@code region.getBlockState} and
+     * then {@code remember} them, and remembering the first block of a section allocates a
+     * {@code BlockState[4096]} for it. A scan that starts at the build limit therefore pays a world
+     * read and, once per section, a 32 KiB allocation, to discover a couple of hundred blocks of air
+     * above the terrain - per column, 256 times a chunk.</p>
+     *
+     * <p>Conservative in both directions. The buffer must not have touched the section, because a
+     * write or a remembered block makes the buffer the authority and the world's own section stale;
+     * and only <em>air</em> counts, not the wider "empty" that includes water and lava, because
+     * {@code hasOnlyAir} is what the section can answer without being walked. A section this says no
+     * about is simply scanned block by block as before, so a wrong-but-conservative answer costs
+     * time rather than correctness.</p>
+     */
+    public boolean sectionIsAllAir(int y) {
+        if (primer == null || !buffer.sectionUntouched(y)) {
+            return false;
+        }
+        int index = primer.getSectionIndex(y);
+        LevelChunkSection[] sections = primer.getSections();
+        if (index < 0 || index >= sections.length) {
+            return false;
+        }
+        return sections[index].hasOnlyAir();
+    }
+
+    /** The lowest {@code y} in the section holding {@code y}. @see #sectionIsAllAir */
+    public int sectionBottomAt(int y) {
+        return buffer.sectionBottom(y);
     }
 
     public LevelAccessor getRegion() {

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -233,11 +233,11 @@ public class CityGenerator {
         phaseNanos = GenerationMetrics.mark();
         phaseAlloc = GenerationMetrics.allocMark();
         if (doCity) {
-            doCityChunk(ctx, info, heightmap, chunk);
+            doCityChunk(ctx, info, heightmap, chunk, ordinal);
             GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CITY, phaseNanos, phaseAlloc);
         } else {
             // We already have a prefilled core chunk (as generated from doCoreChunk)
-            doNormalChunk(ctx, info, heightmap, avoidChunk);
+            doNormalChunk(ctx, info, heightmap, avoidChunk, ordinal);
             // Counted apart from CITY rather than together with it: the two are alternatives, and a
             // combined figure would average a city chunk with a field and describe neither. Their
             // sample counts also say how much of the window is city at all, which is the number that
@@ -420,15 +420,25 @@ public class CityGenerator {
         return holder[0];
     }
 
-    private void doNormalChunk(ChunkGenContext ctx, ChunkPlan info, ChunkHeightmap heightmap, AvoidChunk avoidChunk) {
+    private void doNormalChunk(ChunkGenContext ctx, ChunkPlan info, ChunkHeightmap heightmap, AvoidChunk avoidChunk,
+                               long ordinal) {
 //        debugClearChunk(chunkX, chunkZ, primer);
+        long phaseNanos = GenerationMetrics.mark();
+        long phaseAlloc = GenerationMetrics.allocMark();
         if ((avoidChunk != AvoidChunk.YES || !Config.avoidFlattening()) && profile.isDefault()) {
             Terrain.correctTerrainShape(ctx, this, info.coord, heightmap);
 //            flattenChunkToCityBorder(chunkX, chunkZ);
         }
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.TERRAIN_SHAPE, phaseNanos, phaseAlloc);
 
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         Bridges.generateBridges(ctx, this, info);
         Highways.generateHighways(ctx, this, info);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.TERRAIN_LINKS, phaseNanos, phaseAlloc);
+
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
 
         // Drawn at the scatter area's own anchor, so every chunk of one area agrees about which
         // pack's structure stands there - the same rule Scattered already applies to the reference
@@ -440,6 +450,7 @@ public class CityGenerator {
                 Scattered.generateScattered(ctx, this, info, scatteredSettings);
             }
         }
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.TERRAIN_SCATTERED, phaseNanos, phaseAlloc);
     }
 
     public String getRandomPart(ChunkGenContext ctx, List<String> parts) {
@@ -464,10 +475,13 @@ public class CityGenerator {
     }
 
     // Return true if state is Empty or Plant based - stops (most) funny tree/mushroom action on chunk borders
-    private void doCityChunk(ChunkGenContext ctx, ChunkPlan info, ChunkHeightmap heightmap, ChunkAccess chunk) {
+    private void doCityChunk(ChunkGenContext ctx, ChunkPlan info, ChunkHeightmap heightmap, ChunkAccess chunk,
+                             long ordinal) {
         ChunkDriver driver = ctx.driver;
         boolean building = info.hasBuilding;
 
+        long phaseNanos = GenerationMetrics.mark();
+        long phaseAlloc = GenerationMetrics.allocMark();
         if (info.profile.isDefault()) {
             int minHeight = info.provider.shape().minY();
             BlockState bedrock = Blocks.BEDROCK.defaultBlockState();
@@ -487,8 +501,12 @@ public class CityGenerator {
             }
         }
 
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CITY_BEDROCK, phaseNanos, phaseAlloc);
+
         // City surface leveling - for prettier cities
         // Note: Better results may be achieved with terrain noise adjustment (like how newer structures do it)
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         if (profile.isDefault()) {
             int ground = info.getCityGroundLevel();
             for (int x = 0; x < 16; x++) {
@@ -500,13 +518,20 @@ public class CityGenerator {
                 }
             }
         }
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CITY_LEVEL, phaseNanos, phaseAlloc);
 
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         if (building) {
             generateBuilding(ctx, info, heightmap, chunk);
+            GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CITY_BUILDING, phaseNanos, phaseAlloc);
         } else {
             Streets.generateStreet(ctx, this, info, heightmap);
+            GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CITY_STREET, phaseNanos, phaseAlloc);
         }
 
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         if (info.profile.ruinChance() > 0.0) {
             decorations.ruins(ctx, this, info);
         }
@@ -529,8 +554,12 @@ public class CityGenerator {
                 decorations.rubble(ctx, this, info);
             }
         }
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CITY_DECOR, phaseNanos, phaseAlloc);
 
+        phaseNanos = GenerationMetrics.mark();
+        phaseAlloc = GenerationMetrics.allocMark();
         Stuff.generateStuff(ctx, this, info);
+        GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.CITY_STUFF, phaseNanos, phaseAlloc);
     }
 
     public enum HardAirSetting {

--- a/src/main/java/dev/krona/urbex/worldgen/gen/Terrain.java
+++ b/src/main/java/dev/krona/urbex/worldgen/gen/Terrain.java
@@ -244,6 +244,27 @@ public class Terrain {
         int maxYTouched = Short.MIN_VALUE;       // Max Y that we touched
         int y = maxBuildLimit-1;
         driver.current(x, y, z);
+        // Step over whole sections of nothing but air before reading a single block.
+        //
+        // The scan below starts at the build limit and walks down to the first non-empty block, so
+        // on ordinary terrain it reads a couple of hundred blocks of sky per column, 256 columns a
+        // chunk. Each of those reads misses the buffer, goes to the world, and gets remembered -
+        // and remembering the first block of a section allocates a BlockState[4096] for it. So the
+        // sky above a city was costing tens of thousands of world reads and several hundred KiB per
+        // chunk, to establish that it is air.
+        //
+        // Exactly equivalent, not approximately: every block in a skipped section is air, air is
+        // empty, so the loop below would have stepped through all sixteen and stopped nowhere. A
+        // section is only skipped when it lies wholly above `height`, so the loop still stops at
+        // `height` on a column that is empty all the way down - which is the "nothing to do" case
+        // immediately after.
+        while (driver.getY() > height) {
+            int bottom = driver.sectionBottomAt(driver.getY());
+            if (bottom <= height || !driver.sectionIsAllAir(driver.getY())) {
+                break;
+            }
+            driver.current(x, bottom - 1, z);
+        }
         // We assume here we are not in a void chunk
         while (CityGenerator.isEmpty(driver.getBlock()) && driver.getY() > height) {
             driver.decY();


### PR DESCRIPTION
Follows #206 (now merged). Rebased onto `main`; this branch is just the two commits below.

Cuts a further **15%** off real in-play chunk cost by not reading the sky one block at a time.

## What the instrumentation found

#206 established that `doCityChunk` and `doNormalChunk` are 26% and 15% of real cost but said nothing about which pass inside them owned it. The first commit here splits both, and the answer is that the two paths share one hot primitive:

| pass | µs | on |
|---|---|---|
| `city_level` (surface levelling) | **1011** | city chunks |
| `terrain_shape` (`correctTerrainShape`) | **527** | every other chunk |
| everything else in either path | < 100 each | — |

Both are the same thing: 256 columns through `Terrain.moveDown`/`moveUp`. Together, about a third of what Urbex spends on a chunk.

## The waste

`Terrain.moveDown` starts at `maxBuildLimit - 1` and walks down until it meets a non-empty block. With ground near y≈64 that is ~250 reads per column, ~64,000 per chunk, essentially all returning air.

Each read is worse than it looks. `ChunkDriver.getBlock` misses the buffer, goes to `region.getBlockState`, and then `remember`s the answer — and remembering the first block of a section allocates a `BlockState[4096]`. So the sky above a city cost tens of thousands of world reads *and* several hundred KiB of allocation per chunk (`city_level allocKiB=467`, `terrain_shape allocKiB=380`) to establish that air is air.

## The fix

Whole sections of nothing but air are stepped over without reading any of them. A section qualifies only when:

1. the buffer has never touched it — a write *or a remembered block* makes the buffer the authority and the world's section stale; and
2. the world's own `LevelChunkSection.hasOnlyAir()` is true, which it answers from its block count without being walked.

**Exactly equivalent, not approximately.** Every block in a skipped section is air, air is empty, so the scan would have stepped through all sixteen and stopped nowhere. A section is skipped only when it lies wholly above the floor the scan stops at, so a column empty all the way down still stops exactly where it did and still reports "nothing to do". Only *air* counts, never the wider "empty" that includes water and lava — so a section this declines is scanned block by block as before. A conservative answer costs time, not correctness.

## Results

Measured with `cacheMaxEntries: 1000000` so the run is as reproducible as this codebase currently allows (see #207), across four runs:

| | before | after |
|---|---|---|
| `city_level` | 1011.5 µs | **~460 µs (−55%)** |
| `terrain_shape` | 527.3 µs | **~251 µs (−52%)** |
| **real in-play chunk** | **1984 µs** | **~1686 µs (−15%)** |

Cumulative with #206, real in-play cost is down from **2255 µs to ~1686 µs, about −25%**.

## Verification

**All ten digest checks pass against unmodified goldens**, including the five order-independence variants. Those are the acceptance signal: radius 3–12, well below `cacheMaxEntries`, reproducible run to run.

The radius-40 soak's digest is *not* used as evidence, in either direction — see #207, which this work also contributed a correction to. Worth stating plainly: during these runs the soak produced two different digests **with eviction fully disabled**, which falsified the original "eviction is the mechanism" conclusion in that issue. That divergence reproduces on `main` and is not caused by this branch; what this branch does is shift worker-thread timing enough to make it visible more often. The ten pinned checks are unaffected because they never evict and are deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
