### PR TITLE
feat(api): an experimental API for another mod to drive Urbex generation

### DIFF
--- a/docs/schema/preset.schema.json
+++ b/docs/schema/preset.schema.json
@@ -42,7 +42,11 @@
       "properties": {
         "landscapeType": {
           "type": "string",
-          "enum": ["default", "floating", "cavern"],
+          "enum": [
+            "default",
+            "floating",
+            "cavern"
+          ],
           "description": "Type of landscape."
         },
         "groundLevel": {
@@ -111,7 +115,9 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "cities": {
       "type": "object",
@@ -255,7 +261,9 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "buildings": {
       "type": "object",
@@ -321,16 +329,28 @@
         },
         "multiBuildingStreetConflict": {
           "type": "string",
-          "enum": ["block_all", "override_minor", "override_all"],
+          "enum": [
+            "block_all",
+            "override_minor",
+            "override_all"
+          ],
           "description": "How an accepted multi-building resolves against a planned road under its footprint. block_all: any planned road rejects the candidate. override_minor: only a primary road rejects (a secondary/tertiary road is cut). override_all: no road rejects; every covered road is cut."
         },
         "generateSpawners": {
           "type": "boolean",
           "description": "If true then buildings will be full of spawners."
+        },
+        "spawnerDensity": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Chance that a marked spawner position keeps its spawner. Thins them rather than switching them off, which generateSpawners already does; defaults to 1, so a preset that says nothing about it keeps every marker."
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "roads": {
       "type": "object",
@@ -470,7 +490,9 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "highways": {
       "type": "object",
@@ -516,7 +538,9 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "railways": {
       "type": "object",
@@ -546,7 +570,9 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "destruction": {
       "type": "object",
@@ -658,7 +684,9 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "decoration": {
       "type": "object",
@@ -694,7 +722,9 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "spawn": {
       "type": "object",
@@ -718,12 +748,16 @@
         },
         "forceSpawnBuildings": {
           "type": "array",
-          "items": { "$ref": "#/$defs/qualifiedIdentifier" },
+          "items": {
+            "$ref": "#/$defs/qualifiedIdentifier"
+          },
           "description": "Buildings the player may spawn in when forceSpawnInBuilding is true, each fully qualified. Empty means any building. Can be combined with forceSpawnParts."
         },
         "forceSpawnParts": {
           "type": "array",
-          "items": { "$ref": "#/$defs/qualifiedIdentifier" },
+          "items": {
+            "$ref": "#/$defs/qualifiedIdentifier"
+          },
           "description": "Parts the player may spawn in when forceSpawnInBuilding is true, each fully qualified. Empty means any part. Can be combined with forceSpawnBuildings."
         },
         "spawnCheckRadius": {
@@ -746,7 +780,9 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     },
     "misc": {
       "type": "object",
@@ -762,9 +798,13 @@
         }
       },
       "additionalProperties": false,
-      "patternProperties": { "^_": {} }
+      "patternProperties": {
+        "^_": {}
+      }
     }
   },
   "additionalProperties": false,
-  "patternProperties": { "^_": {} }
+  "patternProperties": {
+    "^_": {}
+  }
 }

--- a/docs/site-api.md
+++ b/docs/site-api.md
@@ -1,0 +1,195 @@
+# The site API
+
+**Experimental.** `dev.krona.urbex.api` may change shape without a deprecation cycle, including
+between patch releases. It is published so the design can be used and argued with, not because it is
+settled. Pin the Urbex version you build against. Nothing outside that package is API.
+
+## What this is for
+
+Urbex normally decides for itself where cities go. A perlin field over the dimension picks the
+centres, the terrain heightmap picks how high each chunk's city sits, and one world style governs the
+level. That is the right default, and until now it was the only thing on offer.
+
+A **site** is the same machinery with three of those answers supplied by another mod: *where*, *how
+high*, and *how far it may reach*. The case it was built for is a cave bunker — a mod carves a
+cavity underground and asks Urbex to fill it, at the cavity's depth, in a different world style from
+the ruins on the surface, without a block escaping the cavity.
+
+Everything else about a site is a preset, and a preset is a datapack file. Lighting density, floor
+counts, cellar counts, ruin chance, corridor chance, road spacing: a site reaches all of them by
+naming a preset, and reaches any of them individually through `presetOverrides`.
+
+## The whole API
+
+```java
+public interface SiteField {
+    boolean isSite(int chunkX, int chunkZ);
+    default int groundY(int chunkX, int chunkZ) { return UrbexApi.DEFAULT_GROUND_Y; }
+}
+
+public record SiteSpec(Identifier id, Identifier preset, WorldStyleMix worldStyles,
+                       @Nullable String presetOverridesJson, SiteField field,
+                       int minY, int maxY, int waterY) {
+    public static Builder builder(Identifier id, Identifier preset, SiteField field);
+}
+
+public interface UrbexSite {
+    boolean fill(WorldGenRegion region, ChunkAccess chunk);
+    SiteSpec spec();
+}
+
+public final class UrbexApi {
+    public static UrbexSite site(ServerLevel level, SiteSpec spec);
+    public static boolean isAvailable(ServerLevel level);
+}
+```
+
+## The one rule that cannot be relaxed
+
+**`SiteField` must be a pure function of the coordinate.**
+
+It is tempting to read it as "the mod tells Urbex about the chunk it is filling". It is not. Urbex
+plans a chunk by reading its *neighbours'* plans — whether a street continues across the border,
+whether a doorway is cut through a shared wall, which of two competing stairs wins, whether a
+multi-chunk building may be accepted here. Those reads reach coordinates you have not asked about and
+may never ask about, on threads you do not own, in an order nobody controls.
+
+So an implementation must be:
+
+- **Pure.** The same coordinate answers the same thing forever — not "once the carver has run", not
+  "once the cave is known". Reading a block, a chunk, a level, or any state a generation pass writes
+  is wrong, and shows up as streets ending in rock and doorways opening into stone.
+- **Total.** It answers for every coordinate in the dimension, including ones far from anything you
+  care about.
+- **Thread-safe.** It is called concurrently from the worldgen worker pool.
+- **Cheap.** It is called for a neighbourhood per planned chunk. Hash arithmetic and noise are fine;
+  anything that allocates per call is not.
+
+The natural shape is a deterministic field derived from the world seed — a region grid, a noise
+threshold, a hashed lattice. Your carver reads the same field, so what gets carved and what gets
+built agree by construction rather than by timing. `Urbex-Bunkers`' `BunkerField` is a worked
+example.
+
+## Where `fill` can be called from
+
+Anywhere a `WorldGenRegion` exists for the chunk: a `Feature`, a `StructurePiece` that has one, or —
+the case this was built for — an injection at the tail of `ChunkGenerator.applyCarvers`, which is the
+stage Urbex itself generates at and the point where the terrain is a pure function of the seed.
+
+**Not from a `WorldCarver`.** A carver is handed a `CarvingContext` and a `ChunkAccess` and has no
+region to write through. Carve in the carver and fill from the carver tail; both read the same
+field, so they need no ordering between them.
+
+Urbex dispatches nothing. A site generates when you call `fill` and at no other time — its own
+carver-tail hook knows nothing about sites.
+
+## The vertical window
+
+`window(minY, maxY)` is inclusive at both ends and is enforced twice:
+
+- **Planning.** The `LevelShape` a site plans against is clamped to the window, so floor counts are
+  chosen to fit rather than being cut off.
+- **Writing.** `ChunkBuffer`, the single point every driver write passes through, refuses everything
+  outside it. A pass that believes it may build to the sky writes nothing above the window whatever
+  it believes.
+
+Deferred writes bypass the driver and are bounded separately, by anchor position, at the three queues
+that accept them. That is exact for the block a todo addresses and approximate for anything its
+callback touches around that block — the upper half of a door, the block a light attaches to.
+
+Leave room. The window bounds planning as well as writing, so a window ten blocks tall does not
+produce a squashed building, it produces a building with no floors in it.
+
+One consequence worth knowing: because the window is absolute, a site and the surface city
+**commute**. It does not matter which of them runs first, so you need not reason about mixin priority
+against Urbex's own hook.
+
+## Water
+
+A site is dry unless you say otherwise, and it ignores its preset's sea level to stay that way.
+
+This is not a detail. A preset names one absolute sea level for a whole dimension — `urbex:cavern`
+says 32 — and a bunker forty blocks under that is not underwater, but every rule that fills below the
+water line thinks it is. A caller reaching for the obvious underground preset would get a bunker
+flooded to the ceiling and no clue why. `waterY(y)` floods a site deliberately; omitting it leaves
+the water table below the floor.
+
+## What a site is, underneath
+
+A second `PlanningContext` and `CityGenerator` over the same level, holding its own
+`DimensionCaches`. Its plans therefore never collide with the level's own at the same chunk
+coordinate, which is what lets one dimension run a heavily ruined world style on the surface and an
+intact one underground.
+
+A site *borrows* the world's compiled assets and block-tag epoch, and the level's deferred task
+queue. It borrows nothing from the level's preset — so **a site generates in a dimension where Urbex
+surface generation is switched off entirely.** A vanilla overworld with bunkers under it is a
+supported configuration.
+
+Building one is expensive (a preset resolution, a world-style field, a road field, a set of caches),
+so `UrbexApi.site` memoises per `(level, spec.id())` and is cheap enough to call per chunk. Two calls
+with one id return one site; registering two different specs under one id logs a warning and keeps
+the first.
+
+## Differences from an ordinary Urbex chunk
+
+| | A dimension | A site |
+|---|---|---|
+| Where the city is | perlin city field vs. threshold | `SiteField.isSite` |
+| Ground level | the preset's, one number for the dimension | `SiteField.groundY`, per chunk |
+| City height band | 0–8, from the terrain height | always 0 — the ground is already exact |
+| A non-city chunk | rendered: ground cover, terrain fix, scattered buildings | **untouched** |
+| Structure avoidance | a village suppresses the city here | not applied; you named the place |
+| Water | the preset's sea level, else the dimension's | `waterY`, and dry by default |
+
+The "untouched" row is what makes a site sparse, and it is the difference that matters most. Outside
+a dimension's cities is still somewhere Urbex has an opinion about; outside a site is somebody else's
+world.
+
+## A complete caller
+
+```java
+public final class MyMod implements ModInitializer {
+
+    private static final Identifier SITE = Identifier.fromNamespaceAndPath("mymod", "bunkers");
+    private static final SiteField FIELD = new BunkerField(/* seeded per world */);
+
+    private static UrbexSite site(ServerLevel level) {
+        return UrbexApi.site(level, SiteSpec
+                .builder(SITE, Identifier.fromNamespaceAndPath("urbex", "cavern"), FIELD)
+                .worldStyle(Identifier.fromNamespaceAndPath("mymod", "bunker_style"))
+                .presetOverrides("""
+                        { "buildings": { "buildingMaxFloors": 2 },
+                          "decoration": { "lightingDensity": 0.95 } }
+                        """)
+                .window(-60, 24)
+                .build());
+    }
+
+    // called from an @Inject at the TAIL of ChunkGenerator.applyCarvers
+    public static void generate(WorldGenRegion region, ChunkAccess chunk) {
+        if (!FIELD.isSite(chunk.getPos().x(), chunk.getPos().z())) {
+            return;                                  // the cheap test first
+        }
+        ServerLevel level = region.getLevel();
+        if (!UrbexApi.isAvailable(level)) {
+            return;                                  // the world has not compiled its assets yet
+        }
+        carveCavity(region, chunk);                  // your carver, reading the same FIELD
+        site(level).fill(region, chunk);
+    }
+}
+```
+
+`minecraft-mods/Urbex-Bunkers` is this, finished and working.
+
+## Failure modes
+
+| Symptom | Cause |
+|---|---|
+| `IllegalStateException` from `site()` | called before any level loaded; guard with `isAvailable` |
+| Streets end in rock, doorways open into stone | the field is not pure or not total |
+| The site is flooded | `waterY` was set, or the window's bottom is under a water table you asked for |
+| Buildings have no floors | the window is too short — it bounds planning too |
+| A warning about two definitions under one id | the spec is not stable across calls; build it once |
+| Nothing generates at all | `fill` is never called, or the field answers false everywhere |

--- a/docs/site-api.md
+++ b/docs/site-api.md
@@ -100,9 +100,27 @@ callback touches around that block — the upper half of a door, the block a lig
 Leave room. The window bounds planning as well as writing, so a window ten blocks tall does not
 produce a squashed building, it produces a building with no floors in it.
 
+It is also the only ceiling Urbex knows about. If your sites are chambers of differing heights, a
+fixed window can only be tight for one of them, and every site with headroom to spare will plan a
+building taller than its own chamber and drive the excess into the rock. Carve your roofs *to the
+window* rather than to a fixed clearance above each floor, and the two agree at every depth at once —
+`Urbex-Bunkers` does exactly this, and the comment on its `WINDOW_MAX_Y` explains why the obvious
+alternative does not work.
+
 One consequence worth knowing: because the window is absolute, a site and the surface city
 **commute**. It does not matter which of them runs first, so you need not reason about mixin priority
 against Urbex's own hook.
+
+## Ground height is quantised to six blocks
+
+`SiteField.groundY` is snapped down to a multiple of six above the window's bottom. Six blocks is a
+storey, and it is the unit Urbex's whole height graph counts in: internally a site's ground becomes
+`cityLevel`, the number every height comparison is written against — whether a doorway can be cut
+through a shared wall, whether a street may slope, which of two competing stairs wins.
+
+Return multiples of six above `minY` and nothing is lost. Return anything else and it is rounded,
+because two parts of a site whose grounds differ by less than a storey have no way to say so to each
+other.
 
 ## Water
 
@@ -136,8 +154,8 @@ the first.
 | | A dimension | A site |
 |---|---|---|
 | Where the city is | perlin city field vs. threshold | `SiteField.isSite` |
-| Ground level | the preset's, one number for the dimension | `SiteField.groundY`, per chunk |
-| City height band | 0–8, from the terrain height | always 0 — the ground is already exact |
+| Ground level | the preset's, one number for the dimension | the window's bottom, one number for the site |
+| City height band | 0–8, from the terrain height | `(groundY − minY) / 6`, from `SiteField.groundY` |
 | A non-city chunk | rendered: ground cover, terrain fix, scattered buildings | **untouched** |
 | Structure avoidance | a village suppresses the city here | not applied; you named the place |
 | Water | the preset's sea level, else the dimension's | `waterY`, and dry by default |
@@ -191,5 +209,7 @@ public final class MyMod implements ModInitializer {
 | Streets end in rock, doorways open into stone | the field is not pure or not total |
 | The site is flooded | `waterY` was set, or the window's bottom is under a water table you asked for |
 | Buildings have no floors | the window is too short — it bounds planning too |
+| Buildings punch through the chamber roof | the window is taller than the chamber; carve to the window |
+| Doors open into a wall, or a floor has none | `groundY` steps by less than six, so two heights collapse to one band |
 | A warning about two definitions under one id | the spec is not stable across calls; build it once |
 | Nothing generates at all | `fill` is never called, or the field answers false everywhere |

--- a/docs/site-api.md
+++ b/docs/site-api.md
@@ -169,6 +169,32 @@ If nothing is found — no site within 512 chunks of the origin, or no chunk mat
 world keeps the spawn it would have had and a warning names the site. Two mods claiming one world's
 spawn is a modpack conflict: first registered wins, and the clash is logged.
 
+## Spawners
+
+`buildings.generateSpawners` is a switch — a world that wants none has none. `buildings.spawnerDensity`
+(0–1) is the dial beside it: it thins what survives, position-addressed like `lootDensity`, so which
+markers keep their spawner is a property of the seed and the coordinate rather than of the order
+parts were generated in. Both must pass, and the density defaults to 1, so a preset that says nothing
+about it keeps every marker.
+
+The dial is the useful one for somewhere a player has to survive: "fewer" is not something a switch
+can say.
+
+## Two sites, one world
+
+Nothing stops a mod registering several sites in one level, and it is how "this place is different
+from that place" is expressed — a site carries one preset and one world style, so two kinds of place
+is two sites.
+
+Give them different ids (separate memo keys, separate caches, and separate road-grid addresses) and
+**complementary fields**, so no chunk belongs to both. `Urbex-Bunkers` does this for its starter
+bunker: one field view covers the bunker nearest the origin, the other covers every other, and
+between them they cover exactly what the undivided field covered.
+
+Two things to know. A site's id feeds its road field, so moving a bunker from one site to the other
+changes its street layout. And `groundY` must stay the *whole* field's answer in both views — a chunk
+on the edge of one reads neighbours belonging to the other, and the contract still says total.
+
 ## Cellars
 
 `buildingMaxCellars` means what it says in a site. In a dimension the effective cap is

--- a/docs/site-api.md
+++ b/docs/site-api.md
@@ -144,6 +144,31 @@ surface too; for a site it no longer matters, because neither reaches one.
 exclusion.** A bunker with a staircase up to a ruined station would be worth having. It needs the
 site to know where the surface is, which nothing here currently tells it.
 
+## Spawning a world's players inside a site
+
+`UrbexApi.spawnIn(factory, SiteSpawn.STREET)` asks that the world's spawn land inside your site.
+
+**Off unless called.** A site changes nothing about where a world puts its players until a mod asks
+it to — a mod that silently relocated spawn because it happened to be installed would be a bad guest.
+
+Call it **once, at mod initialisation**: the world's spawn is chosen while the level loads, so a
+claim made from the generation path has already missed it. That is also why it takes a
+`SiteSpecFactory` rather than a `SiteSpec` — your spec almost certainly needs the world seed, which
+does not exist that early. Return the same spec your generation path uses, id included, so the spawn
+search and the chunks the player walks out into are the same memoised site.
+
+`SiteSpawn.STREET` lands on a site chunk with no building — clear by construction and lit by the
+preset's lighting density. `SiteSpawn.BUILDING` lands on a building's ground floor, which is more
+dramatic and has more furniture for the search to reject.
+
+A claim **outranks the dimension's own spawn settings**, and it works in a dimension with no Urbex
+preset at all — which the dimension's own rules cannot, since they need one. A vanilla overworld
+whose players wake up sealed in a bunker is a supported configuration.
+
+If nothing is found — no site within 512 chunks of the origin, or no chunk matching `where` — the
+world keeps the spawn it would have had and a warning names the site. Two mods claiming one world's
+spawn is a modpack conflict: first registered wins, and the clash is logged.
+
 ## Cellars
 
 `buildingMaxCellars` means what it says in a site. In a dimension the effective cap is

--- a/docs/site-api.md
+++ b/docs/site-api.md
@@ -122,6 +122,36 @@ Return multiples of six above `minY` and nothing is lost. Return anything else a
 because two parts of a site whose grounds differ by less than a storey have no way to say so to each
 other.
 
+## What a site does not get: highways and railways
+
+Neither generates in a site, and this is not a setting.
+
+Both are *networks*. Their height is measured from `groundLevel` rather than from a chunk's own city
+ground, which is exactly what makes them networks: they hold one height across hundreds of chunks
+while the cities they join ride up and down the terrain above them. A site's `groundLevel` is the
+bottom of its window, with the per-chunk height carried in `cityLevel` instead — so the same offset
+puts a railway eighteen blocks *below the window*, which for a bunker at y=−60 is outside the world.
+That is what station staircases descending into the bedrock were.
+
+Re-datuming them onto the chunk's city ground would land them somewhere legal and no better: a
+network needs two ends, and a site is a pocket a few dozen chunks across with nothing to join.
+
+Note that `railwayStationsEnabled` is a separate preset flag from `railwaysEnabled`, so a preset that
+turns railways off — `urbex:cavern` does — still generates stations. That is a surprise on the
+surface too; for a site it no longer matters, because neither reaches one.
+
+**Connecting a site to the surface, or to a real network above it, is a feature and not this
+exclusion.** A bunker with a staircase up to a ruined station would be worth having. It needs the
+site to know where the surface is, which nothing here currently tells it.
+
+## Cellars
+
+`buildingMaxCellars` means what it says in a site. In a dimension the effective cap is
+`buildingMaxCellars + cityLevel` — "how much room is there under this chunk before the datum", where
+the datum is the preset's ground level and `cityLevel` is how far the city has climbed above it. A
+site's datum is the bottom of your window, so the same term reads as *dig as deep as the window
+allows*: a caller asking for 2 cellars at `cityLevel` 8 got up to 10. The term is dropped for sites.
+
 ## Water
 
 A site is dry unless you say otherwise, and it ignores its preset's sea level to stay that way.
@@ -159,6 +189,9 @@ the first.
 | A non-city chunk | rendered: ground cover, terrain fix, scattered buildings | **untouched** |
 | Structure avoidance | a village suppresses the city here | not applied; you named the place |
 | Water | the preset's sea level, else the dimension's | `waterY`, and dry by default |
+| Highways and railways | planned across the world | never generated |
+| Cellar cap | `buildingMaxCellars + cityLevel` | `buildingMaxCellars` |
+| Building height cap | the dimension's build limit | the window top — **one number for the whole site** |
 
 The "untouched" row is what makes a site sparse, and it is the difference that matters most. Outside
 a dimension's cities is still somewhere Urbex has an opinion about; outside a site is somebody else's

--- a/docs/superpowers/plans/2026-08-16-experimental-site-api.md
+++ b/docs/superpowers/plans/2026-08-16-experimental-site-api.md
@@ -1,0 +1,303 @@
+# Experimental Site API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let another mod define a patch of Urbex city — its own preset, world style, ground level
+and hard vertical window — and drive its generation itself, so a cave-bunker mod can carve a cavity
+and ask Urbex to fill it.
+
+**Architecture:** A *site* is a second `PlanningContext` + `CityGenerator` over the same level,
+holding its own `DimensionCaches`. `PlanningContext` gains one nullable component, `SiteBinding`;
+six call sites consult it and every one is inert when it is null. The vertical window is enforced
+structurally at `ChunkBuffer`, the single choke point every driver write passes through. Urbex
+dispatches nothing — the caller calls `fill`.
+
+**Tech Stack:** Java 25, Fabric 26.2, Mixin, Gradle (loom). Tests are JUnit 5 under `src/test/java`.
+
+## Global Constraints
+
+- **No generated output may change.** Every seam is guarded by `site != null`. The five digest
+  goldens (`digest.golden`, `digest-features.golden`, `digest-avoid.golden`,
+  `digest-avoid-modes.golden`, `digest-rail.golden`) must reproduce exactly, at the default worker
+  pool size and at `-Dmax.bg.threads=2`.
+- **The public API is `dev.krona.urbex.api` and nothing else.** No other package gains public types
+  for this feature. Every type in it carries an `@Experimental`-style javadoc warning that it may
+  change without a deprecation cycle.
+- **`SiteField` implementations are contractually pure**, thread-safe, and answer for any
+  coordinate. Urbex calls them for neighbours of the chunk being filled.
+- **No new dispatch.** `CarverHookMixin` and `CityFeature` are not modified.
+- Package layout follows the existing tree: `worldgen/` for generation, `worldgen/lost/` for
+  planning, `setup/` for configuration.
+
+---
+
+### Task 1: The vertical write window at `ChunkBuffer`
+
+The hard half of the Y guarantee, built first because it is independently testable and inert by
+default.
+
+**Files:**
+- Modify: `src/main/java/dev/krona/urbex/worldgen/ChunkBuffer.java`
+- Modify: `src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java:235` (`setPrimer`)
+- Create: `src/test/java/dev/krona/urbex/worldgen/ChunkBufferWindowTest.java`
+
+**Interfaces:**
+- Produces: `ChunkDriver.setPrimer(LevelAccessor, ChunkAccess, int writeMinY, int writeMaxY)` — the
+  existing two-argument overload delegates with the level's own bounds, so no caller changes.
+- Produces: `ChunkBuffer(WriteLog, WorldView, int minY, int maxY, int originX, int originZ, int writeMinY, int writeMaxY)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`ChunkBufferWindowTest` covers, against a buffer whose level is `[-64, 320)` and whose window is
+`[10, 40]`:
+- `set` at y=9 and y=41 is neither logged nor flushed; at y=10 and y=40 both happen.
+- `fill(x, z, 5, 45, state)` writes exactly y=10..40 and logs exactly 31 positions.
+- `fillWhere` outside the window does not consult the `WorldView` at all (a `WorldView` that throws
+  proves it).
+- `remember` outside the window leaves the slot null, so a section that is partly in and partly out
+  flushes only its in-window blocks.
+- An unbounded window (`writeMinY == minY`, `writeMaxY == maxY`) behaves exactly as today.
+
+- [ ] **Step 2: Run and watch them fail** — `./gradlew test --tests '*ChunkBufferWindowTest*'`
+
+- [ ] **Step 3: Implement**
+
+Add `writeMinY` / `writeMaxY` fields. Guard `set`, `fill`, `fillWhere` and `remember`. `fill` and
+`fillWhere` clamp their loop bounds rather than testing per iteration. `sectionUntouched`,
+`sectionBottom` and `get` are unchanged — they are reads, and a read outside the window must keep
+answering about the world.
+
+- [ ] **Step 4: Run the tests and the full suite** — `./gradlew test`
+
+- [ ] **Step 5: Commit** — `feat(worldgen): bound driver writes to a vertical window`
+
+---
+
+### Task 2: `SiteBinding` and the planning seams
+
+The core. After this task a site can be constructed in a test and plans correctly, though nothing
+public can build one yet.
+
+**Files:**
+- Create: `src/main/java/dev/krona/urbex/worldgen/SiteBinding.java`
+- Create: `src/main/java/dev/krona/urbex/worldgen/SiteTerrain.java`
+- Modify: `src/main/java/dev/krona/urbex/worldgen/PlanningContext.java` (tenth component)
+- Modify: `src/main/java/dev/krona/urbex/worldgen/lost/CityField.java:34,58,80`
+- Modify: `src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java:428`
+- Modify: `src/main/java/dev/krona/urbex/worldgen/CityGenerator.java:235`
+- Create: `src/test/java/dev/krona/urbex/worldgen/SitePlanningTest.java`
+
+**Interfaces:**
+- Produces: `record SiteBinding(Identifier id, SiteField field, int minY, int maxY)` where
+  `SiteField` is the public API interface from Task 4 — declare the interface in
+  `dev.krona.urbex.api` now and let this depend on it, rather than defining a duplicate.
+- Produces: `PlanningContext.site()` returning `@Nullable SiteBinding`, plus a compact convenience
+  constructor keeping the existing nine-argument form (passing `null`) so no existing call site or
+  test changes.
+- Produces: `SiteTerrain implements TerrainSampler` — flat heightmap at `field.groundY(coord)`,
+  biome and registry access delegated to a wrapped `TerrainSampler`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`SitePlanningTest`, built on whatever headless `PlanningContext` fixture the existing planning tests
+use (see `src/test/java/dev/krona/urbex/worldgen/` and `plan/`):
+- With a `SiteField` that answers true on a 3×3 block of chunks and `groundY == 30`, the centre
+  chunk's `ChunkPlan.isCity` is true, its `groundLevel` is 30 and its `cityLevel` is 0; a chunk
+  outside the block plans `isCity == false`.
+- The same `ChunkCoord` planned through a site context and through the level's context yields two
+  distinct `ChunkPlan` instances with different `groundLevel` — proving cache separation.
+- A `PlanningContext` with `site() == null` reaches `City.getCityFactor` exactly as before (assert
+  a known-city coordinate under a stock preset still plans as city).
+
+- [ ] **Step 2: Run and watch them fail**
+
+- [ ] **Step 3: Implement the seams**
+
+Each is a single guarded branch:
+
+```java
+// CityField.isCityRaw
+SiteBinding site = provider.site();
+if (site != null) {
+    return site.field().isSite(coord.chunkX(), coord.chunkZ());
+}
+// ... existing void check and city factor
+```
+
+```java
+// CityField.getCityLevel and cityLevelUncached
+if (provider.site() != null) {
+    return 0;   // no surface height bands underground
+}
+```
+
+```java
+// ChunkPlan constructor, replacing `groundLevel = ... : profile.groundLevel();`
+SiteBinding site = provider.site();
+int planned = site != null ? site.field().groundY(key.chunkX(), key.chunkZ())
+                           : profile.groundLevel();
+groundLevel = override != null ? override.groundLevel() : planned;
+```
+
+```java
+// CityGenerator.generateOrThrow, immediately before the doCity branch
+if (!doCity && provider.site() != null) {
+    return;   // a site is sparse: a non-site chunk is left exactly as it was found
+}
+```
+
+Each guard carries a javadoc-grade comment naming *why*, in the register the surrounding code uses.
+
+- [ ] **Step 4: Run the tests and the full suite**
+
+- [ ] **Step 5: Commit** — `feat(worldgen): plan a chunk against a caller-supplied site`
+
+---
+
+### Task 3: Windowing the deferred writes
+
+Post-todos, light todos and level tasks bypass the driver, so the `ChunkBuffer` guard does not reach
+them. Bound them by anchor position.
+
+**Files:**
+- Modify: `src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java:89,101,117`
+- Create: `src/test/java/dev/krona/urbex/worldgen/SiteDeferredWriteTest.java`
+
+**Interfaces:**
+- Consumes: `PlanningContext.site()` from Task 2.
+- Produces: nothing new — `addPostTodo`, `addLightTodo` and `addLevelTask` silently drop
+  out-of-window anchors when a site is bound.
+
+- [ ] **Step 1: Write the failing test** — a `ChunkGenContext` on a site with window `[10, 40]`
+  accepts a post-todo at y=20 and drops one at y=50; same for a light todo and a level task. On a
+  context with no site, nothing is dropped.
+
+- [ ] **Step 2: Run and watch it fail**
+
+- [ ] **Step 3: Implement** — capture the window on the context at construction (from
+  `provider.site()`, or the level's full range when there is none) and test the anchor's Y in the
+  three `add` methods. Document that this is exact for the anchored block and approximate for
+  anything a callback touches around it.
+
+- [ ] **Step 4: Run the suite**
+
+- [ ] **Step 5: Commit** — `feat(worldgen): bound a site's deferred writes to its window`
+
+---
+
+### Task 4: The public API package
+
+**Files:**
+- Create: `src/main/java/dev/krona/urbex/api/SiteField.java`
+- Create: `src/main/java/dev/krona/urbex/api/SiteSpec.java`
+- Create: `src/main/java/dev/krona/urbex/api/UrbexSite.java`
+- Create: `src/main/java/dev/krona/urbex/api/UrbexApi.java`
+- Create: `src/main/java/dev/krona/urbex/api/package-info.java`
+- Create: `src/main/java/dev/krona/urbex/worldgen/SiteRuntimes.java` (internal: builds and memoises)
+- Create: `src/test/java/dev/krona/urbex/api/SiteSpecTest.java`
+- Create: `docs/site-api.md`
+
+**Interfaces:**
+- Consumes: `SiteBinding`, `SiteTerrain` (Task 2); `GenerationSession.current()`,
+  `GenerationSession.runtimeFor(level)`, `Presets.resolve(RegistryAccess, Identifier)`,
+  `Presets.applyOverrides(Preset, PresetDefinition)`, `PresetDefinition.parseOverrides(JsonElement)`,
+  `WorldStyleField.resolve(AssetSnapshot, long, WorldStyleMix)`,
+  `GridRoadField(long, String, PresetRoadGrid)`, `LevelShape.of(LevelReader)`.
+- Produces:
+  - `UrbexApi.site(ServerLevel, SiteSpec) -> UrbexSite`
+  - `UrbexApi.isAvailable(ServerLevel) -> boolean`
+  - `UrbexSite.fill(WorldGenRegion, ChunkAccess) -> boolean`
+  - `SiteSpec.builder(Identifier id, Identifier preset, SiteField field)` with
+    `.worldStyles(WorldStyleMix)`, `.worldStyle(Identifier)`, `.presetOverrides(String json)`,
+    `.window(int minY, int maxY)`, `.build()`.
+
+- [ ] **Step 1: Write the failing tests** — `SiteSpecTest` covers builder validation: `maxY < minY`
+  is rejected at build time with a message naming both values; a null field, id or preset is
+  rejected; the default window is the full level range sentinel; `worldStyle(id)` and
+  `worldStyles(mix)` produce equal specs for a single style.
+
+- [ ] **Step 2: Run and watch them fail**
+
+- [ ] **Step 3: Implement**
+
+`SiteRuntimes` holds a `Map<ServerLevel, Map<Identifier, Site>>` behind the `GenerationSession`
+lifetime, so sites die with their world. Building one:
+
+1. Resolve the preset, apply overrides if present (rethrowing `RetiredPresetKeyException`, logging
+   anything else, exactly as `DimensionRuntime.create` does).
+2. `assets` and `tagEpoch` from `GenerationSession.current()`; refuse with a named exception if the
+   world has not compiled yet.
+3. `LevelShape` = the level's, clamped to the spec's window.
+4. `TerrainSampler` = `SiteTerrain` wrapping a `LevelTerrain` built on fresh `DimensionCaches`.
+5. `PlanningContext` with the new `SiteBinding`, then a `CityGenerator` over it.
+
+`fill` builds a `DimensionRuntime` from the level's published task queue and the world's tag epoch,
+then calls `generator.generate(runtime, region, chunk)`. It does **not** touch `GeneratedChunkMark`:
+the mark guards Urbex's own two dispatch routes, and a caller that calls `fill` twice for one chunk
+has made its own decision.
+
+`docs/site-api.md` is the reference: the purity contract, the "a `WorldCarver` has no
+`WorldGenRegion`, hook the carver tail instead" note, the window semantics, and a complete worked
+example.
+
+- [ ] **Step 4: Run the suite**
+
+- [ ] **Step 5: Commit** — `feat(api): experimental site API`
+
+---
+
+### Task 5: Prove nothing moved
+
+**Files:** none.
+
+- [ ] **Step 1:** `./gradlew test`
+- [ ] **Step 2:** Run all six digest configurations and compare against the goldens.
+- [ ] **Step 3:** Re-run with `-PurbexDigestVmArgs=-Dmax.bg.threads=2`.
+- [ ] **Step 4:** Record the hashes in the branch's PR body. If any golden moves, that is a bug in
+      Tasks 1-4, not a golden to regenerate.
+
+---
+
+### Task 6: `minecraft-mods/Urbex-Bunkers`
+
+**Files (new project):**
+- `build.gradle`, `settings.gradle`, `gradle.properties`, `gradlew` (copied from Urbex's layout)
+- `src/main/resources/fabric.mod.json`, `urbexbunkers.mixins.json`
+- `src/main/java/dev/krona/urbexbunkers/UrbexBunkers.java`
+- `src/main/java/dev/krona/urbexbunkers/BunkerField.java`
+- `src/main/java/dev/krona/urbexbunkers/BunkerCavity.java`
+- `src/main/java/dev/krona/urbexbunkers/mixin/BunkerCarverHookMixin.java`
+- `src/main/resources/data/urbexbunkers/...` — a world style and preset for the bunkers
+- `README.md`
+
+**Interfaces:**
+- Consumes: the whole of Task 4's API.
+
+- [ ] **Step 1:** Scaffold the Fabric mod against the local Urbex jar.
+- [ ] **Step 2:** `BunkerField implements SiteField` — a region grid (default 24 chunks); each region
+      hashes to a centre chunk, a radius in chunks and a depth. `isSite` is a squared-distance test
+      against the region's centre and its two neighbours in each axis so a site near a region edge
+      is not clipped; `groundY` is the region's depth. Pure, no allocation, no state.
+- [ ] **Step 3:** `BunkerCavity` — hollows rock in the window around the site, driven off the same
+      field, so carve and fill cannot disagree.
+- [ ] **Step 4:** `BunkerCarverHookMixin` at `applyCarvers` TAIL: carve, then `fill`. One
+      `UrbexSite` per level, fetched through `UrbexApi.site` (memoised, so per-chunk is fine).
+- [ ] **Step 5:** Build it, run a client, fly to a bunker, screenshot.
+- [ ] **Step 6:** Commit in the Urbex-Bunkers repo.
+
+---
+
+## Self-Review
+
+**Spec coverage:** public surface → Task 4; purity contract → Tasks 2 and 4 (javadoc) and `docs/site-api.md`;
+internal seam table → Tasks 1-3; cache separation → Task 2 test; disabled-dimension support → Task 4
+(`fill` borrows only the task queue and tag epoch); sparse non-site chunk → Task 2; window planning
+half → Task 2 (`LevelShape` clamp, built in Task 4's assembly); window writing half → Task 1;
+deferred writes → Task 3; commuting property → consequence of Tasks 1 and 3, asserted nowhere and
+stated in docs; example mod → Task 6; verification → Task 5 plus each task's own tests.
+
+**Placeholders:** none — every step names the file, the assertion or the code.
+
+**Type consistency:** `SiteField` is declared once, in `dev.krona.urbex.api`, and consumed by
+`SiteBinding`; `SiteBinding.field()` is the only accessor used across Tasks 2 and 3;
+`UrbexSite.fill` has one signature throughout.

--- a/docs/superpowers/specs/2026-08-16-experimental-site-api-design.md
+++ b/docs/superpowers/specs/2026-08-16-experimental-site-api-design.md
@@ -1,6 +1,7 @@
 # Experimental site API: letting another mod ask Urbex to build somewhere
 
-**Status:** design approved 2026-08-16.
+**Status:** design approved 2026-08-16; implemented the same day. Two things changed during
+implementation, both because a real world showed them — see "What building it changed" at the end.
 
 ## The problem
 
@@ -170,3 +171,31 @@ New unit tests:
   in each.
 - `SiteField` answers drive `isCity` and `groundLevel`, and a site's `cityLevel` is 0.
 - A spec re-registered under the same id in the same level returns the same handle.
+
+## What building it changed
+
+Both of these were found by generating a world with `Urbex-Bunkers` loaded and diffing the driver's
+per-chunk write log against a run without it. Neither was visible from the design.
+
+**A site is not subject to structure avoidance.** The design put the sparse early return before the
+structure probe, which left a path around it: the probe can turn `doCity` off *after* that point, and
+a site reaching the `else` branch ran `doNormalChunk` — exactly the world-repainting this was
+supposed to prevent. In the probe world it cost ten of a bunker's eleven chunks, which generated four
+layers of terrain correction and nothing else.
+
+The fix is not another guard in the same place. Avoidance exists to stop Urbex's own city noise
+bulldozing a village it happened to roll on top of; a caller naming a place has already decided, and
+a bunker suppressed by a village forty blocks overhead is a hole in the middle of itself with streets
+running into it — its neighbours' plans still say the middle is there. So a site skips the probe
+entirely, along with the floating-dimension void probe, which asks a question `isCityRaw` has already
+answered for a site. Two region reads saved per chunk as well.
+
+**A site ignores its preset's sea level, and gains `waterY`.** A preset names one absolute sea level
+for a whole dimension. `urbex:cavern` — the obvious preset for anything underground, and the one the
+example mod reaches for — says 32, so the first working bunker came out flooded to the ceiling with
+21,868 blocks of water. Nothing in the design was wrong; the interaction simply does not survive
+contact with a site forty blocks below a dimension's surface.
+
+Making the preset's sea level apply anyway would leave a trap every caller walks into once. So a site
+takes its water level from `SiteSpec.waterY`, which defaults to "there is none", and a caller who
+wants a flooded site asks for one.

--- a/docs/superpowers/specs/2026-08-16-experimental-site-api-design.md
+++ b/docs/superpowers/specs/2026-08-16-experimental-site-api-design.md
@@ -1,0 +1,172 @@
+# Experimental site API: letting another mod ask Urbex to build somewhere
+
+**Status:** design approved 2026-08-16.
+
+## The problem
+
+Urbex decides for itself where cities go. A perlin city field over the whole dimension picks the
+centres, the terrain heightmap picks how high each chunk's city sits, and one world style governs the
+whole level. That is the right default and it is the only thing on offer.
+
+A mod that wants to put Urbex content somewhere Urbex would never choose has nowhere to stand. The
+motivating case is a cave bunker: a third-party mod carves a cavity underground and wants Urbex to
+fill it — at the cavity's Y rather than the surface's, in a different world style from the one
+generating the ruins overhead, and without a single block escaping the cavity.
+
+Everything needed is already in the mod. It is reachable only through decisions Urbex makes on its
+own behalf.
+
+## What we are building
+
+An experimental Java API — `dev.krona.urbex.api` — through which another mod defines a **site**: a
+patch of Urbex city with its own preset, its own world style, its own ground level and a hard
+vertical window. The caller drives. Urbex dispatches nothing; a site generates when, and only when,
+the caller says `fill`.
+
+Plus `minecraft-mods/Urbex-Bunkers`, a working mod that carves cavities and fills them, to prove the
+API is usable from outside.
+
+### Non-goals
+
+- No datapack surface. A site is defined in Java, by the mod that owns it.
+- No new dispatch. Urbex's own carver-tail hook is untouched and knows nothing about sites.
+- No change to any output Urbex generates today. Every seam below is inert when no site is involved.
+
+## The public surface
+
+Four types in `dev.krona.urbex.api`, marked experimental. Nothing else becomes public.
+
+```java
+/** Where this mod's sites are, and how high each one sits. */
+public interface SiteField {
+    boolean isSite(int chunkX, int chunkZ);
+    int groundY(int chunkX, int chunkZ);
+}
+
+/** What a site is built from. A value; its identity is `id`. */
+public record SiteSpec(Identifier id, Identifier preset, List<StyleWeight> worldStyles,
+                       @Nullable String presetOverridesJson, SiteField field,
+                       int minY, int maxY) { /* + builder */ }
+
+/** A live handle onto one site in one level. */
+public interface UrbexSite {
+    boolean fill(WorldGenRegion region, ChunkAccess chunk);
+}
+
+public final class UrbexApi {
+    public static UrbexSite site(ServerLevel level, SiteSpec spec);
+    public static boolean isAvailable(ServerLevel level);
+}
+```
+
+`presetOverridesJson` is the existing `PresetDefinition` overlay that dimension selection already
+applies. Lighting density, floor counts, ruin chance, corridor chance and every other preset field
+therefore reach a site with no new API at all.
+
+### The purity contract, and why it is not negotiable
+
+`SiteField` must be a pure, thread-safe function of the coordinate, and must answer for **any**
+coordinate rather than only the one being filled.
+
+Urbex plans a chunk by reading its neighbours' plans: whether a street continues, whether a doorway
+is cut through a shared wall, whether a stair wins against a competing one, whether a multi-chunk
+building may be accepted. Those reads reach coordinates the caller has not asked about and may never
+ask about. A per-call `boolean bunkerIsHere` cannot answer them, and the visible result is streets
+that stop in rock and doorways that open into nothing.
+
+Putting the field in the spec keeps dispatch entirely in the caller's hands while making the edges
+correct. The caller's carver reads the same field, so what gets carved and what gets built agree by
+construction rather than by timing.
+
+### Cost model
+
+Building a site is expensive: a preset resolution, a world-style field, a road field and a fresh set
+of per-dimension caches. `UrbexApi.site` therefore memoises per `(level, spec.id())` and is cheap to
+call per chunk. Two specs sharing an id in one level are a programming error and are reported as one.
+
+## The internal seam
+
+`PlanningContext` gains a tenth component, `@Nullable SiteBinding site`, carrying the field and the
+window. Six call sites consult it, and every one of them is a no-op when it is null:
+
+| Where | Today | With a site |
+|---|---|---|
+| `CityField.isCityRaw` | perlin city factor vs. threshold | `field.isSite(x, z)` |
+| `CityField.getCityLevel` / `cityLevelUncached` | terrain height band 0..7 | `0` — there are no surface bands underground |
+| `ChunkPlan` constructor | `groundLevel = profile.groundLevel()` | `groundLevel = field.groundY(x, z)` |
+| `CityGenerator.generateOrThrow` | a non-city chunk runs `doNormalChunk` | a non-site chunk returns having written nothing |
+| planning assembly | `LevelTerrain`, level's `LevelShape` | flat `SiteTerrain`, `LevelShape` clamped to the window |
+| `ChunkBuffer` | writes bounded by the level | writes bounded by the window |
+
+A site is a second `PlanningContext` and a second `CityGenerator` over the same level, holding its
+own `DimensionCaches`. Surface plans and site plans therefore never collide in a cache keyed by
+`ChunkCoord`, and one dimension can run a heavily ruined world style at the surface and an intact one
+underground.
+
+A site borrows the level's `LevelTaskQueue` and the world's `TagEpoch` from the published
+`DimensionRuntime` and `GenerationSession`. It does not borrow the level's preset or planning, so
+**a site generates in a dimension where Urbex surface generation is switched off entirely** — a
+vanilla overworld with bunkers under it and nothing above.
+
+### Skipping the non-site chunk
+
+A site is sparse. Where `isSite` is false, `fill` must write nothing at all: no ground cover, no
+terrain correction, no scattered buildings, no bridge scan. That is one early return in
+`generateOrThrow`, before `doNormalChunk`, and it is what stops a bunker layer repainting the world
+it lives inside.
+
+Where `isSite` is true, the ordinary city path runs unchanged, terrain correction included — that
+correction is what gives the bunker a floor.
+
+## The vertical window is a guarantee
+
+Two mechanisms, deliberately:
+
+**Planning** sees a `LevelShape` clamped to `[minY, maxY]`. Floor counts already clamp against
+`shape().maxY()`, so a site plans buildings that fit rather than buildings that are cut off.
+
+**Writing** is bounded at `ChunkBuffer`, the single choke point every driver write passes through.
+`set`, `fill`, `fillWhere` and `remember` drop positions outside the window — one comparison each, on
+a path that already indexes by Y. Nothing outside the window can reach a flushed section, whatever
+any pass believes it is doing.
+
+Deferred writes bypass the driver and are bounded separately, by anchor position, at the three
+queues that accept them: post-todos, light todos and level tasks. This is exact for the block a todo
+addresses and approximate for anything it touches around that block; the javadoc says so rather than
+implying a guarantee the mechanism does not give.
+
+A consequence worth stating: because the window is absolute, a site and the surface city **commute**.
+It does not matter which of them runs first, so a caller need not reason about mixin priority
+against Urbex's own carver-tail hook.
+
+## The example mod: `minecraft-mods/Urbex-Bunkers`
+
+A standalone Fabric mod, depending on Urbex.
+
+- `BunkerField implements SiteField` — a coarse region grid; each region hashes to a centre, a
+  radius and a depth. Pure, allocation-free, no state.
+- A cavity pass that hollows rock around the site, driven off the same field.
+- The `UrbexApi` call that fills it.
+
+Both run from one `applyCarvers` TAIL hook, the stage Urbex itself uses, because that is where a
+`WorldGenRegion` exists. A raw `WorldCarver` receives a `CarvingContext` and cannot write through a
+region, so it cannot call `fill`; the API javadoc states this rather than leaving a caller to find it
+by exception.
+
+The mod configures the site with a different world style from the surface and a window well below
+sea level, which is the whole scenario the API exists for.
+
+## Verification
+
+Everything above is unreachable when `site == null`, so the five digest goldens must not move:
+`digest`, `digest-features`, `digest-avoid`, `digest-avoid-modes`, `digest-rail`. Run at the default
+worker pool size and again at `-Dmax.bg.threads=2`, and report the hashes.
+
+New unit tests:
+
+- `ChunkBuffer` drops writes outside a window and keeps writes inside it, including a run that
+  straddles a boundary and a section that is partly in and partly out.
+- A site's `DimensionCaches` and the level's are distinct — the same `ChunkCoord` plans differently
+  in each.
+- `SiteField` answers drive `isCity` and `groundLevel`, and a site's `cityLevel` is 0.
+- A spec re-registered under the same id in the same level returns the same handle.

--- a/src/main/java/dev/krona/urbex/api/SiteField.java
+++ b/src/main/java/dev/krona/urbex/api/SiteField.java
@@ -1,0 +1,63 @@
+package dev.krona.urbex.api;
+
+/**
+ * Where a mod's sites are, and how high each one sits.
+ *
+ * <p><strong>Experimental.</strong> See {@link UrbexApi} for what that means.</p>
+ *
+ * <h2>This must be a pure function of the coordinate</h2>
+ *
+ * <p>It is tempting to read this as "the mod tells Urbex about the chunk it is filling". It is not.
+ * Urbex plans a chunk by reading its <em>neighbours'</em> plans - whether a street continues across
+ * the border, whether a doorway is cut through a shared wall, which of two competing stairs wins,
+ * whether a multi-chunk building may be accepted here. Those reads reach coordinates the caller has
+ * not asked about and may never ask about, on threads the caller does not own, in an order nobody
+ * controls.</p>
+ *
+ * <p>So an implementation must be:</p>
+ * <ul>
+ *   <li><strong>Pure.</strong> The same coordinate answers the same thing forever. Not "until the
+ *       carver runs", not "once the cave is known" - forever, from the first chunk of the world to
+ *       the last. An implementation that reads a block, a chunk, a level or any state a generation
+ *       pass writes is wrong, and wrong in a way that shows up as streets ending in rock.</li>
+ *   <li><strong>Total.</strong> It answers for every coordinate in the dimension, including ones
+ *       hundreds of chunks from anything the caller cares about.</li>
+ *   <li><strong>Thread-safe.</strong> Called concurrently from the worldgen worker pool.</li>
+ *   <li><strong>Cheap.</strong> Called for a neighbourhood per planned chunk, and planned chunks are
+ *       cached but neighbours are not asked once. Hash arithmetic and noise are fine; anything that
+ *       allocates per call is not.</li>
+ * </ul>
+ *
+ * <p>The natural shape is a deterministic field derived from the world seed - a region grid, a noise
+ * threshold, a hashed lattice. The caller's own carver reads the same field, so what gets carved and
+ * what gets built agree by construction rather than by timing.</p>
+ */
+@FunctionalInterface
+public interface SiteField {
+
+    /**
+     * Whether this mod's site covers the chunk at {@code (chunkX, chunkZ)}.
+     *
+     * <p>This replaces Urbex's own city noise wholesale. Where it answers {@code false}, a
+     * {@link UrbexSite#fill} of that chunk writes nothing at all - not a street, not ground cover,
+     * not a terrain correction. Where it answers {@code true}, the chunk is planned exactly as a
+     * city chunk is planned, with buildings, roads and everything the preset asks for.</p>
+     */
+    boolean isSite(int chunkX, int chunkZ);
+
+    /**
+     * The Y the site's ground sits at in this chunk, in world coordinates.
+     *
+     * <p>The floor the first storey stands on; cellars go below it and floors above it, six blocks
+     * apart, as everywhere else in Urbex. The default is
+     * {@link UrbexApi#DEFAULT_GROUND_Y}, which suits a fixed-depth layer; override it for a field
+     * whose depth varies.</p>
+     *
+     * <p>Only consulted where {@link #isSite} answers {@code true}, but it must still be pure and
+     * total: a chunk on the edge of a site reads its neighbours' ground to decide whether a street
+     * can slope and where a stair goes.</p>
+     */
+    default int groundY(int chunkX, int chunkZ) {
+        return UrbexApi.DEFAULT_GROUND_Y;
+    }
+}

--- a/src/main/java/dev/krona/urbex/api/SiteField.java
+++ b/src/main/java/dev/krona/urbex/api/SiteField.java
@@ -53,6 +53,13 @@ public interface SiteField {
      * {@link UrbexApi#DEFAULT_GROUND_Y}, which suits a fixed-depth layer; override it for a field
      * whose depth varies.</p>
      *
+     * <p><strong>Snapped down to a multiple of six above the window's bottom.</strong> Six blocks is
+     * a storey, and it is the unit every height comparison in Urbex counts in - whether a doorway
+     * can be cut through a shared wall, whether a street may slope, which of two competing stairs
+     * wins. Two parts of a site whose grounds differ by less than one storey have no way to say so
+     * to each other, so a value between two storeys is rounded rather than half-honoured. Return
+     * multiples of six above {@code minY} and nothing is lost.</p>
+     *
      * <p>Only consulted where {@link #isSite} answers {@code true}, but it must still be pure and
      * total: a chunk on the edge of a site reads its neighbours' ground to decide whether a street
      * can slope and where a stair goes.</p>

--- a/src/main/java/dev/krona/urbex/api/SiteSpawn.java
+++ b/src/main/java/dev/krona/urbex/api/SiteSpawn.java
@@ -1,0 +1,27 @@
+package dev.krona.urbex.api;
+
+/**
+ * Where inside a site a claimed world spawn should land.
+ *
+ * <p><strong>Experimental.</strong> See {@link UrbexApi} for what that means.</p>
+ */
+public enum SiteSpawn {
+
+    /**
+     * On a street or open lot - a site chunk the plan gave no building.
+     *
+     * <p>The safe choice, and the one to reach for first. A street is clear by construction and lit
+     * by whatever the preset's lighting density puts there, so the player opens their eyes looking
+     * at the place rather than at the inside of a wall.</p>
+     */
+    STREET,
+
+    /**
+     * Inside a building, on its ground floor.
+     *
+     * <p>The more dramatic opening, and the riskier one: a ground floor is furnished, so the search
+     * has more blocks to reject before it finds somewhere to stand, and a site whose buildings are
+     * dense throughout may push the search further out than {@link #STREET} would.</p>
+     */
+    BUILDING
+}

--- a/src/main/java/dev/krona/urbex/api/SiteSpec.java
+++ b/src/main/java/dev/krona/urbex/api/SiteSpec.java
@@ -1,0 +1,110 @@
+package dev.krona.urbex.api;
+
+import dev.krona.urbex.setup.WorldStyleMix;
+import net.minecraft.resources.Identifier;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * What a site is built from: a value, complete on its own, that {@link UrbexApi#site} turns into a
+ * live {@link UrbexSite}.
+ *
+ * <p><strong>Experimental.</strong> See {@link UrbexApi} for what that means.</p>
+ *
+ * <p>Build one with {@link #builder}. Everything but the id, the preset and the field has a
+ * defensible default, so the shortest useful spec is three arguments and a {@code build()}.</p>
+ *
+ * @param id                  the site's identity within a level. Two calls to
+ *                            {@link UrbexApi#site} with the same id return the same site, so this
+ *                            is what makes a per-chunk call cheap. It also names the site in any
+ *                            diagnostic, so name it after what it builds.
+ * @param preset              the preset this site generates with, as a {@code urbex:preset}
+ *                            registry id. Independent of whatever preset the dimension itself uses.
+ * @param worldStyles         which world styles the site draws from. A single-entry mix is the
+ *                            ordinary case and draws no randomness at all.
+ * @param presetOverridesJson a {@code PresetDefinition} JSON overlay applied on top of the resolved
+ *                            preset, or null. This is how a caller reaches every preset field there
+ *                            is - lighting density, floor counts, ruin chance, corridor chance -
+ *                            without this API growing a method per field. Malformed JSON is logged
+ *                            and the un-overridden preset used, exactly as for a dimension.
+ * @param field               where the sites are and how high they sit. Pure, total, thread-safe;
+ *                            read {@link SiteField} before writing one.
+ * @param minY                the lowest block Y the site may write at, inclusive.
+ * @param maxY                the highest block Y the site may write at, inclusive.
+ */
+public record SiteSpec(Identifier id, Identifier preset, WorldStyleMix worldStyles,
+                       @Nullable String presetOverridesJson, SiteField field, int minY, int maxY) {
+
+    public SiteSpec {
+        Objects.requireNonNull(id, "an Urbex site needs an id");
+        Objects.requireNonNull(preset, "Urbex site '" + id + "' needs a preset");
+        Objects.requireNonNull(worldStyles, "Urbex site '" + id + "' needs at least one world style");
+        Objects.requireNonNull(field, "Urbex site '" + id + "' needs a SiteField");
+        if (maxY < minY) {
+            throw new IllegalArgumentException("Urbex site '" + id + "' has a window whose top ("
+                    + maxY + ") is below its bottom (" + minY + ")");
+        }
+    }
+
+    public static Builder builder(Identifier id, Identifier preset, SiteField field) {
+        return new Builder(id, preset, field);
+    }
+
+    /**
+     * Assembles a {@link SiteSpec}. Not thread-safe, and not meant to be: build the spec once, at
+     * mod initialisation or the first time a level needs it, and keep the {@link UrbexSite}.
+     */
+    public static final class Builder {
+
+        private final Identifier id;
+        private final Identifier preset;
+        private final SiteField field;
+        private WorldStyleMix worldStyles = WorldStyleMix.of(UrbexApi.DEFAULT_WORLD_STYLE);
+        @Nullable
+        private String presetOverridesJson;
+        private int minY = UrbexApi.DEFAULT_MIN_Y;
+        private int maxY = UrbexApi.DEFAULT_MAX_Y;
+
+        private Builder(Identifier id, Identifier preset, SiteField field) {
+            this.id = id;
+            this.preset = preset;
+            this.field = field;
+        }
+
+        /** The one world style this site builds in. */
+        public Builder worldStyle(Identifier style) {
+            this.worldStyles = WorldStyleMix.of(style);
+            return this;
+        }
+
+        /** Several weighted world styles; only the ratios of the weights matter. */
+        public Builder worldStyles(WorldStyleMix mix) {
+            this.worldStyles = mix;
+            return this;
+        }
+
+        /** @see SiteSpec#presetOverridesJson() */
+        public Builder presetOverrides(@Nullable String json) {
+            this.presetOverridesJson = json;
+            return this;
+        }
+
+        /**
+         * The vertical window, inclusive at both ends. Nothing this site generates leaves it.
+         *
+         * <p>Leave room above what you expect to build: the window bounds the site's <em>planning</em>
+         * as well as its writing, so a window ten blocks tall does not produce a squashed building,
+         * it produces a building with no floors in it.</p>
+         */
+        public Builder window(int minY, int maxY) {
+            this.minY = minY;
+            this.maxY = maxY;
+            return this;
+        }
+
+        public SiteSpec build() {
+            return new SiteSpec(id, preset, worldStyles, presetOverridesJson, field, minY, maxY);
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/api/SiteSpec.java
+++ b/src/main/java/dev/krona/urbex/api/SiteSpec.java
@@ -32,9 +32,12 @@ import java.util.Objects;
  *                            read {@link SiteField} before writing one.
  * @param minY                the lowest block Y the site may write at, inclusive.
  * @param maxY                the highest block Y the site may write at, inclusive.
+ * @param waterY              the Y the site's water table sits at, or {@link UrbexApi#NO_WATER} for
+ *                            a dry site. See {@link Builder#waterY}.
  */
 public record SiteSpec(Identifier id, Identifier preset, WorldStyleMix worldStyles,
-                       @Nullable String presetOverridesJson, SiteField field, int minY, int maxY) {
+                       @Nullable String presetOverridesJson, SiteField field, int minY, int maxY,
+                       int waterY) {
 
     public SiteSpec {
         Objects.requireNonNull(id, "an Urbex site needs an id");
@@ -65,6 +68,7 @@ public record SiteSpec(Identifier id, Identifier preset, WorldStyleMix worldStyl
         private String presetOverridesJson;
         private int minY = UrbexApi.DEFAULT_MIN_Y;
         private int maxY = UrbexApi.DEFAULT_MAX_Y;
+        private int waterY = UrbexApi.NO_WATER;
 
         private Builder(Identifier id, Identifier preset, SiteField field) {
             this.id = id;
@@ -103,8 +107,24 @@ public record SiteSpec(Identifier id, Identifier preset, WorldStyleMix worldStyl
             return this;
         }
 
+        /**
+         * Floods the site up to {@code y}. Omit it and the site is dry.
+         *
+         * <p>This exists because the alternative is a trap. A preset's own sea level is one absolute
+         * height for a whole dimension - {@code urbex:cavern} says 32 - and a site forty blocks
+         * under that is not underwater, but every rule that fills below the water line thinks it is.
+         * A caller who reached for the obvious underground preset would get a bunker flooded to the
+         * ceiling and no clue why. So a site ignores the preset's sea level entirely and takes this
+         * instead, which defaults to "there is no water here".</p>
+         */
+        public Builder waterY(int y) {
+            this.waterY = y;
+            return this;
+        }
+
         public SiteSpec build() {
-            return new SiteSpec(id, preset, worldStyles, presetOverridesJson, field, minY, maxY);
+            return new SiteSpec(id, preset, worldStyles, presetOverridesJson, field, minY, maxY,
+                    waterY);
         }
     }
 }

--- a/src/main/java/dev/krona/urbex/api/SiteSpecFactory.java
+++ b/src/main/java/dev/krona/urbex/api/SiteSpecFactory.java
@@ -1,0 +1,28 @@
+package dev.krona.urbex.api;
+
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * Builds a caller's {@link SiteSpec} for a level, on demand.
+ *
+ * <p><strong>Experimental.</strong> See {@link UrbexApi} for what that means.</p>
+ *
+ * <p>This exists because of a timing problem with one honest answer. A spawn claim has to be
+ * registered at mod initialisation - before any world exists, because the world's spawn is chosen
+ * while it loads - but a {@link SiteField} is almost always seeded from the world, so the spec
+ * cannot be built that early. Handing Urbex a factory instead of a spec lets the claim be made
+ * before the seed is known and resolved once the level is in hand.</p>
+ *
+ * <p>Return the <em>same</em> spec your generation path uses, id included. Sites are memoised per
+ * {@code (level, spec id)}, so a matching id means the spawn search and the chunks the player walks
+ * out into are the same site rather than two that merely look alike.</p>
+ */
+@FunctionalInterface
+public interface SiteSpecFactory {
+
+    /**
+     * The spec for {@code level}. Called on the server thread while the level is loading, after its
+     * assets are compiled.
+     */
+    SiteSpec specFor(ServerLevel level);
+}

--- a/src/main/java/dev/krona/urbex/api/UrbexApi.java
+++ b/src/main/java/dev/krona/urbex/api/UrbexApi.java
@@ -1,0 +1,120 @@
+package dev.krona.urbex.api;
+
+import dev.krona.urbex.worldgen.GenerationSession;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * Ask Urbex to build somewhere it would not have chosen.
+ *
+ * <h2>Experimental</h2>
+ *
+ * <p>This package may change shape without a deprecation cycle, including between patch releases of
+ * Urbex. It is published so that the design can be used and argued with, not because it is settled.
+ * Pin the Urbex version you build against.</p>
+ *
+ * <h2>What a site is</h2>
+ *
+ * <p>Urbex normally decides for itself where cities go: a perlin field over the whole dimension
+ * picks the centres, the terrain heightmap picks how high each chunk sits, and one world style
+ * governs the level. A <em>site</em> is the same machinery with three of those answers supplied by
+ * another mod instead - where, how high, and how far it may reach - so a mod that carves cave
+ * bunkers can have them filled with Urbex buildings at the cavity's depth, in a different world
+ * style from the ruins on the surface, without a block escaping the cavity.</p>
+ *
+ * <p>Everything else about a site is a preset, and a preset is a datapack file. Lighting density,
+ * floor counts, cellar counts, ruin chance, corridor chance, road spacing - a site reaches all of
+ * them by naming a preset, and reaches any of them individually through
+ * {@link SiteSpec.Builder#presetOverrides}.</p>
+ *
+ * <h2>Urbex dispatches nothing</h2>
+ *
+ * <p>A site generates when the caller calls {@link UrbexSite#fill} and at no other time. Urbex's own
+ * carver-tail hook knows nothing about sites and will not run one. That is deliberate: the caller
+ * owns the cavity, so the caller owns the timing.</p>
+ *
+ * <h2>The shape of a caller</h2>
+ *
+ * <pre>{@code
+ * // once, at mod init
+ * static final SiteField FIELD = new BunkerField();
+ * static final SiteSpec SPEC = SiteSpec
+ *         .builder(Identifier.fromNamespaceAndPath("mymod", "bunkers"),
+ *                  Identifier.fromNamespaceAndPath("urbex", "standard"),
+ *                  FIELD)
+ *         .worldStyle(Identifier.fromNamespaceAndPath("mymod", "bunker_style"))
+ *         .window(-40, 20)
+ *         .build();
+ *
+ * // per chunk, from somewhere that holds a WorldGenRegion - the tail of applyCarvers is the one
+ * // this was designed for
+ * if (FIELD.isSite(chunk.getPos().x(), chunk.getPos().z()) && UrbexApi.isAvailable(level)) {
+ *     carveCavity(region, chunk);
+ *     UrbexApi.site(level, SPEC).fill(region, chunk);
+ * }
+ * }</pre>
+ *
+ * <p>Read {@link SiteField} before writing one. Its purity contract is the one thing here that
+ * cannot be relaxed.</p>
+ */
+public final class UrbexApi {
+
+    private UrbexApi() {
+    }
+
+    /** The world style a spec uses when it names none: the one Urbex itself defaults to. */
+    public static final Identifier DEFAULT_WORLD_STYLE =
+            Identifier.fromNamespaceAndPath("urbex", "standard");
+
+    /** The ground a {@link SiteField} sits at when it does not override {@code groundY}. */
+    public static final int DEFAULT_GROUND_Y = -20;
+
+    /** The bottom of a window a spec does not name: deep enough for anything underground. */
+    public static final int DEFAULT_MIN_Y = -60;
+
+    /**
+     * The top of a window a spec does not name. Below sea level on purpose - the defaults describe
+     * something underground, because a site that wanted the surface would not need this API.
+     */
+    public static final int DEFAULT_MAX_Y = 40;
+
+    /**
+     * The site {@code spec} names in {@code level}, built on first use and kept for the life of the
+     * world.
+     *
+     * <p>Cheap enough to call per chunk: the lookup is two hash maps. Two calls with the same
+     * {@link SiteSpec#id()} in the same level return the same site, whatever else the specs say -
+     * see {@link dev.krona.urbex.worldgen.SiteRuntimes} for why, and for what is logged when they
+     * disagree.</p>
+     *
+     * @throws IllegalStateException if this world has not compiled its assets yet, which is to say
+     *         if no level has loaded. Guard with {@link #isAvailable} on any path that could run
+     *         that early.
+     */
+    public static UrbexSite site(ServerLevel level, SiteSpec spec) {
+        GenerationSession session = GenerationSession.current();
+        AssetSnapshot assets = session == null ? null : session.assets();
+        if (assets == null) {
+            throw new IllegalStateException("Urbex site '" + spec.id() + "' was requested in '"
+                    + level.dimension().identifier() + "' before this world compiled its Urbex "
+                    + "assets. A site can only be built once a level has loaded; guard with "
+                    + "UrbexApi.isAvailable(level).");
+        }
+        return session.sites().site(level, spec, assets);
+    }
+
+    /**
+     * Whether {@link #site} will succeed for {@code level} right now.
+     *
+     * <p>False before the world's first level load has compiled the asset registries, and false for
+     * a level whose runtime has been retired. Both are transient states around a world's lifecycle
+     * rather than configuration, so a caller that sees false should skip the chunk rather than
+     * report a problem.</p>
+     */
+    public static boolean isAvailable(ServerLevel level) {
+        GenerationSession session = GenerationSession.current();
+        return session != null && session.assets() != null
+                && GenerationSession.runtimeFor(level) != null;
+    }
+}

--- a/src/main/java/dev/krona/urbex/api/UrbexApi.java
+++ b/src/main/java/dev/krona/urbex/api/UrbexApi.java
@@ -73,6 +73,9 @@ public final class UrbexApi {
     /** The bottom of a window a spec does not name: deep enough for anything underground. */
     public static final int DEFAULT_MIN_Y = -60;
 
+    /** {@link SiteSpec.Builder#waterY}'s default: a dry site, with no water table at any height. */
+    public static final int NO_WATER = Integer.MIN_VALUE;
+
     /**
      * The top of a window a spec does not name. Below sea level on purpose - the defaults describe
      * something underground, because a site that wanted the surface would not need this API.

--- a/src/main/java/dev/krona/urbex/api/UrbexApi.java
+++ b/src/main/java/dev/krona/urbex/api/UrbexApi.java
@@ -1,6 +1,7 @@
 package dev.krona.urbex.api;
 
 import dev.krona.urbex.worldgen.GenerationSession;
+import dev.krona.urbex.worldgen.SiteSpawnClaims;
 import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
@@ -105,6 +106,33 @@ public final class UrbexApi {
                     + "UrbexApi.isAvailable(level).");
         }
         return session.sites().site(level, spec, assets);
+    }
+
+    /**
+     * Ask that a world's spawn be placed inside this site.
+     *
+     * <p>Off unless called: a site changes nothing about where a world puts its players until a mod
+     * asks it to. Call this once, at mod initialisation - the world's spawn is chosen while the
+     * level loads, so a claim made later has already missed it. That is why this takes a
+     * {@link SiteSpecFactory} rather than a {@link SiteSpec}: the spec usually needs the world seed,
+     * which does not exist yet at initialisation.</p>
+     *
+     * <p>A claim <strong>outranks the dimension's own spawn settings</strong>. A preset's
+     * {@code spawnCity}, {@code forceSpawnInBuilding} and friends describe where to land in the city
+     * on the surface; a mod that has gone to the trouble of asking for its own site has said
+     * something more specific, and the two cannot both be honoured.</p>
+     *
+     * <p>It also works in a dimension where Urbex's surface generation is switched off entirely,
+     * which the dimension's own spawn rules do not - they need a preset, and such a level has none.
+     * A vanilla overworld whose players start in a bunker is a supported configuration.</p>
+     *
+     * <p>If the search finds nothing - a field that puts no site within 512 chunks of the origin, or
+     * one whose chunks never match {@code where} - the world keeps the spawn it would have had, and
+     * a warning names the site. Two mods claiming one world's spawn is a modpack conflict: the first
+     * registered wins and the clash is logged.</p>
+     */
+    public static void spawnIn(SiteSpecFactory factory, SiteSpawn where) {
+        SiteSpawnClaims.add(factory, where);
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/api/UrbexSite.java
+++ b/src/main/java/dev/krona/urbex/api/UrbexSite.java
@@ -1,0 +1,49 @@
+package dev.krona.urbex.api;
+
+import net.minecraft.server.level.WorldGenRegion;
+import net.minecraft.world.level.chunk.ChunkAccess;
+
+/**
+ * One site, live in one level. Obtained from {@link UrbexApi#site}, cheap to hold, and safe to call
+ * from the worldgen worker pool.
+ *
+ * <p><strong>Experimental.</strong> See {@link UrbexApi} for what that means.</p>
+ */
+public interface UrbexSite {
+
+    /**
+     * Builds this site's content into {@code chunk}, if the site covers it.
+     *
+     * <p>Where {@link SiteField#isSite} answers {@code false} for the chunk, this writes nothing at
+     * all and returns {@code false} - not a street, not ground cover, not a terrain correction. A
+     * caller may therefore call it for every chunk it sees rather than filtering first, though
+     * filtering with the same field is cheaper and is what the example mod does.</p>
+     *
+     * <h2>Where this can be called from</h2>
+     *
+     * <p>Anywhere a {@link WorldGenRegion} exists for the chunk: a {@code Feature}, a
+     * {@code StructurePiece} that has one, or - the case this API was built for - an injection at
+     * the tail of {@code ChunkGenerator.applyCarvers}, which is the stage Urbex itself generates at
+     * and the point where the terrain is a pure function of the seed.</p>
+     *
+     * <p><strong>Not from a {@code WorldCarver}.</strong> A carver is handed a
+     * {@code CarvingContext} and a {@code ChunkAccess} and has no region to write through, so it
+     * cannot call this. Carve in the carver and fill from the carver tail; both read the same
+     * {@link SiteField}, so they agree without having to be ordered.</p>
+     *
+     * <h2>Calling it twice</h2>
+     *
+     * <p>Nothing stops you. Urbex's own two dispatch routes are made mutually exclusive by a mark on
+     * the chunk, because generating twice means the second pass plans against terrain the first has
+     * already rewritten - but that mark is about Urbex's routes, and this method deliberately
+     * neither reads nor sets it. A caller that fills one chunk twice has decided to.</p>
+     *
+     * @return whether anything was generated.
+     * @throws dev.krona.urbex.worldgen.ChunkGenerationFailure if generation failed partway. The
+     *         chunk must not continue through the pipeline; let it propagate.
+     */
+    boolean fill(WorldGenRegion region, ChunkAccess chunk);
+
+    /** The spec this site was built from. */
+    SiteSpec spec();
+}

--- a/src/main/java/dev/krona/urbex/api/package-info.java
+++ b/src/main/java/dev/krona/urbex/api/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Urbex's experimental API for other mods.
+ *
+ * <p><strong>Experimental.</strong> Everything in this package may change shape without a
+ * deprecation cycle, including between patch releases. It is published so the design can be used and
+ * argued with rather than because it is settled. Pin the Urbex version you build against.</p>
+ *
+ * <p>Nothing outside this package is API. Urbex's other packages are internals that move whenever
+ * an issue moves them, and several of them have been rewritten wholesale in a single release.</p>
+ *
+ * <p>Start at {@link dev.krona.urbex.api.UrbexApi}.</p>
+ */
+package dev.krona.urbex.api;

--- a/src/main/java/dev/krona/urbex/config/Preset.java
+++ b/src/main/java/dev/krona/urbex/config/Preset.java
@@ -110,6 +110,7 @@ public class Preset {
     private final boolean MULTI_USE_CORNER;
     private final MultiBuildingStreetConflict MULTI_BUILDING_STREET_CONFLICT;
     private final boolean GENERATE_SPAWNERS;
+    private final float SPAWNER_DENSITY;
     private final int PRIMARY_ROAD_SPACING_X;
     private final int PRIMARY_ROAD_SPACING_Z;
     private final float PRIMARY_ROAD_OPTIONAL_CHANCE;
@@ -241,6 +242,7 @@ public class Preset {
         this.MULTI_USE_CORNER = draft.MULTI_USE_CORNER;
         this.MULTI_BUILDING_STREET_CONFLICT = draft.MULTI_BUILDING_STREET_CONFLICT;
         this.GENERATE_SPAWNERS = draft.GENERATE_SPAWNERS;
+        this.SPAWNER_DENSITY = draft.SPAWNER_DENSITY;
         this.PRIMARY_ROAD_SPACING_X = draft.PRIMARY_ROAD_SPACING_X;
         this.PRIMARY_ROAD_SPACING_Z = draft.PRIMARY_ROAD_SPACING_Z;
         this.PRIMARY_ROAD_OPTIONAL_CHANCE = draft.PRIMARY_ROAD_OPTIONAL_CHANCE;
@@ -378,6 +380,7 @@ public class Preset {
         draft.MULTI_USE_CORNER = MULTI_USE_CORNER;
         draft.MULTI_BUILDING_STREET_CONFLICT = MULTI_BUILDING_STREET_CONFLICT;
         draft.GENERATE_SPAWNERS = GENERATE_SPAWNERS;
+        draft.SPAWNER_DENSITY = SPAWNER_DENSITY;
         draft.PRIMARY_ROAD_SPACING_X = PRIMARY_ROAD_SPACING_X;
         draft.PRIMARY_ROAD_SPACING_Z = PRIMARY_ROAD_SPACING_Z;
         draft.PRIMARY_ROAD_OPTIONAL_CHANCE = PRIMARY_ROAD_OPTIONAL_CHANCE;
@@ -597,7 +600,8 @@ public class Preset {
                 Optional.of(BUILDING_FRONTCHANCE),
                 Optional.of(MULTI_USE_CORNER),
                 Optional.of(MULTI_BUILDING_STREET_CONFLICT),
-                Optional.of(GENERATE_SPAWNERS));
+                Optional.of(GENERATE_SPAWNERS),
+                Optional.of(SPAWNER_DENSITY));
         RoadSettings roads =
                 new RoadSettings(
                 Optional.of(PRIMARY_ROAD_SPACING_X),
@@ -899,6 +903,20 @@ public class Preset {
 
     public boolean generateSpawners() {
         return GENERATE_SPAWNERS;
+    }
+
+    /**
+     * How many of the spawner positions a building's parts mark actually keep a spawner, 0..1.
+     *
+     * <p>The middle setting {@link #generateSpawners} does not have. That one is a switch, which is
+     * the right shape for "this world has no spawners at all" and the wrong one for "fewer" - and
+     * "fewer" is what somewhere a player is meant to survive in usually wants.</p>
+     *
+     * <p>Position-addressed like {@code lootDensity}, so which markers survive is a property of the
+     * seed and the coordinate rather than of the order parts were generated in.</p>
+     */
+    public float spawnerDensity() {
+        return SPAWNER_DENSITY;
     }
 
     public int primaryRoadSpacingX() {

--- a/src/main/java/dev/krona/urbex/config/PresetDraft.java
+++ b/src/main/java/dev/krona/urbex/config/PresetDraft.java
@@ -86,6 +86,7 @@ public final class PresetDraft {
     public float BUILDING_FRONTCHANCE = .2f;
     public boolean MULTI_USE_CORNER = false;
     public MultiBuildingStreetConflict MULTI_BUILDING_STREET_CONFLICT = MultiBuildingStreetConflict.OVERRIDE_MINOR;
+    public float SPAWNER_DENSITY = 1.0f;
     public boolean GENERATE_SPAWNERS = true;
     public int PRIMARY_ROAD_SPACING_X = 8;
     public int PRIMARY_ROAD_SPACING_Z = 8;
@@ -227,6 +228,7 @@ public final class PresetDraft {
         draft.MULTI_USE_CORNER = MULTI_USE_CORNER;
         draft.MULTI_BUILDING_STREET_CONFLICT = MULTI_BUILDING_STREET_CONFLICT;
         draft.GENERATE_SPAWNERS = GENERATE_SPAWNERS;
+        draft.SPAWNER_DENSITY = SPAWNER_DENSITY;
         draft.PRIMARY_ROAD_SPACING_X = PRIMARY_ROAD_SPACING_X;
         draft.PRIMARY_ROAD_SPACING_Z = PRIMARY_ROAD_SPACING_Z;
         draft.PRIMARY_ROAD_OPTIONAL_CHANCE = PRIMARY_ROAD_OPTIONAL_CHANCE;
@@ -536,6 +538,10 @@ public final class PresetDraft {
 
     public boolean generateSpawners() {
         return GENERATE_SPAWNERS;
+    }
+
+    public float spawnerDensity() {
+        return SPAWNER_DENSITY;
     }
 
     public int primaryRoadSpacingX() {

--- a/src/main/java/dev/krona/urbex/gui/settings/Settings.java
+++ b/src/main/java/dev/krona/urbex/gui/settings/Settings.java
@@ -278,6 +278,8 @@ public final class Settings {
         r.section("spawners");
         r.toggle("GENERATE_SPAWNERS", SettingCategory.BUILDINGS,
                 p -> p.generateSpawners(), (p, v) -> p.GENERATE_SPAWNERS = (Boolean) v);
+        r.slider("SPAWNER_DENSITY", SettingCategory.BUILDINGS, 0.0, 1.0, 0.01,
+                p -> (double) p.spawnerDensity(), (p, v) -> p.SPAWNER_DENSITY = ((Double) v).floatValue());
 
         // ==== DAMAGE =========================================================
         // Explosion radii/heights and debris overflow. (Explosion chances live in GENERAL.)

--- a/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
+++ b/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
@@ -5,6 +5,7 @@ import dev.krona.urbex.Urbex;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.PlanningContext;
+import dev.krona.urbex.worldgen.SiteSpawnClaims;
 import dev.krona.urbex.worldgen.lost.*;
 import dev.krona.urbex.worldgen.lost.cityassets.BuildingPart;
 import dev.krona.urbex.worldgen.lost.cityassets.PredefinedCity;
@@ -74,6 +75,13 @@ public class SpawnPlacement {
      */
     public static boolean onCreateSpawnPoint(ServerLevel serverLevel, ServerLevelData settings) {
         LevelAccessor world = serverLevel;
+        // Ahead of everything below, including the "does Urbex generate here at all" check. A site
+        // claim is a mod saying something more specific than a preset's spawn rules can, and it has
+        // to work in a level that has no preset - a vanilla overworld with bunkers under it, which
+        // is exactly the configuration the site API exists to allow.
+        if (applySiteSpawn(serverLevel, settings)) {
+            return true;
+        }
         {
             PlanningContext dimensionInfo = GenerationSession.planningFor(serverLevel);
             if (dimensionInfo == null) {
@@ -163,6 +171,49 @@ public class SpawnPlacement {
                 return true;
             }
         }
+        return false;
+    }
+
+    /**
+     * Places the spawn inside a claimed site, if a mod asked for one and the search found somewhere.
+     *
+     * <p>The anchor a claim yields is the plan's ground floor at a chunk's centre - a Y that is
+     * correct about the layout and says nothing about what block is actually there. So this walks up
+     * from it looking for somewhere to stand, exactly as {@code findSafeSpawnPoint} does for the
+     * dimension's own rules, and reading those blocks is what forces the one chunk to generate.</p>
+     *
+     * <p>Eight blocks of headroom searched, not the whole column: the floor of a street is where the
+     * plan says it is, and a position further up than that is inside whatever was built above, not a
+     * better spot on the same street.</p>
+     */
+    private static boolean applySiteSpawn(ServerLevel serverLevel, ServerLevelData settings) {
+        if (SiteSpawnClaims.isEmpty()) {
+            return false;
+        }
+        SiteSpawnClaims.Anchor anchor = SiteSpawnClaims.findAnchor(serverLevel);
+        if (anchor == null) {
+            return false;
+        }
+        for (int dy = 0; dy <= 8; dy++) {
+            BlockPos candidate = anchor.pos().above(dy);
+            if (!isValidStandingPosition(serverLevel, candidate)) {
+                continue;
+            }
+            BlockPos spawn = candidate.above();
+            LevelData.RespawnData data = new LevelData.RespawnData(
+                    new GlobalPos(serverLevel.dimension(), spawn), 0.0f, 0.0f);
+            serverLevel.setRespawnData(data);
+            settings.setSpawn(data);
+            // Stored as well as set, for the single-player case this map exists for: level.dat may
+            // not exist yet, so the spawn is re-applied when the first player joins.
+            spawnPositions.put(serverLevel.dimension(), spawn);
+            Urbex.getLogger().info("Urbex site '{}' placed this world's spawn at {}, {}, {}.",
+                    anchor.site(), spawn.getX(), spawn.getY(), spawn.getZ());
+            return true;
+        }
+        Urbex.getLogger().warn("Urbex site '{}' offered a spawn at {}, {}, {}, but there was nowhere "
+                        + "to stand within eight blocks of it. The world keeps its own spawn.",
+                anchor.site(), anchor.pos().getX(), anchor.pos().getY(), anchor.pos().getZ());
         return false;
     }
 

--- a/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
+++ b/src/main/java/dev/krona/urbex/setup/SpawnPlacement.java
@@ -41,7 +41,27 @@ import java.util.function.Predicate;
  */
 public class SpawnPlacement {
 
-    private static final Map<ResourceKey<Level>, BlockPos> spawnPositions = new HashMap<>();
+    private static final Map<ResourceKey<Level>, Pending> spawnPositions = new HashMap<>();
+
+    /**
+     * A spawn this class chose, waiting for the first player to arrive.
+     *
+     * @param pos    where the player should end up
+     * @param forced whether to put them there even if the world spawn already says so.
+     *               <p>
+     *               The difference is vanilla's {@code fudgeSpawnLocation}, which does not use the
+     *               world spawn as given: with sky light it searches around it on the
+     *               {@code MOTION_BLOCKING} heightmap for somewhere to stand. For a city on the
+     *               surface that lands on the same street and nobody notices. For a spawn forty
+     *               blocks underground it finds the roof of the world instead, so the world spawn is
+     *               correct, the log says so, and the player is standing in daylight.
+     *               <p>
+     *               So a site's spawn is forced: the fudge is precisely what has to be undone. The
+     *               unforced case is the older one this map was built for - a single-player world
+     *               whose {@code level.dat} did not exist when the spawn was chosen, where the world
+     *               spawn is wrong and correcting it is the whole job.
+     */
+    private record Pending(BlockPos pos, boolean forced) {}
 
     static void reset() {
         spawnPositions.clear();
@@ -51,22 +71,33 @@ public class SpawnPlacement {
         ServerLevel level = serverPlayer.level();
         ResourceKey<Level> dimKey = level.dimension();
 
-        if (spawnPositions.containsKey(dimKey)) {
-            BlockPos correctPos = spawnPositions.get(dimKey);
-            LevelData.RespawnData rd = level.getRespawnData();
-            BlockPos currentWorldSpawn = rd.pos();
+        Pending pending = spawnPositions.get(dimKey);
+        if (pending == null) {
+            return;
+        }
+        BlockPos correctPos = pending.pos();
+        LevelData.RespawnData rd = level.getRespawnData();
+        BlockPos currentWorldSpawn = rd.pos();
 
-            if (!currentWorldSpawn.equals(correctPos)) {
-                LevelData.RespawnData newd = new LevelData.RespawnData(new GlobalPos(level.dimension(), correctPos), 0.0f, 0.0f);
-                level.setRespawnData(newd);
-
-                if (level.getLevelData() instanceof ServerLevelData data) {
-                    data.setSpawn(newd);
-                }
-                serverPlayer.teleportTo(level, correctPos.getX() + 0.5, correctPos.getY(), correctPos.getZ() + 0.5, Collections.emptySet(), serverPlayer.getYRot(), serverPlayer.getXRot(), true);
-                spawnPositions.remove(dimKey);
+        if (!pending.forced() && currentWorldSpawn.equals(correctPos)) {
+            return;
+        }
+        LevelData.RespawnData newd = new LevelData.RespawnData(new GlobalPos(level.dimension(), correctPos), 0.0f, 0.0f);
+        if (!currentWorldSpawn.equals(correctPos)) {
+            level.setRespawnData(newd);
+            if (level.getLevelData() instanceof ServerLevelData data) {
+                data.setSpawn(newd);
             }
         }
+        serverPlayer.teleportTo(level, correctPos.getX() + 0.5, correctPos.getY(), correctPos.getZ() + 0.5, Collections.emptySet(), serverPlayer.getYRot(), serverPlayer.getXRot(), true);
+        if (pending.forced()) {
+            // Their personal respawn point too, as though they had slept there. Without it the first
+            // death undoes the whole thing: respawning goes back through the world spawn and the
+            // same fudge, and a player who woke up sealed underground finds themselves on the
+            // surface for good the first time something kills them.
+            serverPlayer.setRespawnPosition(new ServerPlayer.RespawnConfig(newd, true), false);
+        }
+        spawnPositions.remove(dimKey);
     }
 
     /**
@@ -159,7 +190,7 @@ public class SpawnPlacement {
                     LevelData.RespawnData data = new LevelData.RespawnData(new GlobalPos(serverLevel.dimension(), pos), 0.0f, 0.0f);
                     serverLevel.setRespawnData(data);
                     settings.setSpawn(data);
-                    spawnPositions.put(serverLevel.dimension(), pos);
+                    spawnPositions.put(serverLevel.dimension(), new Pending(pos, false));
                     return true;
                 }
             } else {
@@ -167,7 +198,7 @@ public class SpawnPlacement {
                 LevelData.RespawnData data = new LevelData.RespawnData(new GlobalPos(serverLevel.dimension(), pos), 0.0f, 0.0f);
                 serverLevel.setRespawnData(data);
                 settings.setSpawn(data);
-                spawnPositions.put(serverLevel.dimension(), pos);
+                spawnPositions.put(serverLevel.dimension(), new Pending(pos, false));
                 return true;
             }
         }
@@ -204,9 +235,9 @@ public class SpawnPlacement {
                     new GlobalPos(serverLevel.dimension(), spawn), 0.0f, 0.0f);
             serverLevel.setRespawnData(data);
             settings.setSpawn(data);
-            // Stored as well as set, for the single-player case this map exists for: level.dat may
-            // not exist yet, so the spawn is re-applied when the first player joins.
-            spawnPositions.put(serverLevel.dimension(), spawn);
+            // Forced, because the player still has to be moved even though the world spawn is now
+            // right: vanilla fudges the arrival position onto the surface heightmap. See Pending.
+            spawnPositions.put(serverLevel.dimension(), new Pending(spawn, true));
             Urbex.getLogger().info("Urbex site '{}' placed this world's spawn at {}, {}, {}.",
                     anchor.site(), spawn.getX(), spawn.getY(), spawn.getZ());
             return true;

--- a/src/main/java/dev/krona/urbex/varia/DensitySelector.java
+++ b/src/main/java/dev/krona/urbex/varia/DensitySelector.java
@@ -14,6 +14,10 @@ public final class DensitySelector {
         return admit(worldSeed, pos, density, Rng.Purpose.LOOT_DENSITY);
     }
 
+    public static boolean spawner(long worldSeed, BlockPos pos, float density) {
+        return admit(worldSeed, pos, density, Rng.Purpose.SPAWNER_DENSITY);
+    }
+
     private static boolean admit(long worldSeed, BlockPos pos, float density, Rng.Purpose purpose) {
         if (density <= 0.0f) {
             return false;

--- a/src/main/java/dev/krona/urbex/varia/Rng.java
+++ b/src/main/java/dev/krona/urbex/varia/Rng.java
@@ -88,7 +88,14 @@ public final class Rng {
         // Only reached when the mix has more than one entry: a world created with a single style
         // never draws here at all, which is what keeps its generation identical to what it was
         // before mixing existed.
-        WORLD_STYLE
+        WORLD_STYLE,
+        // Whether a marked spawner position keeps its spawner.
+        //
+        // Last, and that is the whole of why it is here rather than beside LOOT_DENSITY where it
+        // belongs by subject. A purpose's ordinal feeds the hash, so a constant added anywhere but
+        // the end reseeds every stream below it and rewrites every world that ever generated. Added
+        // here, nothing that existed before it moves.
+        SPAWNER_DENSITY
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkBuffer.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkBuffer.java
@@ -67,6 +67,20 @@ final class ChunkBuffer {
     private final int originX;
     private final int originZ;
     /**
+     * The lowest and highest Y this buffer will accept a block at, inclusive.
+     *
+     * <p>Ordinarily the level's own bounds, in which case these reject nothing. A
+     * {@link SiteBinding site} narrows them to its window, and this is where that window stops being
+     * a convention and becomes a guarantee: every driver write in the mod passes through
+     * {@link #set}, {@link #fill} or {@link #fillWhere}, so a pass that believes it may build to the
+     * sky writes nothing above the window whatever it believes. The alternative - clamping at each
+     * of the eighteen generation passes - is a rule someone has to keep, and the nineteenth pass
+     * breaks it silently, in a world nobody is looking at, hundreds of blocks from the caller who
+     * asked for a bunker.</p>
+     */
+    private final int writeMinY;
+    private final int writeMaxY;
+    /**
      * One slot per section, filled on first write to that section.
      *
      * <p>Lazily, and that is the point: a chunk touches a handful of the level's 24 sections, but
@@ -80,14 +94,35 @@ final class ChunkBuffer {
     /** Reused by {@link #fillWhere}'s fallback read; created on first use, never escapes. */
     private BlockPos.MutableBlockPos scratch;
 
+    /** A buffer that will write anywhere in the level. */
     ChunkBuffer(WriteLog log, WorldView world, int minY, int maxY, int originX, int originZ) {
+        this(log, world, minY, maxY, originX, originZ, minY, maxY - 1);
+    }
+
+    /**
+     * @param minY      the level's lowest block Y, which sizes the section table
+     * @param maxY      one past the level's highest block Y, likewise
+     * @param writeMinY the lowest Y this buffer accepts a write at, inclusive
+     * @param writeMaxY the highest Y this buffer accepts a write at, inclusive
+     */
+    ChunkBuffer(WriteLog log, WorldView world, int minY, int maxY, int originX, int originZ,
+                int writeMinY, int writeMaxY) {
         this.log = log;
         this.world = world;
         this.minY = minY;
         this.sections = (maxY - minY) / SECTION_HEIGHT;
         this.originX = originX;
         this.originZ = originZ;
+        // Intersected with the level rather than trusted: a caller may name a window wider than the
+        // dimension, and the section table is sized for the dimension.
+        this.writeMinY = Math.max(writeMinY, minY);
+        this.writeMaxY = Math.min(writeMaxY, maxY - 1);
         this.cache = new Section[sections];
+    }
+
+    /** Whether this buffer will accept a write at {@code y}. */
+    private boolean inWindow(int y) {
+        return y >= writeMinY && y <= writeMaxY;
     }
 
     /** The section holding {@code y}, created if this is the first write to it. */
@@ -110,7 +145,7 @@ final class ChunkBuffer {
      * call site is what stopped bulk fills placing literal {@code structure_void} blocks.</p>
      */
     void set(int x, int y, int z, BlockState state) {
-        if (isTransparent(state)) {
+        if (isTransparent(state) || !inWindow(y)) {
             return;
         }
         int idx = index(x, y, z);
@@ -127,7 +162,9 @@ final class ChunkBuffer {
         if (isTransparent(state)) {
             return;
         }
-        for (int y = y1; y <= y2; y++) {
+        // Clamped once rather than tested per block: a run reaching from a cellar floor to a roof
+        // crosses the window boundary at most twice, and the loop is hot.
+        for (int y = Math.max(y1, writeMinY), top = Math.min(y2, writeMaxY); y <= top; y++) {
             int idx = index(x, y, z);
             Section section = sectionFor(y);
             if (section.blocks[idx] != state) {
@@ -149,7 +186,7 @@ final class ChunkBuffer {
         if (isTransparent(state)) {
             return;
         }
-        for (int y = y1; y <= y2; y++) {
+        for (int y = Math.max(y1, writeMinY), top = Math.min(y2, writeMaxY); y <= top; y++) {
             int idx = index(x, y, z);
             Section section = sectionFor(y);
             BlockState existing = section.blocks[idx];
@@ -202,6 +239,15 @@ final class ChunkBuffer {
      * chunk - 4096 slots of terrain rewritten with the values they already had (issue #52).</p>
      */
     void remember(int x, int y, int z, BlockState state) {
+        // Windowed too, though a remembered block is a read rather than a write. A section that
+        // straddles the boundary is flushed in full once anything inside the window writes to it,
+        // and every non-null slot in a flushed section is copied out - so an out-of-window slot
+        // holding a remembered value would be written back to the world. Harmless today, because
+        // what it writes back is what the world already holds; not something the window's guarantee
+        // should rest on. Dropping it costs a re-read at most.
+        if (!inWindow(y)) {
+            return;
+        }
         sectionFor(y).blocks[index(x, y, z)] = state;
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkDriver.java
@@ -232,14 +232,27 @@ public class ChunkDriver {
     private int cx;
     private int cz;
 
+    /** Drives {@code primer} with no vertical restriction beyond the level's own. */
     public void setPrimer(LevelAccessor region, ChunkAccess primer) {
+        setPrimer(region, primer, Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Drives {@code primer}, refusing every write outside {@code [writeMinY, writeMaxY]}.
+     *
+     * <p>The window is intersected with the level's bounds, so the two unbounded sentinels above
+     * mean "the whole level" rather than an arithmetic accident. See {@link ChunkBuffer} for why
+     * the refusal lives there and not at the passes that write.</p>
+     */
+    public void setPrimer(LevelAccessor region, ChunkAccess primer, int writeMinY, int writeMaxY) {
         this.region = region;
         this.seed = region instanceof WorldGenLevel level ? level.getSeed() : 0L;
         this.primer = primer;
         if (primer != null) {
             buffer = new ChunkBuffer(this::wrote, region::getBlockState,
                     region.getMinY(), region.getMaxY() + 1,
-                    primer.getPos().x() << 4, primer.getPos().z() << 4);
+                    primer.getPos().x() << 4, primer.getPos().z() << 4,
+                    writeMinY, writeMaxY);
             this.cx = primer.getPos().x();
             this.cz = primer.getPos().z();
             shaper = new BlockShaper(chunkView, region, seed);

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
@@ -66,16 +66,8 @@ public final class ChunkGenContext {
     /** The world seed, for the position-addressed picks that resolve palette characters. */
     public final long seed;
 
-    /**
-     * The lowest and highest Y this generation may write at, inclusive.
-     *
-     * <p>The level's own bounds for an ordinary chunk, and a {@link SiteBinding site}'s window when
-     * a caller named one. {@link ChunkBuffer} is what enforces this for driver writes; these two
-     * fields exist because the three deferred queues below <em>bypass</em> the driver - they hand a
-     * callback to the world, later - so the buffer never sees them.</p>
-     */
-    private final int writeMinY;
-    private final int writeMaxY;
+    /** The band of Y this generation may write in; see {@link WriteWindow}. */
+    private final WriteWindow window;
 
     public ChunkGenContext(WorldGenRegion region, ChunkAccess chunk, ChunkCoord coord,
                            PlanningContext provider, Preset profile, ChunkPlan info,
@@ -90,31 +82,16 @@ public final class ChunkGenContext {
         this.info = info;
         this.palette = info.getCompiledPalette();
         this.street = info.getCityStyle().getStreetBlock();
-        SiteBinding site = provider.site();
-        this.writeMinY = site != null ? Math.max(site.minY(), region.getMinY()) : region.getMinY();
-        this.writeMaxY = site != null ? Math.min(site.maxY(), region.getMaxY()) : region.getMaxY();
+        this.window = WriteWindow.of(provider.site(), region.getMinY(), region.getMaxY());
         this.driver = new ChunkDriver();
-        this.driver.setPrimer(region, chunk, writeMinY, writeMaxY);
+        this.driver.setPrimer(region, chunk, window.minY(), window.maxY());
         this.buffers = new NoiseBuffers();
         this.seed = provider.seed();
         this.lightTodo = new LightTodoQueue(coord.chunkX(), coord.chunkZ());
     }
 
-    /**
-     * Whether a deferred write anchored at {@code pos} is inside this generation's window.
-     *
-     * <p>Exact for the block a todo names and approximate for anything the callback touches around
-     * it - the upper half of a door, the block a light is attached to. The queues hold opaque
-     * callbacks, so the anchor is the only thing there is to test. What this buys is that a site
-     * cannot place a chest, a spawner or a light one block outside its window, which is the whole of
-     * what these queues are used for; what it does not buy is a proof about the block beside it.</p>
-     */
-    private boolean inWindow(BlockPos pos) {
-        return pos.getY() >= writeMinY && pos.getY() <= writeMaxY;
-    }
-
     void addLightTodo(BlockPos pos, @Nullable LightPool pool) {
-        if (!inWindow(pos)) {
+        if (!window.contains(pos)) {
             return;
         }
         lightTodo.add(pos, pool);
@@ -129,7 +106,7 @@ public final class ChunkGenContext {
      * todo at the same position replaces the first.
      */
     void addPostTodo(BlockPos pos, Consumer<WorldGenLevel> todo) {
-        if (!inWindow(pos)) {
+        if (!window.contains(pos)) {
             return;
         }
         postTodo.add(pos, todo);
@@ -148,7 +125,7 @@ public final class ChunkGenContext {
      * be run against the next world with the same dimension id.
      */
     public void addLevelTask(BlockPos pos, LevelTaskQueue.Task task) {
-        if (!inWindow(pos)) {
+        if (!window.contains(pos)) {
             return;
         }
         levelTasks.add(pos, task);

--- a/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/ChunkGenContext.java
@@ -66,6 +66,17 @@ public final class ChunkGenContext {
     /** The world seed, for the position-addressed picks that resolve palette characters. */
     public final long seed;
 
+    /**
+     * The lowest and highest Y this generation may write at, inclusive.
+     *
+     * <p>The level's own bounds for an ordinary chunk, and a {@link SiteBinding site}'s window when
+     * a caller named one. {@link ChunkBuffer} is what enforces this for driver writes; these two
+     * fields exist because the three deferred queues below <em>bypass</em> the driver - they hand a
+     * callback to the world, later - so the buffer never sees them.</p>
+     */
+    private final int writeMinY;
+    private final int writeMaxY;
+
     public ChunkGenContext(WorldGenRegion region, ChunkAccess chunk, ChunkCoord coord,
                            PlanningContext provider, Preset profile, ChunkPlan info,
                            LevelTaskQueue levelTasks, TagSnapshot tags) {
@@ -79,14 +90,33 @@ public final class ChunkGenContext {
         this.info = info;
         this.palette = info.getCompiledPalette();
         this.street = info.getCityStyle().getStreetBlock();
+        SiteBinding site = provider.site();
+        this.writeMinY = site != null ? Math.max(site.minY(), region.getMinY()) : region.getMinY();
+        this.writeMaxY = site != null ? Math.min(site.maxY(), region.getMaxY()) : region.getMaxY();
         this.driver = new ChunkDriver();
-        this.driver.setPrimer(region, chunk);
+        this.driver.setPrimer(region, chunk, writeMinY, writeMaxY);
         this.buffers = new NoiseBuffers();
         this.seed = provider.seed();
         this.lightTodo = new LightTodoQueue(coord.chunkX(), coord.chunkZ());
     }
 
+    /**
+     * Whether a deferred write anchored at {@code pos} is inside this generation's window.
+     *
+     * <p>Exact for the block a todo names and approximate for anything the callback touches around
+     * it - the upper half of a door, the block a light is attached to. The queues hold opaque
+     * callbacks, so the anchor is the only thing there is to test. What this buys is that a site
+     * cannot place a chest, a spawner or a light one block outside its window, which is the whole of
+     * what these queues are used for; what it does not buy is a proof about the block beside it.</p>
+     */
+    private boolean inWindow(BlockPos pos) {
+        return pos.getY() >= writeMinY && pos.getY() <= writeMaxY;
+    }
+
     void addLightTodo(BlockPos pos, @Nullable LightPool pool) {
+        if (!inWindow(pos)) {
+            return;
+        }
         lightTodo.add(pos, pool);
     }
 
@@ -99,6 +129,9 @@ public final class ChunkGenContext {
      * todo at the same position replaces the first.
      */
     void addPostTodo(BlockPos pos, Consumer<WorldGenLevel> todo) {
+        if (!inWindow(pos)) {
+            return;
+        }
         postTodo.add(pos, todo);
     }
 
@@ -115,6 +148,9 @@ public final class ChunkGenContext {
      * be run against the next world with the same dimension id.
      */
     public void addLevelTask(BlockPos pos, LevelTaskQueue.Task task) {
+        if (!inWindow(pos)) {
+            return;
+        }
         levelTasks.add(pos, task);
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -201,6 +201,25 @@ public class CityGenerator {
 
         boolean doCity = info.isCity;
 
+        if (!doCity && provider.site() != null) {
+            // A site is sparse, and this is what makes it so. Where the caller's field says there is
+            // nothing, this chunk is left exactly as it was found - no ground cover, no terrain
+            // correction, no scattered building, no bridge scan, no rails, no debris. The driver has
+            // nothing buffered and is never flushed.
+            //
+            // The alternative is what a dimension does: every chunk that is not city is still a
+            // chunk Urbex renders, because outside a city is somewhere it has an opinion about. A
+            // site has no opinion about outside. A bunker layer that ran doNormalChunk would repaint
+            // the world it lives inside - a mod asking for a cavern filled would find its surface
+            // grass replaced, three hundred blocks up, by a pass reading a heightmap that says the
+            // ground is in the cavern.
+            //
+            // Ahead of the structure probe below, which reads the region: there is nothing here for
+            // a village to be avoided by.
+            GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.PROBE, phaseNanos, phaseAlloc);
+            return;
+        }
+
         // Check if there is no village or other structure here. We don't do this for multibuildings because otherwise part of the multibuilding might be cut off
         AvoidChunk avoidChunk = AvoidChunk.NO;
         if (!info.multiBuildingPos.isMulti()) {

--- a/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
+++ b/src/main/java/dev/krona/urbex/worldgen/CityGenerator.java
@@ -201,28 +201,35 @@ public class CityGenerator {
 
         boolean doCity = info.isCity;
 
-        if (!doCity && provider.site() != null) {
-            // A site is sparse, and this is what makes it so. Where the caller's field says there is
-            // nothing, this chunk is left exactly as it was found - no ground cover, no terrain
+        // A site's field settles this on its own, and neither probe below applies to one. Each of the
+        // three guards says why where it stands.
+        boolean isSite = provider.site() != null;
+
+        if (isSite && !doCity) {
+            // A site is sparse, and this is what makes it so: where the caller's field says there is
+            // nothing, the chunk is left exactly as it was found - no ground cover, no terrain
             // correction, no scattered building, no bridge scan, no rails, no debris. The driver has
             // nothing buffered and is never flushed.
             //
-            // The alternative is what a dimension does: every chunk that is not city is still a
-            // chunk Urbex renders, because outside a city is somewhere it has an opinion about. A
-            // site has no opinion about outside. A bunker layer that ran doNormalChunk would repaint
-            // the world it lives inside - a mod asking for a cavern filled would find its surface
-            // grass replaced, three hundred blocks up, by a pass reading a heightmap that says the
-            // ground is in the cavern.
-            //
-            // Ahead of the structure probe below, which reads the region: there is nothing here for
-            // a village to be avoided by.
+            // That is the difference between a site and a dimension. Outside a dimension's cities is
+            // still somewhere Urbex has an opinion about, so a non-city chunk is rendered rather
+            // than skipped; outside a site is somebody else's world. A bunker layer that ran
+            // doNormalChunk would repaint it - a mod asking for one cavern filled would find its
+            // surface grass replaced, three hundred blocks up, by a pass reading a heightmap that
+            // says the ground is in the cavern.
             GenerationMetrics.phase(ordinal, GenerationMetrics.Phase.PROBE, phaseNanos, phaseAlloc);
             return;
         }
 
         // Check if there is no village or other structure here. We don't do this for multibuildings because otherwise part of the multibuilding might be cut off
+        //
+        // Nor for a site. Avoidance exists to stop Urbex's own city noise bulldozing a village it
+        // happened to roll on top of; a caller naming a place has already decided. A site suppressed
+        // by a structure forty blocks overhead is a bunker missing from the middle of itself, with a
+        // street running into the gap from either side - and the plan its neighbours built still says
+        // the middle is there. It saves a region read per chunk, too.
         AvoidChunk avoidChunk = AvoidChunk.NO;
-        if (!info.multiBuildingPos.isMulti()) {
+        if (!isSite && !info.multiBuildingPos.isMulti()) {
             avoidChunk = hasBlacklistedStructure(region, chunkX, chunkZ);
             if (avoidChunk != AvoidChunk.NO) {
                 // Only this chunk's rendering. The cached ChunkPlan and ChunkCandidate used
@@ -243,7 +250,11 @@ public class CityGenerator {
         // If this chunk has a building or street but we're in a floating profile and
         // we happen to have a void chunk we detect that here and go back to normal chunk generation
         // anyway
-        if (doCity && provider.preset().cityAvoidVoid() && provider.preset().isFloating()) {
+        //
+        // Not for a site: this asks whether a floating dimension has an island at this coordinate,
+        // and a site is not on the islands - CityField.isCityRaw answers for one without consulting
+        // them at all, so asking here would contradict the verdict that got us this far.
+        if (!isSite && doCity && provider.preset().cityAvoidVoid() && provider.preset().isFloating()) {
             boolean v = isVoid(ctx, 2, 2) || isVoid(ctx, 2, 14) || isVoid(ctx, 14, 2) || isVoid(ctx, 14, 14) || isVoid(ctx, 8, 8);
             doCity = !v;
         }

--- a/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
+++ b/src/main/java/dev/krona/urbex/worldgen/GenerationSession.java
@@ -68,6 +68,12 @@ public final class GenerationSession {
     private final Object owner;
     private final RuntimeRepository<ServerLevel, DimensionRuntime> dimensions = new RuntimeRepository<>();
     /**
+     * The sites other mods have asked for. Owned here so they die with the world, for the same
+     * reason every runtime does: a site holds a seed, compiled assets and a set of caches, and a
+     * second world in the same JVM must not inherit the first world's.
+     */
+    private final SiteRuntimes sites = new SiteRuntimes();
+    /**
      * Everything this world compiled, or null until the first level load compiles it. One field
      * rather than two, because the two halves are captured together and neither is usable without
      * the other: the tag epoch is expanded <em>from</em> the assets, so a reader that could see one
@@ -240,8 +246,14 @@ public final class GenerationSession {
         return world == null ? null : world.tags();
     }
 
+    /** The sites another mod has asked for in this world; see {@link SiteRuntimes}. */
+    public SiteRuntimes sites() {
+        return sites;
+    }
+
     /** Retires a level's runtime. Chunks already generating keep the runtime they captured. */
     public void unload(ServerLevel level) {
+        sites.unload(level);
         DimensionRuntime retired = dimensions.retire(level);
         if (retired != null) {
             reportUnfinishedWork(level, retired);

--- a/src/main/java/dev/krona/urbex/worldgen/Parts.java
+++ b/src/main/java/dev/krona/urbex/worldgen/Parts.java
@@ -388,7 +388,7 @@ public class Parts {
     public static Identifier getRandomSpawnerMob(Level world, RandomSource random, PlanningContext diminfo, ChunkPlan info, ChunkPlan.ConditionTodo todo, BlockPos pos) {
         String condition = todo.getCondition();
         Condition cnd = diminfo.assets().conditions().getOrThrow(condition);
-        int level = (pos.getY() - diminfo.preset().groundLevel()) / CityGenerator.FLOORHEIGHT;
+        int level = (pos.getY() - diminfo.baseGroundLevel()) / CityGenerator.FLOORHEIGHT;
         int floor = (pos.getY() - info.getCityGroundLevel()) / CityGenerator.FLOORHEIGHT;
         String belowFloor = ConditionContext.NO_PART;
         ConditionContext conditionContext = new ConditionContext(level, floor, info.cellars, info.getNumFloors(),
@@ -423,7 +423,7 @@ public class Parts {
         if (tileentity instanceof RandomizableContainerBlockEntity rcbe) {
             if (todo != null) {
                 String lootTable = todo.getCondition();
-                int level = (pos.getY() - diminfo.preset().groundLevel()) / CityGenerator.FLOORHEIGHT;
+                int level = (pos.getY() - diminfo.baseGroundLevel()) / CityGenerator.FLOORHEIGHT;
                 int floor = (pos.getY() - info.getCityGroundLevel()) / CityGenerator.FLOORHEIGHT;
                 ConditionContext conditionContext = new ConditionContext(level, floor, info.cellars, info.getNumFloors(),
                         todo.getPart(), ConditionContext.NO_PART, todo.getBuilding(), info.coord) {

--- a/src/main/java/dev/krona/urbex/worldgen/Parts.java
+++ b/src/main/java/dev/krona/urbex/worldgen/Parts.java
@@ -261,9 +261,11 @@ public class Parts {
     }
 
     private static BlockState handleSpawner(ChunkGenContext ctx, CityGenerator feature, ChunkPlan info, IBuildingPart part, int oy, WorldGenLevel world, int rx, int rz, int y, BlockState b, Palette.Info inf) {
-        if (SpecialMarkerPolicy.generateSpawner(info.profile)) {
+        // Hoisted above the admission check, which is now addressed by position - the marker's
+        // world coordinate is what decides whether this one keeps its spawner.
+        BlockPos pos = info.getRelativePos(rx, oy + y, rz);
+        if (SpecialMarkerPolicy.generateSpawner(ctx.seed, pos, info.profile)) {
             String mobid = inf.mobId();
-            BlockPos pos = info.getRelativePos(rx, oy + y, rz);
             CompoundTag tag = new CompoundTag();
             tag.putInt("x", pos.getX());
             tag.putInt("y", pos.getY());

--- a/src/main/java/dev/krona/urbex/worldgen/PlanningContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/PlanningContext.java
@@ -106,4 +106,16 @@ public record PlanningContext(
     public ChunkCoord coord(int chunkX, int chunkZ) {
         return new ChunkCoord(dimension, chunkX, chunkZ);
     }
+
+    /**
+     * The Y that {@code cityLevel} 0 sits at: the preset's ground level, or a site's window bottom.
+     * <p>
+     * What a condition means by "level" - the number a loot table or a spawner rule is matched
+     * against. Asking the preset directly, as this used to, gives a site the ground level of a
+     * dimension it is nowhere near: {@code urbex:cavern} says 40, so a bunker at -36 reported level
+     * -12 and matched whatever a datapack wrote for the bottom of the world.
+     */
+    public int baseGroundLevel() {
+        return site != null ? site.minY() : preset.groundLevel();
+    }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/PlanningContext.java
+++ b/src/main/java/dev/krona/urbex/worldgen/PlanningContext.java
@@ -40,8 +40,12 @@ import javax.annotation.Nullable;
  * @param worldStyles which world style governs where, when the world mixes several.
  * @param roadField   where the roads are: a pure function of seed, dimension id and grid settings.
  * @param caches      the per-dimension memo tables. Every entry is a pure function of the above.
- * @param shape       how deep and how high the dimension goes, and where its water sits.
+ * @param shape       how deep and how high the dimension goes, and where its water sits. Clamped to
+ *                    the window when this context belongs to a {@code site}.
  * @param terrain     the ground height and the biome, sampled without reading a block.
+ * @param site        null for a level planning for itself, which is every chunk Urbex generates on
+ *                    its own behalf. Non-null when another mod asked for this patch of city and
+ *                    answers three of planning's inputs itself; see {@link SiteBinding}.
  */
 public record PlanningContext(
         long seed,
@@ -52,7 +56,21 @@ public record PlanningContext(
         RoadField roadField,
         DimensionCaches caches,
         LevelShape shape,
-        TerrainSampler terrain) {
+        TerrainSampler terrain,
+        @Nullable SiteBinding site) {
+
+    /**
+     * A context for a level planning on its own behalf.
+     *
+     * <p>Every caller that existed before sites did builds one of these, and none of them had to
+     * change: a site is an addition to what a planning context can be, not a new argument every
+     * composition root has to have an opinion about.</p>
+     */
+    public PlanningContext(long seed, ResourceKey<Level> dimension, Preset preset,
+                           AssetSnapshot assets, WorldStyleField worldStyles, RoadField roadField,
+                           DimensionCaches caches, LevelShape shape, TerrainSampler terrain) {
+        this(seed, dimension, preset, assets, worldStyles, roadField, caches, shape, terrain, null);
+    }
 
     /**
      * The heightmap at {@code coord}. Shared and not to be written to - see

--- a/src/main/java/dev/krona/urbex/worldgen/SiteBinding.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SiteBinding.java
@@ -1,0 +1,60 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.api.SiteField;
+import net.minecraft.resources.Identifier;
+
+/**
+ * What makes a {@link PlanningContext} a caller's rather than the level's.
+ *
+ * <p>A <em>site</em> is a patch of Urbex city that another mod asked for: its own preset, its own
+ * world style, its own ground level and a vertical window it may not leave. The motivating case is
+ * a bunker in a cave - the mod carves the cavity, then asks Urbex to fill it, in a different world
+ * style from the ruins overhead.</p>
+ *
+ * <p>Everything about a site that planning needs is here, and it is deliberately small. A site is
+ * not a new kind of generation: it is the ordinary planning path with three of its inputs answered
+ * by the caller instead of by the dimension.</p>
+ *
+ * <ul>
+ *   <li><em>Where the city is</em> - {@link CityField#isCityRaw} asks the field instead of the
+ *       perlin city rarity map.</li>
+ *   <li><em>How high it sits</em> - {@code ChunkPlan}'s ground level comes from the field instead of
+ *       the preset's fixed one, and there are no terrain height bands underground, so
+ *       {@code cityLevel} is always 0.</li>
+ *   <li><em>How far it may reach</em> - {@link #minY} and {@link #maxY}, enforced twice: the
+ *       {@link LevelShape} a site plans against is clamped to them, so buildings are planned to fit
+ *       rather than cut off; and {@link ChunkBuffer} refuses every write outside them, so what is
+ *       planned is not what the guarantee rests on.</li>
+ * </ul>
+ *
+ * <p>A null binding on a {@code PlanningContext} is a level generating for itself, which is every
+ * chunk Urbex has ever generated. Each of the six places that consult this is a guarded branch whose
+ * null side is exactly what the code did before sites existed.</p>
+ *
+ * @param id    the site's identity, as the caller named it. Diagnostics only - what separates one
+ *              site's cached plans from another's is that they hold different
+ *              {@link DimensionCaches}, not this.
+ * @param field where the caller's sites are. Pure, total and thread-safe; see {@link SiteField}.
+ * @param minY  the lowest block Y this site may write at, inclusive.
+ * @param maxY  the highest block Y this site may write at, inclusive.
+ */
+public record SiteBinding(Identifier id, SiteField field, int minY, int maxY) {
+
+    public SiteBinding {
+        if (maxY < minY) {
+            throw new IllegalArgumentException(
+                    "Urbex site '" + id + "' has a window whose top (" + maxY
+                            + ") is below its bottom (" + minY + ")");
+        }
+    }
+
+    /** The site's ground level at a coordinate; see {@link SiteField#groundY}. */
+    public int groundY(int chunkX, int chunkZ) {
+        return field.groundY(chunkX, chunkZ);
+    }
+
+    /** Whether the site covers a coordinate; see {@link SiteField#isSite}. */
+    public boolean covers(int chunkX, int chunkZ) {
+        return field.isSite(chunkX, chunkZ);
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/SiteBinding.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SiteBinding.java
@@ -48,9 +48,39 @@ public record SiteBinding(Identifier id, SiteField field, int minY, int maxY) {
         }
     }
 
-    /** The site's ground level at a coordinate; see {@link SiteField#groundY}. */
-    public int groundY(int chunkX, int chunkZ) {
-        return field.groundY(chunkX, chunkZ);
+    /**
+     * Which six-block band above {@link #minY} this chunk's ground sits in.
+     *
+     * <p><strong>This, and not the ground level, is how a site's height reaches planning.</strong>
+     * The distinction is not a detail. {@code cityLevel} is the number every height comparison in
+     * Urbex is written against - whether a doorway can be cut through a shared wall, whether a
+     * street may slope, which of two stairs wins, whether a bridge has anything to land on. A
+     * dimension's {@code groundLevel} is one constant for the whole world, so all of the variation
+     * lives in {@code cityLevel} and those comparisons are total.</p>
+     *
+     * <p>Putting a site's per-chunk height in {@code groundLevel} instead left every one of them
+     * reading {@code cityLevel == 0} for two chunks twenty blocks apart, concluding they were level,
+     * and cutting doors between them accordingly. The height has to travel down the channel built to
+     * carry it.</p>
+     *
+     * <p>The cost is that a site's ground is quantised to {@link CityGenerator#FLOORHEIGHT}, which
+     * is what {@link SiteField#groundY} documents. That is not an arbitrary rounding: six blocks is
+     * a storey, and a city whose grounds differ by less than one storey has no way to say so.</p>
+     */
+    public int cityLevelAt(int chunkX, int chunkZ) {
+        return Math.floorDiv(field.groundY(chunkX, chunkZ) - minY, CityGenerator.FLOORHEIGHT);
+    }
+
+    /**
+     * The Y this chunk's ground floor actually sits at: {@link SiteField#groundY} snapped down to
+     * the storey lattice rising from {@link #minY}.
+     *
+     * <p>What the terrain sampler reports and what the buildings stand on, so the two cannot
+     * disagree - a heightmap saying one thing while {@code getCityGroundLevel()} says another is a
+     * building floating over its own corrected terrain, or buried in it.</p>
+     */
+    public int effectiveGroundY(int chunkX, int chunkZ) {
+        return minY + cityLevelAt(chunkX, chunkZ) * CityGenerator.FLOORHEIGHT;
     }
 
     /** Whether the site covers a coordinate; see {@link SiteField#isSite}. */

--- a/src/main/java/dev/krona/urbex/worldgen/SiteRuntimes.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SiteRuntimes.java
@@ -3,6 +3,7 @@ package dev.krona.urbex.worldgen;
 import com.google.gson.JsonParser;
 import dev.krona.urbex.Urbex;
 import dev.krona.urbex.api.SiteSpec;
+import dev.krona.urbex.api.UrbexApi;
 import dev.krona.urbex.api.UrbexSite;
 import dev.krona.urbex.config.Preset;
 import dev.krona.urbex.config.PresetRoadGrid;
@@ -121,18 +122,17 @@ public final class SiteRuntimes {
      * {@code shape().maxY()}, so a site plans buildings that fit rather than buildings that get cut
      * off at the top by {@link ChunkBuffer}.</p>
      *
-     * <p>The sea level is put <em>below</em> the window rather than carried over from the level.
-     * A dimension's sea level is a fact about its surface; a site three hundred blocks under it is
-     * not underwater, and every rule that fills below the water line would think it was. A preset
-     * that wants a flooded site says so with its own {@code seaLevel}, which takes precedence over
-     * this everywhere it is read.</p>
+     * <p>The sea level is {@link SiteSpec#waterY}'s, and neither the level's nor the preset's. Both
+     * of those are one absolute height for a whole dimension, which says nothing useful about
+     * somewhere three hundred blocks under it - see {@link SiteSpec.Builder#waterY}. A dry site puts
+     * the water table one block below its own floor, which is the honest way to say "there is none".
+     * </p>
      */
     private static LevelShape shapeFor(ServerLevel level, SiteSpec spec) {
         LevelShape whole = LevelShape.of(level);
-        return new LevelShape(
-                Math.max(whole.minY(), spec.minY()),
-                Math.min(whole.maxY(), spec.maxY()),
-                Math.max(whole.minY(), spec.minY()) - 1);
+        int bottom = Math.max(whole.minY(), spec.minY());
+        int water = spec.waterY() == UrbexApi.NO_WATER ? bottom - 1 : spec.waterY();
+        return new LevelShape(bottom, Math.min(whole.maxY(), spec.maxY()), water);
     }
 
     /**

--- a/src/main/java/dev/krona/urbex/worldgen/SiteRuntimes.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SiteRuntimes.java
@@ -76,6 +76,17 @@ public final class SiteRuntimes {
         return raced != null ? raced : built;
     }
 
+    /**
+     * The planning context behind a live site.
+     *
+     * <p>Package-visible and deliberately not on {@link UrbexSite}: a caller has no business holding
+     * a {@code PlanningContext}, which is an internal that moves whenever an issue moves it. The
+     * spawn search needs one because it asks for {@link dev.krona.urbex.worldgen.lost.ChunkPlan}s.
+     */
+    static PlanningContext planningFor(UrbexSite site) {
+        return ((Site) site).planning;
+    }
+
     /** Drops the sites of a level that is unloading. */
     public void unload(ServerLevel level) {
         byLevel.remove(level);

--- a/src/main/java/dev/krona/urbex/worldgen/SiteRuntimes.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SiteRuntimes.java
@@ -1,0 +1,236 @@
+package dev.krona.urbex.worldgen;
+
+import com.google.gson.JsonParser;
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.api.SiteSpec;
+import dev.krona.urbex.api.UrbexSite;
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.config.PresetRoadGrid;
+import dev.krona.urbex.config.Presets;
+import dev.krona.urbex.plan.grid.GridRoadField;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
+import dev.krona.urbex.worldgen.lost.regassets.RetiredPresetKeyException;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.WorldGenRegion;
+import net.minecraft.world.level.chunk.ChunkAccess;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The sites another mod has asked for, in the levels they were asked for.
+ *
+ * <p>Building a site is expensive - a preset resolution, a world-style field, a road field and a
+ * fresh set of per-dimension caches - and a caller wants one per chunk. So it is built once per
+ * {@code (level, spec id)} and kept, and that memo is what makes
+ * {@link dev.krona.urbex.api.UrbexApi#site} cheap enough to call from a generation path.</p>
+ *
+ * <p>Owned by the {@link GenerationSession}, and so it lives exactly as long as the world does.
+ * A static map keyed by dimension id is precisely the shape issue #125 removed from
+ * {@code CityFeature}: a second world in the same JVM inherited the first world's entry, complete
+ * with its seed, its assets and its caches.</p>
+ *
+ * <h2>What a site borrows and what it owns</h2>
+ *
+ * <p>It <em>owns</em> its planning context and its generator, which is what lets it use a different
+ * preset and a different world style from the dimension it sits in, and its own
+ * {@link DimensionCaches}, which is what stops its plans colliding with the level's own at the same
+ * {@code ChunkCoord}.</p>
+ *
+ * <p>It <em>borrows</em> the world's compiled assets and block-tag epoch, and the level's deferred
+ * task queue. Borrowing the queue is what makes a site's deferred work drain: the tick handler
+ * drains the queue on the level's published runtime, and a queue of the site's own would fill up and
+ * never be looked at.</p>
+ *
+ * <p>It borrows nothing from the level's <em>preset</em>, which is the point worth stating: a site
+ * generates in a dimension where Urbex surface generation is switched off entirely. A vanilla
+ * overworld with bunkers under it is a supported configuration, not an accident.</p>
+ */
+public final class SiteRuntimes {
+
+    private final Map<ServerLevel, Map<Identifier, Site>> byLevel = new ConcurrentHashMap<>();
+
+    /**
+     * The site {@code spec} names in {@code level}, built on first use.
+     *
+     * <p>Keyed by {@code spec.id()} alone. A caller that hands two different specs under one id gets
+     * the first one back, with a warning: the alternative is two sites racing to be the definition
+     * of the same name, and a world whose bunkers depend on which chunk generated first.</p>
+     */
+    public UrbexSite site(ServerLevel level, SiteSpec spec, AssetSnapshot assets) {
+        Map<Identifier, Site> sites = byLevel.computeIfAbsent(level, l -> new ConcurrentHashMap<>());
+        Site known = sites.get(spec.id());
+        if (known != null) {
+            warnIfRedefined(known, spec);
+            return known;
+        }
+        // Built outside the map. Construction reaches the registries and compiles a road field;
+        // doing it inside computeIfAbsent would hold a bin lock across all of it, on a path several
+        // worldgen workers enter at once.
+        Site built = build(level, spec, assets);
+        Site raced = sites.putIfAbsent(spec.id(), built);
+        return raced != null ? raced : built;
+    }
+
+    /** Drops the sites of a level that is unloading. */
+    public void unload(ServerLevel level) {
+        byLevel.remove(level);
+    }
+
+    private static void warnIfRedefined(Site known, SiteSpec spec) {
+        if (known.spec().equals(spec)) {
+            return;
+        }
+        Urbex.getLogger().warn(
+                "Two different Urbex site definitions were registered under the id '{}' in '{}'. The "
+                        + "first one is what generates; the second is ignored. A site id is what "
+                        + "makes a per-chunk lookup cheap, so it has to mean one thing.",
+                spec.id(), known.level().dimension().identifier());
+    }
+
+    private static Site build(ServerLevel level, SiteSpec spec, AssetSnapshot assets) {
+        long seed = level.getSeed();
+        Preset preset = resolvePreset(level, spec);
+        SiteBinding binding = new SiteBinding(spec.id(), spec.field(), spec.minY(), spec.maxY());
+        DimensionCaches caches = new DimensionCaches(seed);
+        PlanningContext planning = new PlanningContext(
+                seed,
+                level.dimension(),
+                preset,
+                assets,
+                WorldStyleField.resolve(assets, seed, spec.worldStyles()),
+                // The site's id is part of the road field's address, so two sites in one dimension
+                // do not lay their streets on the same grid lines - and neither of them lands on the
+                // dimension's own.
+                new GridRoadField(seed, level.dimension().identifier() + "#" + spec.id(),
+                        PresetRoadGrid.of(preset)),
+                caches,
+                shapeFor(level, spec),
+                new SiteTerrain(new LevelTerrain(level, preset, caches), binding),
+                binding);
+        return new Site(spec, level, planning, new CityGenerator(planning, preset));
+    }
+
+    /**
+     * The level's shape, clamped to the site's window.
+     *
+     * <p>This is the planning half of the window: floor counts already clamp against
+     * {@code shape().maxY()}, so a site plans buildings that fit rather than buildings that get cut
+     * off at the top by {@link ChunkBuffer}.</p>
+     *
+     * <p>The sea level is put <em>below</em> the window rather than carried over from the level.
+     * A dimension's sea level is a fact about its surface; a site three hundred blocks under it is
+     * not underwater, and every rule that fills below the water line would think it was. A preset
+     * that wants a flooded site says so with its own {@code seaLevel}, which takes precedence over
+     * this everywhere it is read.</p>
+     */
+    private static LevelShape shapeFor(ServerLevel level, SiteSpec spec) {
+        LevelShape whole = LevelShape.of(level);
+        return new LevelShape(
+                Math.max(whole.minY(), spec.minY()),
+                Math.min(whole.maxY(), spec.maxY()),
+                Math.max(whole.minY(), spec.minY()) - 1);
+    }
+
+    /**
+     * Resolves the site's preset and applies its overlay.
+     *
+     * <p>The same three-way rule {@code DimensionRuntime.create} uses for a dimension's overrides,
+     * and deliberately so: a retired preset key is rethrown, because silently generating with an
+     * un-overridden preset is how a caller ends up debugging a world that ignored half its
+     * configuration; anything else malformed is logged and the base preset used, because a site that
+     * refuses to build takes the caller's whole chunk down with it.</p>
+     */
+    private static Preset resolvePreset(ServerLevel level, SiteSpec spec) {
+        Preset preset = Presets.resolve(level.registryAccess(), spec.preset());
+        String overrides = spec.presetOverridesJson();
+        if (overrides == null) {
+            return preset;
+        }
+        try {
+            return Presets.applyOverrides(preset,
+                    PresetDefinition.parseOverrides(JsonParser.parseString(overrides)));
+        } catch (RetiredPresetKeyException e) {
+            throw e;
+        } catch (Exception e) {
+            Urbex.getLogger().error("Malformed preset overrides on Urbex site '{}'; generating with "
+                    + "the un-overridden preset '{}'.", spec.id(), spec.preset(), e);
+            return preset;
+        }
+    }
+
+    /**
+     * One site: the caller's spec, and the planning context and generator built from it.
+     *
+     * <p>Nothing here is per-chunk. The {@link DimensionRuntime} a generation needs is assembled at
+     * {@link #fill} from the level's published one, so a site cannot hold a queue or a tag epoch
+     * belonging to a world that has since been unloaded.</p>
+     */
+    private static final class Site implements UrbexSite {
+
+        private final SiteSpec spec;
+        private final ServerLevel level;
+        private final PlanningContext planning;
+        private final CityGenerator generator;
+        /** So a lifecycle bug is one line in the log rather than one per chunk of a whole world. */
+        private final AtomicBoolean reportedMissingRuntime = new AtomicBoolean();
+
+        private Site(SiteSpec spec, ServerLevel level, PlanningContext planning,
+                     CityGenerator generator) {
+            this.spec = spec;
+            this.level = level;
+            this.planning = planning;
+            this.generator = generator;
+        }
+
+        @Override
+        public SiteSpec spec() {
+            return spec;
+        }
+
+        ServerLevel level() {
+            return level;
+        }
+
+        @Override
+        public boolean fill(WorldGenRegion region, ChunkAccess chunk) {
+            if (!spec.field().isSite(chunk.getPos().x(), chunk.getPos().z())) {
+                return false;
+            }
+            DimensionRuntime published = GenerationSession.runtimeFor(region);
+            if (published == null) {
+                reportMissingRuntime();
+                return false;
+            }
+            GenerationSession session = GenerationSession.current();
+            TagEpoch tags = session == null ? null : session.tagEpoch();
+            if (tags == null) {
+                reportMissingRuntime();
+                return false;
+            }
+            // The level's task queue and the world's tag epoch, paired with this site's own planning
+            // and generator. Built per call rather than held: an unload or a reload republishes what
+            // this reads, and a chunk starting now must generate against what is published now.
+            generator.generate(
+                    new DimensionRuntime(level, planning, generator, published.tasks(), tags),
+                    region, chunk);
+            return true;
+        }
+
+        private void reportMissingRuntime() {
+            if (!reportedMissingRuntime.compareAndSet(false, true)) {
+                return;
+            }
+            Urbex.getLogger().error(
+                    "Urbex site '{}' was asked to fill a chunk of '{}', but that level has no "
+                            + "published Urbex runtime and the world has compiled no assets. The "
+                            + "chunk gets no site content. Either the level loaded without "
+                            + "ServerLevelEvents.LOAD firing, or its runtime was retired while "
+                            + "chunks were still generating.",
+                    spec.id(), level.dimension().identifier());
+        }
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/SiteSpawnClaims.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SiteSpawnClaims.java
@@ -1,0 +1,151 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.Urbex;
+import dev.krona.urbex.api.SiteSpawn;
+import dev.krona.urbex.api.SiteSpec;
+import dev.krona.urbex.api.SiteSpecFactory;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.lost.ChunkPlan;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerLevel;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Mods that have asked for a world's spawn to land inside one of their sites.
+ *
+ * <p>Registered at mod initialisation and never cleared, because a claim is configuration rather
+ * than world state: the same mod wants the same thing of the next world it loads. What <em>is</em>
+ * world state - the site, its planning context, its caches - is built per level through
+ * {@link SiteRuntimes} and dies with that level, so a claim outliving a world costs nothing.</p>
+ *
+ * <p>Off unless a caller asks. A site that has not claimed spawn changes nothing about where a world
+ * puts its players, which is why there is no "none" to configure: the claim either exists or it does
+ * not.</p>
+ *
+ * <h2>Why the search is cheap</h2>
+ *
+ * <p>A {@link dev.krona.urbex.api.SiteField} is a pure function of the coordinate and is required to
+ * be cheap, so the outward scan can ask it about tens of thousands of chunks for the price of some
+ * hash arithmetic. Only the handful of coordinates it answers yes to get a {@link ChunkPlan} built,
+ * and only the first that matches the caller's preference gets a block read.</p>
+ */
+public final class SiteSpawnClaims {
+
+    /**
+     * How far out to look, in chunks. A site dense enough to be worth spawning in is normally found
+     * within a few dozen; this is the point at which "your field does not put anything near the
+     * origin" is the more useful answer than searching forever.
+     */
+    private static final int SEARCH_RADIUS_CHUNKS = 512;
+
+    private static final List<Claim> CLAIMS = new CopyOnWriteArrayList<>();
+
+    /** @param where which kind of site chunk the caller wants to wake up in */
+    private record Claim(SiteSpecFactory factory, SiteSpawn where) {}
+
+    private SiteSpawnClaims() {
+    }
+
+    /** @see dev.krona.urbex.api.UrbexApi#spawnIn */
+    public static void add(SiteSpecFactory factory, SiteSpawn where) {
+        CLAIMS.add(new Claim(factory, where));
+    }
+
+    public static boolean isEmpty() {
+        return CLAIMS.isEmpty();
+    }
+
+    /**
+     * The chunk-centre position a claimed site offers for {@code level}'s spawn, at the height its
+     * ground floor sits, or {@code null} if nothing claimed one or nothing was found.
+     *
+     * <p>The Y is where the plan says the floor is, not where a block is. Finding somewhere to
+     * actually stand from there is {@code SpawnPlacement}'s job - it already owns that check, and it
+     * is the only step here that reads a block and so forces a chunk to generate.</p>
+     *
+     * <p>First claim wins. Two mods both asking to own a world's spawn is a modpack conflict rather
+     * than something to resolve by a rule, so it is logged and the first is used.</p>
+     */
+    @Nullable
+    public static Anchor findAnchor(ServerLevel level) {
+        if (CLAIMS.isEmpty()) {
+            return null;
+        }
+        GenerationSession session = GenerationSession.current();
+        AssetSnapshot assets = session == null ? null : session.assets();
+        if (assets == null) {
+            return null;
+        }
+        warnIfContested();
+        Claim claim = CLAIMS.get(0);
+        SiteSpec spec = claim.factory().specFor(level);
+        PlanningContext planning = SiteRuntimes.planningFor(session.sites().site(level, spec, assets));
+        Anchor found = search(spec, claim.where(), planning);
+        if (found == null) {
+            Urbex.getLogger().warn(
+                    "Urbex site '{}' claimed the spawn of '{}', but no {} chunk was found within {} "
+                            + "chunks of the origin. The world keeps the spawn it would have had.",
+                    spec.id(), level.dimension().identifier(), claim.where(), SEARCH_RADIUS_CHUNKS);
+        }
+        return found;
+    }
+
+    /**
+     * Where a claimed spawn wants to be.
+     *
+     * @param pos  the chunk's centre, at the Y the plan puts its ground floor
+     * @param site the site that offered it, so a log line can name who moved the spawn
+     */
+    public record Anchor(BlockPos pos, Identifier site) {}
+
+    private static void warnIfContested() {
+        if (CLAIMS.size() > 1) {
+            Urbex.getLogger().warn("{} mods have claimed this world's spawn for an Urbex site. The "
+                    + "first registered wins; the rest are ignored.", CLAIMS.size());
+        }
+    }
+
+    /**
+     * Spirals out from the origin chunk, asking the caller's field first and the plan only where it
+     * says yes.
+     */
+    @Nullable
+    private static Anchor search(SiteSpec spec, SiteSpawn where, PlanningContext planning) {
+        for (int ring = 0; ring <= SEARCH_RADIUS_CHUNKS; ring++) {
+            for (int cx = -ring; cx <= ring; cx++) {
+                for (int cz = -ring; cz <= ring; cz++) {
+                    // Only the ring's edge; everything inside it was covered by a smaller ring.
+                    if (ring != 0 && Math.abs(cx) != ring && Math.abs(cz) != ring) {
+                        continue;
+                    }
+                    if (!spec.field().isSite(cx, cz)) {
+                        continue;
+                    }
+                    ChunkPlan plan = ChunkPlan.getChunkPlan(planning.coord(cx, cz), planning);
+                    if (!matches(plan, where)) {
+                        continue;
+                    }
+                    return new Anchor(
+                            new BlockPos((cx << 4) + 8, plan.getCityGroundLevel(), (cz << 4) + 8),
+                            spec.id());
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean matches(ChunkPlan plan, SiteSpawn where) {
+        if (!plan.isCity()) {
+            return false;
+        }
+        return switch (where) {
+            case STREET -> !plan.hasBuilding;
+            case BUILDING -> plan.hasBuilding;
+        };
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/SiteTerrain.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SiteTerrain.java
@@ -44,7 +44,7 @@ public final class SiteTerrain implements TerrainSampler {
      */
     @Override
     public ChunkHeightmap heightmap(ChunkCoord coord) {
-        return new ChunkHeightmap(LandscapeType.DEFAULT, site.groundY(coord.chunkX(), coord.chunkZ()));
+        return new ChunkHeightmap(LandscapeType.DEFAULT, site.effectiveGroundY(coord.chunkX(), coord.chunkZ()));
     }
 
     /**
@@ -55,7 +55,7 @@ public final class SiteTerrain implements TerrainSampler {
      */
     @Override
     public void sampleAccurateHeight(ChunkHeightmap heightmap, int chunkX, int chunkZ) {
-        int ground = site.groundY(chunkX, chunkZ);
+        int ground = site.effectiveGroundY(chunkX, chunkZ);
         heightmap.accurateHeights(ground, ground, ground, ground);
     }
 

--- a/src/main/java/dev/krona/urbex/worldgen/SiteTerrain.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SiteTerrain.java
@@ -1,0 +1,73 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.config.LandscapeType;
+import dev.krona.urbex.varia.ChunkCoord;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.world.level.biome.Biome;
+
+import javax.annotation.Nullable;
+
+/**
+ * The terrain a {@link SiteBinding site} plans against: flat, at the height the caller named.
+ *
+ * <p>A site is somewhere the dimension's own surface has nothing to say about. Asking the chunk
+ * generator how high the ground is at a bunker three hundred blocks underground answers about the
+ * hillside overhead, and every rule that reads it - which height band the city sits in, how far the
+ * terrain has to be corrected to meet a street, whether this is a void chunk - then answers about
+ * the hillside too. So the heightmap comes from {@link dev.krona.urbex.api.SiteField#groundY}
+ * instead, and it is flat within a chunk: a cavity floor is a floor.</p>
+ *
+ * <p>Biomes are <em>not</em> replaced. A site is still somewhere in the world, and a datapack's
+ * biome conditions - which building goes in a desert, which palette a swamp gets - should answer
+ * about where the player actually is. They are delegated to the level's own sampler, which is also
+ * what keeps registry-backed rules working.</p>
+ */
+public final class SiteTerrain implements TerrainSampler {
+
+    private final TerrainSampler delegate;
+    private final SiteBinding site;
+
+    public SiteTerrain(TerrainSampler delegate, SiteBinding site) {
+        this.delegate = delegate;
+        this.site = site;
+    }
+
+    /**
+     * A flat heightmap at the site's ground.
+     *
+     * <p>Built per call rather than cached. {@link ChunkHeightmap} is mutable and the contract on
+     * {@link TerrainSampler#heightmap} says the returned instance is shared and must not be written
+     * to - a rule the correction pass keeps by copying. Constructing one is two field writes, which
+     * is cheaper than the cache lookup that would protect it.</p>
+     */
+    @Override
+    public ChunkHeightmap heightmap(ChunkCoord coord) {
+        return new ChunkHeightmap(LandscapeType.DEFAULT, site.groundY(coord.chunkX(), coord.chunkZ()));
+    }
+
+    /**
+     * The four extra points a real sampler takes across the chunk all report the same flat height
+     * here, so this folds that height in four times. Not a no-op, despite there being nothing to
+     * sample: min and max are {@code 0} on an unsampled map, and a caller that asked for them would
+     * get the number zero rather than the site's floor.
+     */
+    @Override
+    public void sampleAccurateHeight(ChunkHeightmap heightmap, int chunkX, int chunkZ) {
+        int ground = site.groundY(chunkX, chunkZ);
+        heightmap.accurateHeights(ground, ground, ground, ground);
+    }
+
+    @Nullable
+    @Override
+    public Holder<Biome> biome(BlockPos pos) {
+        return delegate.biome(pos);
+    }
+
+    @Nullable
+    @Override
+    public RegistryAccess registryAccess() {
+        return delegate.registryAccess();
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/SpecialMarkerPolicy.java
+++ b/src/main/java/dev/krona/urbex/worldgen/SpecialMarkerPolicy.java
@@ -14,7 +14,19 @@ final class SpecialMarkerPolicy {
         return DensitySelector.loot(seed, marker, profile.lootDensity());
     }
 
-    static boolean generateSpawner(Preset profile) {
-        return profile.generateSpawners();
+    /**
+     * Whether the marker at {@code marker} keeps its spawner.
+     *
+     * <p>Two gates, and they answer different questions. {@code generateSpawners} is the switch: a
+     * world that wants none has none. {@code spawnerDensity} thins what survives, position-addressed
+     * like loot so which markers keep theirs is a property of the seed and the coordinate rather
+     * than of the order the parts were generated in.</p>
+     *
+     * <p>The density defaults to 1, so a preset that says nothing about it admits every marker and
+     * generates exactly what it did before this existed.</p>
+     */
+    static boolean generateSpawner(long seed, BlockPos marker, Preset profile) {
+        return profile.generateSpawners()
+                && DensitySelector.spawner(seed, marker, profile.spawnerDensity());
     }
 }

--- a/src/main/java/dev/krona/urbex/worldgen/WriteWindow.java
+++ b/src/main/java/dev/krona/urbex/worldgen/WriteWindow.java
@@ -1,0 +1,57 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.core.BlockPos;
+
+import javax.annotation.Nullable;
+
+/**
+ * The band of Y one generation may write in, inclusive at both ends.
+ *
+ * <p>The level's own bounds for a chunk Urbex generates on its own behalf, and a {@link SiteBinding
+ * site}'s window when another mod named one. Two things read it, for two different reasons:</p>
+ *
+ * <ul>
+ *   <li>{@link ChunkBuffer}, which every driver write passes through, so a pass that believes it may
+ *       build to the sky writes nothing above the window whatever it believes.</li>
+ *   <li>{@link ChunkGenContext}'s three deferred queues, which <em>bypass</em> the driver - they
+ *       hand a callback to the world to run later - so the buffer never sees them.</li>
+ * </ul>
+ *
+ * <p>A value rather than two ints on the context, because the intersection rule below is the kind of
+ * arithmetic that is obviously right until it is quietly wrong at one end, and it is worth being
+ * able to assert about on its own.</p>
+ */
+public record WriteWindow(int minY, int maxY) {
+
+    /**
+     * The window for a generation in a level bounded by {@code [levelMinY, levelMaxY]}.
+     *
+     * <p>A site's window is intersected with the level's rather than trusted: a caller may name a
+     * window wider than the dimension - a sensible thing to do when the caller does not know which
+     * dimension it will be asked about - and the section table a buffer allocates is sized for the
+     * dimension.</p>
+     */
+    public static WriteWindow of(@Nullable SiteBinding site, int levelMinY, int levelMaxY) {
+        if (site == null) {
+            return new WriteWindow(levelMinY, levelMaxY);
+        }
+        return new WriteWindow(Math.max(site.minY(), levelMinY), Math.min(site.maxY(), levelMaxY));
+    }
+
+    public boolean contains(int y) {
+        return y >= minY && y <= maxY;
+    }
+
+    /**
+     * Whether a deferred write anchored at {@code pos} is inside the window.
+     *
+     * <p>Exact for the block a todo names and approximate for anything its callback touches around
+     * it - the upper half of a door, the block a light is attached to. The queues hold opaque
+     * callbacks, so the anchor is the only thing there is to test. What this buys is that a site
+     * cannot place a chest, a spawner or a light one block outside its window, which is what these
+     * queues are used for; what it does not buy is a proof about the block beside it.</p>
+     */
+    public boolean contains(BlockPos pos) {
+        return contains(pos.getY());
+    }
+}

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -433,8 +433,14 @@ public class ChunkPlan {
         int plannedGround = site != null ? site.groundY(key.chunkX(), key.chunkZ())
                 : profile.groundLevel();
         groundLevel = override != null ? override.groundLevel() : plannedGround;
+        // A site's water is the caller's, not the preset's. A preset names one absolute sea level for
+        // a whole dimension, and a site three hundred blocks under that dimension's sea is not
+        // underwater - but every rule that fills below the water line would think it was, and a
+        // bunker built with urbex:cavern (sea level 32) comes out flooded to the ceiling. The site's
+        // LevelShape carries what SiteSpec.waterY asked for, which is "below everything here" unless
+        // the caller said otherwise.
         int wl = profile.seaLevel();
-        waterLevel = wl == -1 ? provider.shape().seaLevel() : wl;
+        waterLevel = site != null || wl == -1 ? provider.shape().seaLevel() : wl;
         WorldSettings.RailwayAvoidance avoidance = provider.worldStyles().primary().getWorldSettings().railwayAvoidance();
 
         // In a multi building we copy all information from the top-left chunk

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -615,7 +615,12 @@ public class ChunkPlan {
             zBridge = rand.nextFloat() < profile.bridgeChance();
         }
 
-        if (rand.nextFloat() < profile.railwayDungeonChance()) {
+        // The draw happens either way, so the layout stream does not depend on whether this is a
+        // site - only whether the part is kept. A rail dungeon is a room off the railway, drawn at
+        // groundLevel + RAILWAY_LEVEL_OFFSET * 6 like the rails themselves, and a site has neither
+        // the railway nor a groundLevel that means what that formula assumes.
+        boolean keepRailDungeon = rand.nextFloat() < profile.railwayDungeonChance() && site == null;
+        if (keepRailDungeon) {
             if (!hasBuilding || (Railway.RAILWAY_LEVEL_OFFSET < (cityLevel - cellars))) {
                 railDungeon = provider.assets().parts().getOrWarn(getCityStyle().getRandomRailDungeon(rand, this.coord));
             } else {
@@ -634,7 +639,12 @@ public class ChunkPlan {
     }
 
     private int getMaxcellars(CityStyle cs) {
-        int maxcellars = profile.buildingMaxCellars() + cityLevel;
+        // The + cityLevel term is "how much room there is under this chunk's ground before the
+        // datum", which for a dimension is how far the city has climbed above its ground level. For
+        // a site the datum is the bottom of the caller's window, so the same term reads as "dig as
+        // deep as the window allows" - and a caller who wrote buildingMaxCellars: 2 got up to ten.
+        // A site's number means what it says.
+        int maxcellars = profile.buildingMaxCellars() + (provider.site() != null ? 0 : cityLevel);
         if (buildingType.getMaxCellars() != -1 && buildingType.getOverrideFloors()) {
             maxcellars = buildingType.getMaxCellars();
             return maxcellars;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -426,12 +426,13 @@ public class ChunkPlan {
                 candidate.buildingType().getName());
         hasBuilding = override != null || content.hasBuilding();
 
-        // A site's ground is wherever the caller said it is, chunk by chunk, in place of the
-        // preset's one fixed number for the whole dimension. The editing override still wins over
-        // both: it is a command naming a height, and it names it for either kind of context.
+        // A site's base, not its ground: the per-chunk height travels in cityLevel above, because
+        // that is the number every height comparison in Urbex is written against. See
+        // SiteBinding.cityLevelAt for what putting it here instead did to doors. The editing
+        // override still wins over both - it is a command naming a height, for either kind of
+        // context.
         SiteBinding site = provider.site();
-        int plannedGround = site != null ? site.groundY(key.chunkX(), key.chunkZ())
-                : profile.groundLevel();
+        int plannedGround = site != null ? site.minY() : profile.groundLevel();
         groundLevel = override != null ? override.groundLevel() : plannedGround;
         // A site's water is the caller's, not the preset's. A preset names one absolute sea level for
         // a whole dimension, and a site three hundred blocks under that dimension's sea is not

--- a/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/ChunkPlan.java
@@ -10,6 +10,7 @@ import dev.krona.urbex.setup.Config;
 import dev.krona.urbex.varia.*;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
 import dev.krona.urbex.worldgen.PlanningContext;
+import dev.krona.urbex.worldgen.SiteBinding;
 import dev.krona.urbex.worldgen.CityGenerator;
 import dev.krona.urbex.worldgen.lost.cityassets.*;
 import dev.krona.urbex.worldgen.lost.regassets.data.PredefinedBuilding;
@@ -425,7 +426,13 @@ public class ChunkPlan {
                 candidate.buildingType().getName());
         hasBuilding = override != null || content.hasBuilding();
 
-        groundLevel = override != null ? override.groundLevel() : profile.groundLevel();
+        // A site's ground is wherever the caller said it is, chunk by chunk, in place of the
+        // preset's one fixed number for the whole dimension. The editing override still wins over
+        // both: it is a command naming a height, and it names it for either kind of context.
+        SiteBinding site = provider.site();
+        int plannedGround = site != null ? site.groundY(key.chunkX(), key.chunkZ())
+                : profile.groundLevel();
+        groundLevel = override != null ? override.groundLevel() : plannedGround;
         int wl = profile.seaLevel();
         waterLevel = wl == -1 ? provider.shape().seaLevel() : wl;
         WorldSettings.RailwayAvoidance avoidance = provider.worldStyles().primary().getWorldSettings().railwayAvoidance();

--- a/src/main/java/dev/krona/urbex/worldgen/lost/CityField.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/CityField.java
@@ -68,10 +68,11 @@ public final class CityField {
      * This function uses its own cache.
      */
     public static int getCityLevel(ChunkCoord key, PlanningContext provider) {
-        if (provider.site() != null) {
-            // Uncached, and ahead of the cache lookup, because there is nothing to compute: see
-            // siteCityLevel().
-            return siteCityLevel();
+        SiteBinding boundSite = provider.site();
+        if (boundSite != null) {
+            // Uncached, and ahead of the cache lookup: it is a floorDiv of a field call, which is
+            // cheaper than the map lookup that would memoise it.
+            return boundSite.cityLevelAt(key.chunkX(), key.chunkZ());
         }
         // Unconditional. This used to be gated on provider.getWorld() != null, "In LC preview we
         // don't want to use the cache as the config isn't loaded yet" - a guard from when the
@@ -98,8 +99,9 @@ public final class CityField {
     }
 
     public static int cityLevelUncached(ChunkCoord key, PlanningContext provider) {
-        if (provider.site() != null) {
-            return siteCityLevel();
+        SiteBinding boundSite = provider.site();
+        if (boundSite != null) {
+            return boundSite.cityLevelAt(key.chunkX(), key.chunkZ());
         }
         int result;
         if (provider.preset().isFloating()) {
@@ -110,21 +112,6 @@ public final class CityField {
             result = getCityLevelNormal(key, provider, provider.preset());
         }
         return result;
-    }
-
-    /**
-     * A site's city level, which is always the ground floor.
-     *
-     * <p>The nine level bands exist to let a city climb a hillside: a chunk whose terrain is higher
-     * gets a higher band, and its buildings start six blocks further up per band, so a city drapes
-     * over the landscape instead of being cut into it. A site has no landscape to drape over - its
-     * ground is wherever the caller said, flat, chunk by chunk - and the height it wants is already
-     * expressed exactly, by {@link dev.krona.urbex.api.SiteField#groundY}. Banding it a second time
-     * would raise buildings off the floor the caller named, in multiples of six, for no reason
-     * anybody could see from outside.</p>
-     */
-    private static int siteCityLevel() {
-        return 0;
     }
 
     private static int getCityLevelCavern(ChunkCoord coord, PlanningContext provider) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/CityField.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/CityField.java
@@ -5,6 +5,7 @@ import dev.krona.urbex.setup.Config;
 import dev.krona.urbex.varia.ChunkCoord;
 import dev.krona.urbex.worldgen.ChunkHeightmap;
 import dev.krona.urbex.worldgen.PlanningContext;
+import dev.krona.urbex.worldgen.SiteBinding;
 
 /**
  * Where a city is, and how high it sits.
@@ -32,6 +33,18 @@ public final class CityField {
      * Don't use the cache as we're busy building the cache.
      */
     public static boolean isCityRaw(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        SiteBinding site = provider.site();
+        if (site != null) {
+            // The caller's field replaces the city mask outright - not intersected with it, not
+            // consulted alongside it. A mod asking Urbex to fill a cavity it carved is naming the
+            // place; whether Urbex's own noise would have put a city there is a question about a
+            // different world, and answering it would leave the caller with bunkers wherever the
+            // two happened to agree.
+            //
+            // Ahead of the void check as well, which is about a floating dimension having no island
+            // at a coordinate. A site is not on the islands.
+            return site.covers(coord.chunkX(), coord.chunkZ());
+        }
         if (isVoidChunk(coord, provider)) {
             // If we have a void chunk then no city here
             return false;
@@ -55,6 +68,11 @@ public final class CityField {
      * This function uses its own cache.
      */
     public static int getCityLevel(ChunkCoord key, PlanningContext provider) {
+        if (provider.site() != null) {
+            // Uncached, and ahead of the cache lookup, because there is nothing to compute: see
+            // siteCityLevel().
+            return siteCityLevel();
+        }
         // Unconditional. This used to be gated on provider.getWorld() != null, "In LC preview we
         // don't want to use the cache as the config isn't loaded yet" - a guard from when the
         // preview shared the dimension's caches. It has held its own DimensionCaches, built from
@@ -80,6 +98,9 @@ public final class CityField {
     }
 
     public static int cityLevelUncached(ChunkCoord key, PlanningContext provider) {
+        if (provider.site() != null) {
+            return siteCityLevel();
+        }
         int result;
         if (provider.preset().isFloating()) {
             result = getCityLevelFloating(key, provider);
@@ -89,6 +110,21 @@ public final class CityField {
             result = getCityLevelNormal(key, provider, provider.preset());
         }
         return result;
+    }
+
+    /**
+     * A site's city level, which is always the ground floor.
+     *
+     * <p>The nine level bands exist to let a city climb a hillside: a chunk whose terrain is higher
+     * gets a higher band, and its buildings start six blocks further up per band, so a city drapes
+     * over the landscape instead of being cut into it. A site has no landscape to drape over - its
+     * ground is wherever the caller said, flat, chunk by chunk - and the height it wants is already
+     * expressed exactly, by {@link dev.krona.urbex.api.SiteField#groundY}. Banding it a second time
+     * would raise buildings off the floor the caller named, in multiples of six, for no reason
+     * anybody could see from outside.</p>
+     */
+    private static int siteCityLevel() {
+        return 0;
     }
 
     private static int getCityLevelCavern(ChunkCoord coord, PlanningContext provider) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Highway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Highway.java
@@ -57,6 +57,13 @@ public class Highway {
     }
 
     private static int getHighwayLevel(PlanningContext provider, Preset profile, TimedCache<ChunkCoord, Integer> cache, Function<ChunkCoord, Boolean> hasHighway, Orientation orientation, ChunkCoord cp) {
+        if (provider.site() != null) {
+            // No highway through a site, for the reason spelled out on Railway.RAILWAY_LEVEL_OFFSET:
+            // a highway is a road between cities held at one height across hundreds of chunks, and a
+            // site is a pocket with nothing on the other side of it. Its height would be measured
+            // from the site's window bottom, too.
+            return -1;
+        }
         Integer known = cache.get(cp);
         if (known != null) {
             return known;

--- a/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/Railway.java
@@ -19,6 +19,22 @@ import static dev.krona.urbex.worldgen.lost.Railway.RailDirection.*;
 
 public class Railway {
 
+    /**
+     * How far below {@code groundLevel} the network runs, in storeys.
+     *
+     * <p>Below {@code groundLevel}, and not below the chunk's own city ground - which is what makes
+     * a railway a <em>network</em>: it holds one height across hundreds of chunks while the cities
+     * it joins ride up and down on the terrain above it.</p>
+     *
+     * <p><strong>That is also why a site never has one.</strong> A site's {@code groundLevel} is the
+     * bottom of its window, with the per-chunk height carried in {@code cityLevel} instead, so this
+     * offset would put the rails eighteen blocks <em>below the window</em> - out of the world
+     * entirely for a bunker at y=-60, which is where the station staircases were seen descending to.
+     * Re-datuming them onto the chunk's city ground would land them somewhere legal but no better:
+     * a network needs two ends, and a site is a pocket a few dozen chunks across with nothing to
+     * join. Connecting a site's stations to the surface, or to a real network above it, is a
+     * feature; putting rails at a plausible height inside a sealed bunker is not.</p>
+     */
     public static final int RAILWAY_LEVEL_OFFSET = -3;
 
     /*
@@ -317,6 +333,10 @@ public class Railway {
     }
 
     public static RailChunkInfo getRailChunkType(ChunkCoord coord, PlanningContext provider, Preset profile) {
+        if (provider.site() != null) {
+            // A site has no railway, and cannot: see the note on this class's site handling below.
+            return RailChunkInfo.NOTHING;
+        }
         TimedCache<ChunkCoord, RailChunkInfo> cache = provider.caches().railInfo;
         RailChunkInfo known = cache.get(coord);
         if (known != null) {

--- a/src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/preset/BuildingSettings.java
+++ b/src/main/java/dev/krona/urbex/worldgen/lost/regassets/data/preset/BuildingSettings.java
@@ -20,9 +20,10 @@ public record BuildingSettings(
         Optional<Float> buildingFrontChance,
         Optional<Boolean> multiUseCorner,
         Optional<MultiBuildingStreetConflict> multiBuildingStreetConflict,
-        Optional<Boolean> generateSpawners) {
+        Optional<Boolean> generateSpawners,
+        Optional<Float> spawnerDensity) {
 
-    public static final Set<String> KEYS = Set.of("buildingChance", "buildingMinFloors", "buildingMaxFloors", "buildingMinFloorsChance", "buildingMaxFloorsChance", "buildingMinCellars", "buildingMaxCellars", "buildingDoorwayChance", "buildingFrontChance", "multiUseCorner", "multiBuildingStreetConflict", "generateSpawners");
+    public static final Set<String> KEYS = Set.of("buildingChance", "buildingMinFloors", "buildingMaxFloors", "buildingMinFloorsChance", "buildingMaxFloorsChance", "buildingMinCellars", "buildingMaxCellars", "buildingDoorwayChance", "buildingFrontChance", "multiUseCorner", "multiBuildingStreetConflict", "generateSpawners", "spawnerDensity");
 
     private static final Codec<MultiBuildingStreetConflict> MULTI_BUILDING_STREET_CONFLICT_CODEC = Codec.STRING.comapFlatMap(
             s -> {
@@ -47,7 +48,8 @@ public record BuildingSettings(
                     Codec.floatRange(0.0f, 1.0f).optionalFieldOf("buildingFrontChance").forGetter(BuildingSettings::buildingFrontChance),
                     Codec.BOOL.optionalFieldOf("multiUseCorner").forGetter(BuildingSettings::multiUseCorner),
                     MULTI_BUILDING_STREET_CONFLICT_CODEC.optionalFieldOf("multiBuildingStreetConflict").forGetter(BuildingSettings::multiBuildingStreetConflict),
-                    Codec.BOOL.optionalFieldOf("generateSpawners").forGetter(BuildingSettings::generateSpawners)
+                    Codec.BOOL.optionalFieldOf("generateSpawners").forGetter(BuildingSettings::generateSpawners),
+                    Codec.floatRange(0.0f, 1.0f).optionalFieldOf("spawnerDensity").forGetter(BuildingSettings::spawnerDensity)
             ).apply(i, BuildingSettings::new));
     public static final Codec<BuildingSettings> CODEC = UnknownKeys.warning(RAW, KEYS, "buildings");
 
@@ -64,5 +66,6 @@ public record BuildingSettings(
         multiUseCorner.ifPresent(v -> p.MULTI_USE_CORNER = v);
         multiBuildingStreetConflict.ifPresent(v -> p.MULTI_BUILDING_STREET_CONFLICT = v);
         generateSpawners.ifPresent(v -> p.GENERATE_SPAWNERS = v);
+        spawnerDensity.ifPresent(v -> p.SPAWNER_DENSITY = v);
     }
 }

--- a/src/main/resources/assets/urbex/lang/en_us.json
+++ b/src/main/resources/assets/urbex/lang/en_us.json
@@ -200,6 +200,8 @@
   "urbex.setting.GENERATE_NETHER.tooltip": "If true then generate a cavern type world in the Nether",
   "urbex.setting.GENERATE_SPAWNERS": "Generate Spawners",
   "urbex.setting.GENERATE_SPAWNERS.tooltip": "If true then the buildings will be full of spawners",
+  "urbex.setting.SPAWNER_DENSITY": "Spawner Density",
+  "urbex.setting.SPAWNER_DENSITY.tooltip": "How many of the marked spawner positions actually keep a spawner. 1 keeps every one; lower thins them out. Turn Generate Spawners off for none at all.",
   "urbex.setting.LIGHTING_DENSITY": "Lighting Density",
   "urbex.setting.LIGHTING_DENSITY.tooltip": "Chance that an optional decorative-light marker places a light",
   "urbex.setting.LOOT_DENSITY": "Loot Density",

--- a/src/test/java/dev/krona/urbex/api/SiteSpecTest.java
+++ b/src/test/java/dev/krona/urbex/api/SiteSpecTest.java
@@ -1,0 +1,108 @@
+package dev.krona.urbex.api;
+
+import dev.krona.urbex.setup.WorldStyleMix;
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a caller can and cannot say when defining a site.
+ *
+ * <p>Every failure here is one a mod author hits at initialisation, holding a stack trace, rather
+ * than three hundred blocks underground wondering why the bunkers are the wrong shape. That is the
+ * point of validating in the constructor: a {@link SiteSpec} is built once and generates for the
+ * life of a world, so there is no cheap moment later to notice it was wrong.</p>
+ */
+class SiteSpecTest {
+
+    private static final Identifier ID = Identifier.fromNamespaceAndPath("urbextest", "bunkers");
+    private static final Identifier PRESET = Identifier.fromNamespaceAndPath("urbex", "cavern");
+    private static final SiteField FIELD = (x, z) -> true;
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void theShortestUsefulSpecIsThreeArgumentsAndABuild() {
+        SiteSpec spec = SiteSpec.builder(ID, PRESET, FIELD).build();
+
+        assertEquals(ID, spec.id());
+        assertEquals(PRESET, spec.preset());
+        assertEquals(WorldStyleMix.of(UrbexApi.DEFAULT_WORLD_STYLE), spec.worldStyles());
+        assertNull(spec.presetOverridesJson());
+        assertEquals(UrbexApi.DEFAULT_MIN_Y, spec.minY());
+        assertEquals(UrbexApi.DEFAULT_MAX_Y, spec.maxY());
+    }
+
+    /**
+     * The default that stops the commonest trap: a preset written for a dimension names an absolute
+     * sea level, and a site under that dimension is not underwater.
+     */
+    @Test
+    void aSiteIsDryUnlessTheCallerAsksForWater() {
+        assertEquals(UrbexApi.NO_WATER, SiteSpec.builder(ID, PRESET, FIELD).build().waterY());
+        assertEquals(-30, SiteSpec.builder(ID, PRESET, FIELD).waterY(-30).build().waterY());
+    }
+
+    @Test
+    void anUpsideDownWindowIsRefusedNamingBothEnds() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> SiteSpec.builder(ID, PRESET, FIELD).window(20, -40).build());
+
+        assertTrue(thrown.getMessage().contains("20") && thrown.getMessage().contains("-40"),
+                "a caller who transposed two numbers should be able to see that from the message: "
+                        + thrown.getMessage());
+    }
+
+    @Test
+    void aWindowOfOneBlockIsLegalIfUseless() {
+        assertEquals(7, SiteSpec.builder(ID, PRESET, FIELD).window(7, 7).build().minY());
+    }
+
+    @Test
+    void aSingleStyleAndAOneEntryMixSayTheSameThing() {
+        Identifier style = Identifier.fromNamespaceAndPath("urbextest", "bunker");
+
+        assertEquals(SiteSpec.builder(ID, PRESET, FIELD).worldStyles(WorldStyleMix.of(style)).build(),
+                SiteSpec.builder(ID, PRESET, FIELD).worldStyle(style).build());
+    }
+
+    @Test
+    void everythingASiteCannotDoWithoutIsRequired() {
+        assertThrows(NullPointerException.class,
+                () -> SiteSpec.builder(null, PRESET, FIELD).build());
+        assertThrows(NullPointerException.class,
+                () -> SiteSpec.builder(ID, null, FIELD).build());
+        assertThrows(NullPointerException.class,
+                () -> SiteSpec.builder(ID, PRESET, null).build());
+    }
+
+    /**
+     * The id is the memo key, so equal specs must be equal values - otherwise the "you registered
+     * two different sites under one id" warning fires on every chunk for a caller that simply builds
+     * its spec inline.
+     */
+    @Test
+    void twoSpecsBuiltTheSameWayAreEqual() {
+        assertEquals(spec(), spec());
+    }
+
+    private static SiteSpec spec() {
+        return SiteSpec.builder(ID, PRESET, FIELD)
+                .worldStyle(Identifier.fromNamespaceAndPath("urbex", "standard"))
+                .presetOverrides("{}")
+                .window(-60, 24)
+                .waterY(-50)
+                .build();
+    }
+}

--- a/src/test/java/dev/krona/urbex/config/SiteOverrideApplicationTest.java
+++ b/src/test/java/dev/krona/urbex/config/SiteOverrideApplicationTest.java
@@ -1,0 +1,87 @@
+package dev.krona.urbex.config;
+
+import com.google.gson.JsonParser;
+import dev.krona.urbex.worldgen.lost.regassets.PresetDefinition;
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * That a partial {@code PresetDefinition} overlay reaches the resolved preset.
+ *
+ * <p>This is the one thing a site caller cannot check for itself. DFU codecs ignore map keys they do
+ * not recognise, so an overlay naming a section or a field that does not exist is dropped in
+ * silence: the world generates, nothing is logged, and the only symptom is that the setting had no
+ * effect - which looks exactly like the setting not working.</p>
+ *
+ * <p>The overlay below is {@code Urbex-Bunkers}' own, field for field. If a preset key is ever
+ * renamed, this fails here rather than in somebody's cave.</p>
+ */
+class SiteOverrideApplicationTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static final String BUNKER_OVERLAY = """
+            {
+              "buildings": {
+                "buildingChance": 0.6,
+                "buildingMinFloors": 0,
+                "buildingMaxFloors": 3,
+                "buildingMinCellars": 1,
+                "buildingMaxCellars": 2
+              },
+              "decoration": {
+                "lightingDensity": 0.95
+              },
+              "destruction": {
+                "ruinChance": 0.0
+              }
+            }
+            """;
+
+    @Test
+    void aPartialOverlayChangesOnlyWhatItNames() {
+        PresetDraft draft = new PresetDraft(Identifier.fromNamespaceAndPath("urbex", "test-base"));
+        draft.BUILDING_MAXFLOORS = 9;
+        draft.BUILDING_MAXCELLARS = 9;
+        draft.RUIN_CHANCE = 0.5f;
+        draft.CORRIDOR_CHANCE = 0.25f;      // named by no section below
+        Preset base = draft.resolve();
+
+        Preset overridden = Presets.applyOverrides(base,
+                PresetDefinition.parseOverrides(JsonParser.parseString(BUNKER_OVERLAY)));
+
+        assertEquals(3, overridden.buildingMaxFloors(), "buildingMaxFloors did not take");
+        assertEquals(2, overridden.buildingMaxCellars(), "buildingMaxCellars did not take");
+        assertEquals(0.6f, overridden.buildingChance(), 1e-6, "buildingChance did not take");
+        assertEquals(0.95f, overridden.lightingDensity(), 1e-6, "lightingDensity did not take");
+        assertEquals(0.0f, overridden.ruinChance(), 1e-6, "ruinChance did not take");
+        assertEquals(0.25f, overridden.corridorChance(), 1e-6,
+                "an overlay must leave everything it does not name alone");
+    }
+
+    /**
+     * The failure this whole class is about. A section that does not exist is not an error to a
+     * codec - it is a key nobody asked about - so the overlay silently does nothing.
+     */
+    @Test
+    void anOverlayNamingASectionThatDoesNotExistChangesNothing() {
+        PresetDraft draft = new PresetDraft(Identifier.fromNamespaceAndPath("urbex", "test-base"));
+        draft.BUILDING_MAXFLOORS = 9;
+        Preset base = draft.resolve();
+
+        Preset overridden = Presets.applyOverrides(base, PresetDefinition.parseOverrides(
+                JsonParser.parseString("{ \"building\": { \"buildingMaxFloors\": 3 } }")));
+
+        assertEquals(9, overridden.buildingMaxFloors(),
+                "a misspelled section is dropped in silence - that is the trap this documents");
+    }
+}

--- a/src/test/java/dev/krona/urbex/varia/RngTest.java
+++ b/src/test/java/dev/krona/urbex/varia/RngTest.java
@@ -180,13 +180,16 @@ class RngTest {
             968677072947688043L, 7783050954197339180L, 5127804395627648118L, -7549811660803165866L
     };
 
-    private static final Rng.Purpose LAST_PURPOSE = Rng.Purpose.WORLD_STYLE;
+    private static final Rng.Purpose LAST_PURPOSE = Rng.Purpose.SPAWNER_DENSITY;
 
+    // Regenerated when SPAWNER_DENSITY was appended and became the last purpose. WORLD_STYLE's own
+    // stream is unchanged - the constant went after it, so no ordinal that existed before moved and
+    // no world that ever generated draws differently.
     private static final long[] GOLDEN_LAST = {
-            4834304774118109573L, 1213360875175908703L, -4979639623981822999L, 913972631060055965L
+            7323855892107149811L, -1773399582171714355L, 7530877591947830040L, 2715313787682340918L
     };
 
-    private static final int PURPOSE_COUNT = 42;
+    private static final int PURPOSE_COUNT = 43;
 
     private static final String PURPOSE_ORDER =
             "BUILDING,MULTI,PARTS,RUINS,RUBBLE,LEAVES,DEBRIS,STUFF,SPAWNERS,LOOT,VEGETATION,"
@@ -196,5 +199,5 @@ class RngTest {
                     + "TERRAIN_FIX_UPPER,CITY_STYLE_LOCAL,VEGETATION_GROWTH,BUILDING_FLOORS,BUILDING_LAYOUT,"
                     + "VEGETATION_XMAX,VEGETATION_ZMIN,VEGETATION_ZMAX,EXPLOSION_ACCEPT,EXPLOSION_MINI_ACCEPT,"
                     + "LIGHTING_DENSITY,LIGHTING_VARIANT,LOOT_DENSITY,"
-                    + "LARGE_BRIDGE,WORLD_STYLE";
+                    + "LARGE_BRIDGE,WORLD_STYLE,SPAWNER_DENSITY";
 }

--- a/src/test/java/dev/krona/urbex/worldgen/ChunkBufferWindowTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/ChunkBufferWindowTest.java
@@ -1,0 +1,187 @@
+package dev.krona.urbex.worldgen;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.BulkSectionAccess;
+import net.minecraft.world.level.chunk.ProtoChunk;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The vertical window: what a buffer built for a {@link SiteBinding site} refuses.
+ *
+ * <p>A site names a range of Y and nothing it generates may leave it - a bunker that punches a
+ * stairwell up through the surface is the failure this exists to make impossible. The refusal is
+ * here, at the one point every driver write passes through, rather than at the eighteen generation
+ * passes that write: a rule kept in eighteen places is a rule the nineteenth pass breaks.</p>
+ *
+ * <p>The unbounded case is tested alongside the bounded one on purpose. Every chunk Urbex has ever
+ * generated goes through the unbounded path, so "this changed nothing for a normal world" is a
+ * property worth asserting rather than inferring from the digests.</p>
+ */
+class ChunkBufferWindowTest {
+
+    /** Low enough and high enough to sit inside one section, and to straddle a section boundary. */
+    private static final int WINDOW_MIN = 10;
+    private static final int WINDOW_MAX = 40;
+
+    private final List<String> log = new ArrayList<>();
+
+    private final BlockState stone = Blocks.STONE.defaultBlockState();
+    private final BlockState dirt = Blocks.DIRT.defaultBlockState();
+    private final BlockState air = Blocks.AIR.defaultBlockState();
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private ChunkBuffer windowed(ChunkBuffer.WorldView world) {
+        return new ChunkBuffer(
+                (x, y, z, state) -> log.add(x + "," + y + "," + z + "="
+                        + BuiltInRegistries.BLOCK.getKey(state.getBlock())),
+                world, -64, 320, 0, 0, WINDOW_MIN, WINDOW_MAX);
+    }
+
+    /** Nothing in the buffer, so any read the buffer does not answer itself is a test failure. */
+    private ChunkBuffer windowed() {
+        return windowed(pos -> {
+            throw new AssertionError("unexpected world read at " + pos);
+        });
+    }
+
+    @Test
+    void aWriteBelowTheWindowIsRefused() {
+        ChunkBuffer buffer = windowed();
+
+        buffer.set(1, WINDOW_MIN - 1, 1, stone);
+
+        assertTrue(log.isEmpty(), "a block one below the window is outside it");
+        assertNull(buffer.get(1, WINDOW_MIN - 1, 1));
+    }
+
+    @Test
+    void aWriteAboveTheWindowIsRefused() {
+        ChunkBuffer buffer = windowed();
+
+        buffer.set(1, WINDOW_MAX + 1, 1, stone);
+
+        assertTrue(log.isEmpty(), "a block one above the window is outside it");
+        assertNull(buffer.get(1, WINDOW_MAX + 1, 1));
+    }
+
+    @Test
+    void bothEdgesOfTheWindowAreInside() {
+        ChunkBuffer buffer = windowed();
+
+        buffer.set(1, WINDOW_MIN, 1, stone);
+        buffer.set(1, WINDOW_MAX, 1, stone);
+
+        assertIterableEquals(List.of("1," + WINDOW_MIN + ",1=minecraft:stone",
+                "1," + WINDOW_MAX + ",1=minecraft:stone"), log,
+                "the window is inclusive at both ends");
+    }
+
+    @Test
+    void aFillIsClippedToTheWindowRatherThanRefused() {
+        windowed().fill(1, 2, WINDOW_MIN - 5, WINDOW_MAX + 5, stone);
+
+        assertEquals(WINDOW_MAX - WINDOW_MIN + 1, log.size(),
+                "a run reaching past the window keeps the part of itself that is inside it");
+        assertEquals("1," + WINDOW_MIN + ",2=minecraft:stone", log.get(0));
+        assertEquals("1," + WINDOW_MAX + ",2=minecraft:stone", log.get(log.size() - 1));
+    }
+
+    @Test
+    void aFillEntirelyOutsideTheWindowNeverRunsItsLoop() {
+        windowed().fill(1, 2, WINDOW_MAX + 1, WINDOW_MAX + 100, stone);
+
+        assertTrue(log.isEmpty(), "nothing in that run is inside the window");
+    }
+
+    /**
+     * The conditional fill reads the world where the buffer holds nothing, so a refused position
+     * must be refused before that read rather than after it. The world view throws, which is what
+     * turns "before" into an assertion.
+     */
+    @Test
+    void aConditionalFillOutsideTheWindowDoesNotEvenReadTheWorld() {
+        ChunkBuffer buffer = windowed();
+
+        buffer.fillWhere(1, 1, WINDOW_MAX + 1, WINDOW_MAX + 8, air, state -> true);
+
+        assertTrue(log.isEmpty());
+    }
+
+    @Test
+    void aConditionalFillIsClippedLikeAnUnconditionalOne() {
+        ChunkBuffer buffer = windowed(pos -> {
+            if (pos.getY() < WINDOW_MIN || pos.getY() > WINDOW_MAX) {
+                throw new AssertionError("read the world outside the window at " + pos);
+            }
+            return stone;
+        });
+
+        buffer.fillWhere(1, 1, WINDOW_MIN - 3, WINDOW_MIN + 1, air, state -> state == stone);
+
+        assertIterableEquals(List.of("1," + WINDOW_MIN + ",1=minecraft:air",
+                "1," + (WINDOW_MIN + 1) + ",1=minecraft:air"), log);
+    }
+
+    /**
+     * A section that straddles the window boundary is flushed in full once anything inside the
+     * window writes to it, and every non-null slot in a flushed section is copied out. So a
+     * remembered block above the boundary would reach the world through a write below it.
+     */
+    @Test
+    void aStraddlingSectionFlushesOnlyItsInWindowBlocks() {
+        ProtoChunk chunk = TestChunk.emptyChunk();
+        BlockPos above = new BlockPos(1, WINDOW_MAX + 1, 1);
+        chunk.setBlockState(above, stone, 0);
+        LevelAccessor level = TestChunk.levelFor(chunk);
+        ChunkBuffer buffer = windowed(level::getBlockState);
+
+        buffer.remember(above.getX(), above.getY(), above.getZ(), dirt);
+        buffer.set(1, WINDOW_MAX, 1, dirt);
+        flush(buffer, level);
+
+        assertEquals(dirt, chunk.getBlockState(new BlockPos(1, WINDOW_MAX, 1)),
+                "the block inside the window is written");
+        assertEquals(stone, chunk.getBlockState(above),
+                "the block above it keeps what the world already held");
+        assertEquals(WINDOW_MAX >> 4, above.getY() >> 4,
+                "this proves nothing unless the two blocks share a section");
+    }
+
+    @Test
+    void anUnboundedBufferAcceptsTheWholeLevel() {
+        ChunkBuffer buffer = new ChunkBuffer(
+                (x, y, z, state) -> log.add(x + "," + y + "," + z), pos -> stone, -64, 320, 0, 0);
+
+        buffer.set(1, -64, 1, stone);
+        buffer.set(1, 319, 1, stone);
+
+        assertIterableEquals(List.of("1,-64,1", "1,319,1"), log,
+                "the bottom and top blocks of the level are both writable when no window is named");
+    }
+
+    private static void flush(ChunkBuffer buffer, LevelAccessor level) {
+        BulkSectionAccess bulk = new BulkSectionAccess(level);
+        buffer.flush(bulk);
+        bulk.close();
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/SitePlanningTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/SitePlanningTest.java
@@ -1,0 +1,214 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.api.SiteField;
+import dev.krona.urbex.config.LandscapeType;
+import dev.krona.urbex.config.Preset;
+import dev.krona.urbex.config.PresetDraft;
+import dev.krona.urbex.plan.RoadField;
+import dev.krona.urbex.varia.ChunkCoord;
+import dev.krona.urbex.worldgen.lost.ChunkCandidate;
+import dev.krona.urbex.worldgen.lost.ChunkCandidates;
+import dev.krona.urbex.worldgen.lost.CityField;
+import dev.krona.urbex.worldgen.lost.cityassets.AssetSnapshot;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a {@link SiteBinding} changes about planning, and what it deliberately does not.
+ *
+ * <p>These are assertions about the three inputs a caller takes over - where the city is, how high
+ * it sits, and which height band it lands in - at the layer they are answered rather than through a
+ * whole generated chunk. A full {@code ChunkPlan} needs compiled parts, palettes and city styles;
+ * these three answers need none of that, and testing them here is what makes it possible to say the
+ * null-binding path is unchanged.</p>
+ */
+class SitePlanningTest {
+
+    /** Three chunks wide, so a site has an inside, an edge and an outside. */
+    private static final SiteField THREE_BY_THREE = new SiteField() {
+        @Override
+        public boolean isSite(int chunkX, int chunkZ) {
+            return Math.abs(chunkX) <= 1 && Math.abs(chunkZ) <= 1;
+        }
+
+        @Override
+        public int groundY(int chunkX, int chunkZ) {
+            // Varying by coordinate on purpose: a constant would pass even if the code read the
+            // preset's single ground level and ignored the field.
+            return -30 + chunkX;
+        }
+    };
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void theCallersFieldDecidesWhereTheCityIs() {
+        PlanningContext site = planning(binding());
+        Preset preset = site.preset();
+
+        assertTrue(CityField.isCityRaw(new ChunkCoord(Level.OVERWORLD, 0, 0), site, preset),
+                "the middle of the caller's field is city");
+        assertTrue(CityField.isCityRaw(new ChunkCoord(Level.OVERWORLD, 1, -1), site, preset),
+                "so is its corner");
+        assertFalse(CityField.isCityRaw(new ChunkCoord(Level.OVERWORLD, 2, 0), site, preset),
+                "one chunk past it is not");
+    }
+
+    /**
+     * The floating landscape makes every chunk a void chunk, which is a non-city verdict a level
+     * reaches before it ever looks at the city factor. A site has no islands to be off the edge of,
+     * so its field has to be asked first.
+     */
+    @Test
+    void theFieldIsAskedAheadOfTheVoidCheck() {
+        PresetDraft draft = new PresetDraft(Identifier.fromNamespaceAndPath("urbex", "test-floating"));
+        draft.LANDSCAPE_TYPE = LandscapeType.FLOATING;
+        Preset floating = draft.resolve();
+        PlanningContext site = planning(floating, binding());
+
+        assertTrue(CityField.isCityRaw(new ChunkCoord(Level.OVERWORLD, 0, 0), site, floating));
+    }
+
+    @Test
+    void aSiteSitsOnTheGroundTheFieldNamesRatherThanThePresetsOne() {
+        PlanningContext site = planning(binding());
+
+        assertEquals(-30, site.heightmap(0, 0).getHeight());
+        assertEquals(-29, site.heightmap(1, 0).getHeight(),
+                "the ground follows the field's coordinate, not one number for the dimension");
+    }
+
+    /**
+     * The nine bands raise a city six blocks at a time as the terrain under it climbs. A site's
+     * ground is already exact, so banding it again would lift every building off the floor the
+     * caller named, in multiples of six, for no reason visible from outside.
+     */
+    @Test
+    void aSiteHasNoHeightBands() {
+        PlanningContext site = planning(binding());
+        ChunkCoord coord = new ChunkCoord(Level.OVERWORLD, 0, 0);
+
+        assertEquals(0, CityField.getCityLevel(coord, site));
+        assertEquals(0, CityField.cityLevelUncached(coord, site));
+    }
+
+    @Test
+    void aCandidateTakesItsCityVerdictFromTheField() {
+        PlanningContext site = planning(binding());
+
+        ChunkCandidate inside = ChunkCandidates.candidateUncached(
+                new ChunkCoord(Level.OVERWORLD, 0, 0), site);
+        ChunkCandidate outside = ChunkCandidates.candidateUncached(
+                new ChunkCoord(Level.OVERWORLD, 9, 9), site);
+
+        assertTrue(inside.isCity());
+        assertEquals(0, inside.cityLevel());
+        assertFalse(outside.isCity());
+    }
+
+    /**
+     * The property that lets one dimension run a ruined world style on the surface and an intact one
+     * underground: the two contexts hold different caches, so the same coordinate can plan two ways
+     * without either answer overwriting the other.
+     */
+    @Test
+    void aSiteCachesApartFromTheLevelItSitsIn() {
+        PlanningContext level = planning(null);
+        PlanningContext site = planning(binding());
+        ChunkCoord coord = new ChunkCoord(Level.OVERWORLD, 0, 0);
+
+        assertNotSame(level.caches(), site.caches());
+        assertEquals(0, CityField.getCityLevel(coord, site));
+        assertEquals(0, level.caches().cityLevel.size(),
+                "asking the site did not populate the level's cache");
+    }
+
+    /**
+     * The null-binding path, asserted rather than inferred. Every chunk Urbex has ever generated
+     * takes it, and the digests are evidence about driver writes rather than about this branch.
+     */
+    @Test
+    void aContextWithNoSiteStillReadsTheCityNoise() {
+        PlanningContext level = planning(null);
+
+        // A flat, always-below-ground terrain sampler with the default landscape is not a void
+        // chunk, so isCityRaw reaches the city factor - which is what this asserts it still does.
+        // Whether that coordinate happens to be city is the noise's business, not this test's.
+        assertFalse(CityField.isVoidChunk(new ChunkCoord(Level.OVERWORLD, 0, 0), level));
+        assertEquals(level.preset().groundLevel(), level.heightmap(0, 0).getHeight(),
+                "with no site, the heightmap is the level's own");
+    }
+
+    private static SiteBinding binding() {
+        return new SiteBinding(Identifier.fromNamespaceAndPath("urbextest", "bunkers"),
+                THREE_BY_THREE, -60, 0);
+    }
+
+    private static PlanningContext planning(SiteBinding site) {
+        return planning(new PresetDraft(Identifier.fromNamespaceAndPath("urbex", "test-site")).resolve(), site);
+    }
+
+    private static PlanningContext planning(Preset preset, SiteBinding site) {
+        long seed = 1234L;
+        DimensionCaches caches = new DimensionCaches(seed);
+        TerrainSampler terrain = flatTerrain(preset);
+        return new PlanningContext(
+                seed, Level.OVERWORLD, preset, AssetSnapshot.empty(),
+                TestWorldStyles.singleStyleField(seed),
+                refusingRoadField(),
+                caches,
+                LevelShape.VANILLA_OVERWORLD,
+                site == null ? terrain : new SiteTerrain(terrain, site),
+                site);
+    }
+
+    /** The dimension's own terrain: flat at the preset's ground level, like a superflat world. */
+    private static TerrainSampler flatTerrain(Preset preset) {
+        return new TerrainSampler() {
+            @Override
+            public ChunkHeightmap heightmap(ChunkCoord coord) {
+                return new ChunkHeightmap(preset.landscapeType(), preset.groundLevel());
+            }
+
+            @Override
+            public void sampleAccurateHeight(ChunkHeightmap heightmap, int chunkX, int chunkZ) {
+                int ground = preset.groundLevel();
+                heightmap.accurateHeights(ground, ground, ground, ground);
+            }
+
+            @Override
+            public Holder<Biome> biome(BlockPos pos) {
+                throw new AssertionError("nothing here plans against a biome");
+            }
+
+            @Override
+            public RegistryAccess registryAccess() {
+                return null;
+            }
+        };
+    }
+
+    /** Reaching the road field means something asked a question a site's city verdict should not. */
+    private static RoadField refusingRoadField() {
+        return (chunkX, chunkZ) -> {
+            throw new AssertionError("nothing here has any reason to read the road field");
+        };
+    }
+}

--- a/src/test/java/dev/krona/urbex/worldgen/SitePlanningTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/SitePlanningTest.java
@@ -46,9 +46,10 @@ class SitePlanningTest {
 
         @Override
         public int groundY(int chunkX, int chunkZ) {
-            // Varying by coordinate on purpose: a constant would pass even if the code read the
-            // preset's single ground level and ignored the field.
-            return -30 + chunkX;
+            // Varying by coordinate on purpose, and by whole storeys: a constant would pass even if
+            // the code read the preset's single ground level and ignored the field, and a sub-storey
+            // step would only prove the rounding.
+            return -30 + 6 * chunkX;
         }
     };
 
@@ -91,22 +92,61 @@ class SitePlanningTest {
         PlanningContext site = planning(binding());
 
         assertEquals(-30, site.heightmap(0, 0).getHeight());
-        assertEquals(-29, site.heightmap(1, 0).getHeight(),
+        assertEquals(-24, site.heightmap(1, 0).getHeight(),
                 "the ground follows the field's coordinate, not one number for the dimension");
     }
 
     /**
-     * The nine bands raise a city six blocks at a time as the terrain under it climbs. A site's
-     * ground is already exact, so banding it again would lift every building off the floor the
-     * caller named, in multiples of six, for no reason visible from outside.
+     * The bug this exists to prevent: a site's per-chunk height must travel in {@code cityLevel},
+     * because that is the number every height comparison in Urbex is written against. With the
+     * height in {@code groundLevel} and {@code cityLevel} pinned to 0, two chunks a storey apart
+     * both reported level 0, {@code Doors.hasConnectionToTopOrOutside} concluded they were level,
+     * and a door was cut between a floor and the wall beside it.
      */
     @Test
-    void aSiteHasNoHeightBands() {
+    void aSitesHeightTravelsInTheCityLevel() {
+        PlanningContext site = planning(binding());
+
+        // The window's bottom is -60, so ground -30 is five storeys up and -24 is six.
+        assertEquals(5, CityField.getCityLevel(new ChunkCoord(Level.OVERWORLD, 0, 0), site));
+        assertEquals(6, CityField.getCityLevel(new ChunkCoord(Level.OVERWORLD, 1, 0), site));
+        assertEquals(5, CityField.cityLevelUncached(new ChunkCoord(Level.OVERWORLD, 0, 0), site));
+    }
+
+    /**
+     * And the two halves must agree: {@code groundLevel + cityLevel * 6} is what buildings stand on,
+     * and the heightmap is what the terrain under them is corrected to.
+     */
+    @Test
+    void theGroundABuildingStandsOnIsTheGroundTheTerrainIsCorrectedTo() {
         PlanningContext site = planning(binding());
         ChunkCoord coord = new ChunkCoord(Level.OVERWORLD, 0, 0);
 
-        assertEquals(0, CityField.getCityLevel(coord, site));
-        assertEquals(0, CityField.cityLevelUncached(coord, site));
+        int base = site.baseGroundLevel();
+        int cityGround = base + CityField.getCityLevel(coord, site) * CityGenerator.FLOORHEIGHT;
+
+        assertEquals(-60, base, "a site's base is its window's bottom, not the preset's ground");
+        assertEquals(site.heightmap(0, 0).getHeight(), cityGround);
+    }
+
+    /** Six blocks is a storey, and a site cannot express a step smaller than one. */
+    @Test
+    void aGroundBetweenTwoStoreysIsSnappedDown() {
+        SiteBinding binding = new SiteBinding(Identifier.fromNamespaceAndPath("urbextest", "odd"),
+                new SiteField() {
+                    @Override
+                    public boolean isSite(int chunkX, int chunkZ) {
+                        return true;
+                    }
+
+                    @Override
+                    public int groundY(int chunkX, int chunkZ) {
+                        return -27;     // four blocks above the -31 storey line, not six
+                    }
+                }, -60, 0);
+
+        assertEquals(5, binding.cityLevelAt(0, 0));
+        assertEquals(-30, binding.effectiveGroundY(0, 0));
     }
 
     @Test
@@ -119,7 +159,7 @@ class SitePlanningTest {
                 new ChunkCoord(Level.OVERWORLD, 9, 9), site);
 
         assertTrue(inside.isCity());
-        assertEquals(0, inside.cityLevel());
+        assertEquals(5, inside.cityLevel(), "ground -30 is five storeys above the window's -60");
         assertFalse(outside.isCity());
     }
 
@@ -135,7 +175,7 @@ class SitePlanningTest {
         ChunkCoord coord = new ChunkCoord(Level.OVERWORLD, 0, 0);
 
         assertNotSame(level.caches(), site.caches());
-        assertEquals(0, CityField.getCityLevel(coord, site));
+        assertEquals(5, CityField.getCityLevel(coord, site));
         assertEquals(0, level.caches().cityLevel.size(),
                 "asking the site did not populate the level's cache");
     }

--- a/src/test/java/dev/krona/urbex/worldgen/SpecialMarkerPolicyTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/SpecialMarkerPolicyTest.java
@@ -10,21 +10,76 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SpecialMarkerPolicyTest {
 
+    private static final BlockPos MARKER = new BlockPos(12, 70, -4);
+
     @Test
-    void lootAdmissionUsesDensityWhileSpawnerAdmissionDoesNot() {
+    void lootAdmissionUsesDensity() {
         PresetDraft draft = new PresetDraft(Identifier.fromNamespaceAndPath("urbex", "marker-policy"));
-        BlockPos marker = new BlockPos(12, 70, -4);
-        draft.GENERATE_SPAWNERS = true;
 
         draft.LOOT_DENSITY = 0.0f;
-        assertFalse(SpecialMarkerPolicy.populateLoot(41L, marker, draft.resolve()));
-        assertTrue(SpecialMarkerPolicy.generateSpawner(draft.resolve()));
+        assertFalse(SpecialMarkerPolicy.populateLoot(41L, MARKER, draft.resolve()));
 
         draft.LOOT_DENSITY = 1.0f;
-        assertTrue(SpecialMarkerPolicy.populateLoot(41L, marker, draft.resolve()));
-        assertTrue(SpecialMarkerPolicy.generateSpawner(draft.resolve()));
+        assertTrue(SpecialMarkerPolicy.populateLoot(41L, MARKER, draft.resolve()));
+    }
+
+    /**
+     * The switch and the dial answer different questions, and both have to hold.
+     *
+     * <p>{@code generateSpawners} is "this world has none". {@code spawnerDensity} is "fewer", which
+     * a switch cannot express and which is what somewhere a player has to survive usually wants.</p>
+     */
+    @Test
+    void spawnerAdmissionNeedsBothTheSwitchAndTheDensity() {
+        PresetDraft draft = new PresetDraft(Identifier.fromNamespaceAndPath("urbex", "marker-policy"));
+
+        draft.GENERATE_SPAWNERS = true;
+        draft.SPAWNER_DENSITY = 1.0f;
+        assertTrue(SpecialMarkerPolicy.generateSpawner(41L, MARKER, draft.resolve()));
+
+        draft.SPAWNER_DENSITY = 0.0f;
+        assertFalse(SpecialMarkerPolicy.generateSpawner(41L, MARKER, draft.resolve()),
+                "density zero admits nothing, even with the switch on");
 
         draft.GENERATE_SPAWNERS = false;
-        assertFalse(SpecialMarkerPolicy.generateSpawner(draft.resolve()));
+        draft.SPAWNER_DENSITY = 1.0f;
+        assertFalse(SpecialMarkerPolicy.generateSpawner(41L, MARKER, draft.resolve()),
+                "the switch still wins, whatever the density says");
+    }
+
+    /**
+     * The default, and the reason every existing world generates unchanged: a preset that says
+     * nothing about the density admits every marker its parts put down.
+     */
+    @Test
+    void aPresetThatNamesNoDensityKeepsEverySpawner() {
+        PresetDraft draft = new PresetDraft(Identifier.fromNamespaceAndPath("urbex", "marker-policy"));
+
+        assertTrue(draft.resolve().generateSpawners());
+        for (int x = 0; x < 40; x++) {
+            BlockPos marker = new BlockPos(x * 7, 64 + x, -x * 3);
+            assertTrue(SpecialMarkerPolicy.generateSpawner(41L, marker, draft.resolve()),
+                    "marker at " + marker + " was refused under the default density");
+        }
+    }
+
+    /** Thinning is position-addressed, so the same marker answers the same way every time. */
+    @Test
+    void aThinnedSpawnerIsAPropertyOfTheSeedAndThePosition() {
+        PresetDraft draft = new PresetDraft(Identifier.fromNamespaceAndPath("urbex", "marker-policy"));
+        draft.SPAWNER_DENSITY = 0.5f;
+
+        int kept = 0;
+        for (int x = 0; x < 200; x++) {
+            BlockPos marker = new BlockPos(x, 64, x * 2);
+            boolean first = SpecialMarkerPolicy.generateSpawner(41L, marker, draft.resolve());
+            assertTrue(first == SpecialMarkerPolicy.generateSpawner(41L, marker, draft.resolve()),
+                    "the same marker answered two different ways");
+            if (first) {
+                kept++;
+            }
+        }
+        assertTrue(kept > 50 && kept < 150,
+                "half density kept " + kept + " of 200, which is not a half of anything");
     }
 }

--- a/src/test/java/dev/krona/urbex/worldgen/WriteWindowTest.java
+++ b/src/test/java/dev/krona/urbex/worldgen/WriteWindowTest.java
@@ -1,0 +1,82 @@
+package dev.krona.urbex.worldgen;
+
+import dev.krona.urbex.api.SiteField;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * How a generation's write window is derived, and what it admits.
+ *
+ * <p>The arithmetic is four lines and obviously right, which is exactly why it is worth asserting:
+ * an off-by-one at either end is a bunker whose ceiling is one block into the caller's rock, or a
+ * level whose bottom row of bedrock stops being writable.</p>
+ */
+class WriteWindowTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    /** A field nothing here asks about; these tests are about the window, not the coverage. */
+    private static final SiteField ANY = (x, z) -> true;
+
+    private static SiteBinding site(int minY, int maxY) {
+        return new SiteBinding(Identifier.fromNamespaceAndPath("urbextest", "site"), ANY, minY, maxY);
+    }
+
+    @Test
+    void noSiteMeansTheWholeLevel() {
+        WriteWindow window = WriteWindow.of(null, -64, 319);
+
+        assertEquals(new WriteWindow(-64, 319), window);
+        assertTrue(window.contains(-64));
+        assertTrue(window.contains(319));
+    }
+
+    @Test
+    void aSiteNarrowsTheWindowToItsOwn() {
+        WriteWindow window = WriteWindow.of(site(-40, 20), -64, 319);
+
+        assertEquals(new WriteWindow(-40, 20), window);
+        assertFalse(window.contains(-41));
+        assertTrue(window.contains(-40));
+        assertTrue(window.contains(20));
+        assertFalse(window.contains(21));
+    }
+
+    /**
+     * A caller that does not know which dimension it will be asked about names a window wide enough
+     * for any of them. The level is what decides, not the guess.
+     */
+    @Test
+    void aSiteWiderThanTheLevelIsCutBackToTheLevel() {
+        WriteWindow window = WriteWindow.of(site(-2048, 2048), -64, 319);
+
+        assertEquals(new WriteWindow(-64, 319), window);
+    }
+
+    @Test
+    void aSiteOverlappingOneEndKeepsTheOtherEndOfTheLevel() {
+        assertEquals(new WriteWindow(-64, 20), WriteWindow.of(site(-2048, 20), -64, 319));
+        assertEquals(new WriteWindow(-40, 319), WriteWindow.of(site(-40, 2048), -64, 319));
+    }
+
+    @Test
+    void aDeferredWriteIsJudgedByItsAnchorsHeightAlone() {
+        WriteWindow window = WriteWindow.of(site(-40, 20), -64, 319);
+
+        assertTrue(window.contains(new BlockPos(10_000, 0, -10_000)),
+                "horizontal distance is not this window's business");
+        assertFalse(window.contains(new BlockPos(0, 21, 0)));
+    }
+}


### PR DESCRIPTION
**Another mod can now ask Urbex to build somewhere Urbex would never have chosen.**

A **site** is Urbex's own machinery with three of its inputs supplied by a caller instead: *where*, *how high*, and *how far it may reach*. The case it was built for is a cave bunker — a mod carves a cavity underground and asks Urbex to fill it, at the cavity's depth, in a different world style from the ruins on the surface, without a block escaping the cavity.

Experimental, in `dev.krona.urbex.api` and nowhere else. Four public types.

```java
UrbexApi.site(level, SiteSpec
        .builder(id, Identifier.of("urbex", "cavern"), field)
        .worldStyle(Identifier.of("mymod", "bunker_style"))
        .presetOverrides(json)
        .window(-60, 24)
        .build())
    .fill(region, chunk);
```

## One seam, and it is inert without a caller

`PlanningContext` gains a tenth component, `@Nullable SiteBinding`. Six call sites consult it; every one is a no-op when it is null.

| Where | A dimension | A site |
|---|---|---|
| `CityField.isCityRaw` | perlin city field vs. threshold | `SiteField.isSite` |
| `CityField.getCityLevel` | terrain height band 0–8 | `(groundY − minY) / 6` |
| `ChunkPlan` ground / water | the preset's | the window's bottom / `SiteSpec.waterY` |
| `CityGenerator.generateOrThrow` | a non-city chunk is rendered | a non-site chunk is **untouched** |
| planning assembly | `LevelTerrain`, the level's `LevelShape` | flat `SiteTerrain`, `LevelShape` clamped to the window |
| `ChunkBuffer` | bounded by the level | bounded by the window |

A site is a second `PlanningContext` + `CityGenerator` over the same level with its own `DimensionCaches`, so its plans never collide with the level's at the same `ChunkCoord`. It borrows the world's assets and tag epoch and the level's task queue — and **nothing from the level's preset**, so a site generates in a dimension where Urbex's surface generation is switched off entirely.

Urbex dispatches nothing. `CarverHookMixin` and `CityFeature` are untouched.

## The window is structural, not a convention

Enforced twice. Planning sees a `LevelShape` clamped to the window, so floors are chosen to fit. Writing is bounded at `ChunkBuffer` — the one point every driver write passes through — so a pass that believes it may build to the sky writes nothing above the window whatever it believes. Deferred writes bypass the driver and are bounded separately, by anchor position, at the three queues that accept them.

Measured over a generated world: **33,196 site writes, y −40..24, zero outside the window**, with the maximum landing exactly on the window top — the clamp is biting, not merely present.

A consequence worth stating: the window is absolute, so a site and the surface city **commute**. No caller has to reason about mixin priority against Urbex's own hook.

## Three things running it found that the design did not

Each was found by generating a world with the example mod loaded and diffing the driver's per-chunk write log against a run without it. None was visible from the design, and none from a screenshot.

**A site was only sparse when its own field said so.** Structure avoidance can turn `doCity` off *after* the sparse guard, so a site landing on a village fell through to `doNormalChunk` and repainted the surface it was a guest in — ten of a bunker's eleven chunks, in the probe world. Avoidance now does not apply to a site at all: it exists to stop Urbex's own city noise bulldozing a village it rolled on top of, and a caller naming a place has already decided. A bunker suppressed by a village forty blocks overhead is a hole in the middle of itself, with streets running into it from either side and every neighbour's plan still saying the middle is there.

**The first working bunker was flooded to the ceiling** — 21,868 blocks of water. A preset names one absolute sea level for a whole dimension; `urbex:cavern`, the obvious choice for anything underground, says 32. A site forty blocks below that is not underwater, but every rule that fills below the water line thought it was. A site now ignores its preset's sea level and takes `SiteSpec.waterY`, dry by default.

**Doors were cut into walls.** The important one. `cityLevel` is how two chunks compare their heights to each other — doorways through shared walls, street slopes, which of two competing stairs wins. A dimension's `groundLevel` is one constant for the whole world, so all the variation lives in `cityLevel` and those comparisons are total. Putting a site's per-chunk height in `groundLevel` and pinning `cityLevel` to 0 left every one of them reading "level" for two chunks twenty blocks apart: `Doors.hasConnectionToTopOrOutside` agreed, and cut a door between a floor and the wall beside it. Height now travels down the channel built to carry it.

The cost is that a site's ground is quantised to a storey, which `SiteField.groundY` documents — six blocks is the unit the height graph counts in, and two grounds closer than that have no way to say so to each other.

Verified after the fix: doors land at y −35, −29, −17 for floors at −36, −30, −18. One block above their own floor, every time.

## Results

| | |
|---|---|
| tests | **810 pass** (19 new) |
| `digest` | `0d02b09f2f6bbd36` — unmoved |
| `digest-features` | `638d95f7d5991aa0` — unmoved |
| `digest-avoid` | `bb5143d195ae8f41` — unmoved |
| `digest-avoid-modes` | `00bb7d785a75057f` — unmoved |
| `digest-rail` | `e63c15b545d365f3` — unmoved |

All eight digest run configurations, at the default worker pool size and again at `-Dmax.bg.threads=2`. Every seam here is unreachable when `site == null`, which is what makes the goldens evidence rather than reassurance.

New tests: `ChunkBufferWindowTest` (the window admits and refuses, including a run straddling a boundary and a section half in and half out), `WriteWindowTest` (how the window is derived), `SitePlanningTest` (the field drives `isCity` and the height; a site's caches are separate from the level's; the null-binding path is unchanged), `SiteSpecTest` (builder validation).

## Consumer

`Urbex-Bunkers` — a standalone Fabric mod that carves domed chambers underground and fills them through this API, with its own `BunkerFieldTest` covering the purity contract this API cannot check for callers. Not yet on GitHub; it lives beside this checkout.

## Reviewing

`docs/site-api.md` is the reference — the purity contract, the window, the quantisation, and a failure-mode table. `docs/superpowers/specs/2026-08-16-experimental-site-api-design.md` carries the design and a "what building it changed" section.

The judgement most worth a second opinion is **the purity contract on `SiteField`**. It is what makes a push-driven API produce coherent edges, and it is a requirement a caller can violate silently — the symptom is streets ending in rock, far from the call that caused it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
